### PR TITLE
Added tools for checking generated landpattern grid patterns

### DIFF
--- a/tests/landpatterns/SOIC.stanza
+++ b/tests/landpatterns/SOIC.stanza
@@ -1,10 +1,13 @@
 #use-added-syntax(jitx, tests)
 defpackage jsl/tests/landpatterns/SOIC:
   import core
+  import collections
   import jitx
   import jitx/commands
 
   import jsl/tests/utils
+  import jsl/tests/landpatterns/defchecks
+
   import jsl/landpatterns/SOIC
   import jsl/landpatterns/packages
   import jsl/landpatterns/leads
@@ -52,34 +55,225 @@ deftest(SOIC) test-body:
   #EXPECT(in-range?(min-max(7.45, 7.55), typ(width(W-SOIC))))
   #EXPECT(in-range?(min-max(2.4, 2.6), typ(height(W-SOIC))))
 
-deftest(SOIC) test-package:
+deftest(SOIC) test-SOIC-N:
+  for num-pins in [8, 14, 20] do:
+    val N = SOIC-N(
+      num-leads = num-pins,
+      lead-span = min-max(5.8, 6.2),
+      package-length = min-max(8.55, 8.75)
+    )
+    val expName = to-string("SOIC127P600X155-%_" % [num-pins])
+    #EXPECT(name(N) == expName)
 
-  val N14 = SOIC-N(
-    num-leads = 14,
-    lead-span = min-max(5.8, 6.2),
-    package-length = min-max(8.55, 8.75)
-  )
-  #EXPECT(name(N14) == "SOIC127P600X155-14")
+    val N-lp = create-landpattern(N)
 
-  val W14 = SOIC-W(
-    num-leads = 14,
-    lead-span = min-max(10.01, 10.64),
-    package-length = min-max(8.788, 9.195)
-  )
-  #EXPECT(name(W14) == "SOIC127P1032X250-14")
+    val exp-Pitch-X = tol%(5.2, (1 %))
+    val exp-Pitch-Y = tol%(1.27, (1 %))
 
-  val N14-lp = create-landpattern(N14)
-  val W14-lp = create-landpattern(W14)
+    val grid = PadGrid(N-lp)
 
-  val N14-str = get-def-string(N14-lp)
-  val W14-str = get-def-string(W14-lp)
-  ; TODO - analyze the ESIR output and check for:
-  ;   -  14 pads on the Top Layer
-  ;   -  Ideally we detect the positions of those pads and confirm
-  ;       that there are no overlaps.
-  ; TODO - Likely need a regex dependency here.
-  #EXPECT(index-of-chars(N14-str, "pad") is-not False)
-  #EXPECT(index-of-chars(W14-str, "pad") is-not False)
+    #EXPECT(length(rows(grid)) == num-pins / 2)
+    #EXPECT(check-row-pitch(grid, exp-Pitch-Y))
+    #EXPECT(check-column-pitch(grid, exp-Pitch-X))
 
-  ; TODO - 8, 16, 20 pin packages
-  ; TODO - 32 pin package with smaller pitch (0.65mm)
+    for row in values(rows(grid)) do:
+      #EXPECT(length(row) == 2)
+      for lp-pad in row do:
+        val pd = pad(lp-pad)
+        val shape = pad-shape(pd)
+        #EXPECT(shape is Rectangle)
+
+deftest(SOIC) test-SOIC-W:
+  for num-pins in [8, 14, 20] do:
+    val W = SOIC-W(
+      num-leads = num-pins,
+      lead-span = min-max(10.01, 10.64),
+      package-length = min-max(8.788, 9.195)
+    )
+
+    val expName = to-string("SOIC127P1032X250-%_" % [num-pins])
+    #EXPECT(name(W) == expName)
+
+    val W-lp = create-landpattern(W)
+
+    val exp-Pitch-X = tol%(9.6, (1 %))
+    val exp-Pitch-Y = tol%(1.27, (1 %))
+
+    val grid = PadGrid(W-lp)
+
+    #EXPECT(length(rows(grid)) == num-pins / 2)
+    #EXPECT(check-row-pitch(grid, exp-Pitch-Y))
+    #EXPECT(check-column-pitch(grid, exp-Pitch-X))
+
+    for row in values(rows(grid)) do:
+      #EXPECT(length(row) == 2)
+      for lp-pad in row do:
+        val pd = pad(lp-pad)
+        val shape = pad-shape(pd)
+        #EXPECT(shape is Rectangle)
+
+deftest(SOIC) test-fine-pitch:
+    val num-pins = 32
+    val W-fp = SOIC-W(
+      num-leads = num-pins,
+      lead-span = min-max(10.01, 10.64),
+      package-length = min-max(8.788, 9.195)
+      pitch = 0.65
+    )
+
+    val expName = to-string("SOIC65P1032X250-%_" % [num-pins])
+    #EXPECT(name(W-fp) == expName)
+
+    val W-lp = create-landpattern(W-fp)
+
+    val exp-Pitch-X = tol%(9.6, (1 %))
+    val exp-Pitch-Y = tol%(0.65, (1 %))
+
+    val grid = PadGrid(W-lp)
+
+    #EXPECT(length(rows(grid)) == num-pins / 2)
+    #EXPECT(check-row-pitch(grid, exp-Pitch-Y))
+    #EXPECT(check-column-pitch(grid, exp-Pitch-X))
+
+    for row in values(rows(grid)) do:
+      #EXPECT(length(row) == 2)
+      for lp-pad in row do:
+        val pd = pad(lp-pad)
+        val shape = pad-shape(pd)
+        #EXPECT(shape is Rectangle)
+
+deftest(SOIC) test-thermal-lead:
+  val num-pins = 8
+  val W = SOIC-W(
+      num-leads = num-pins,
+      lead-span = min-max(10.01, 10.64),
+      package-length = min-max(8.788, 9.195),
+      thermal-lead? = RoundedRectangle(3.0, 3.0, 0.2)
+    )
+
+    val expName = to-string("SOIC127P1032X250-%_" % [num-pins])
+    #EXPECT(name(W) == expName)
+
+    val W-lp = create-landpattern(W)
+
+    val grid = PadGrid(W-lp)
+
+    #EXPECT(length(rows(grid)) == (num-pins / 2) + 1)
+    #EXPECT(length(columns(grid)) == 2 + 1)
+
+    val thermPad? = find-pad-by-ref(W-lp, 9)
+    #EXPECT(thermPad? is-not False)
+    val thermPad = thermPad? as LandPatternPad
+    #EXPECT(pad-shape(pad(thermPad)) is RoundedRectangle)
+
+deftest(SOIC) test-pad-numbering:
+  val num-pins = 8
+  val W = SOIC-W(
+      num-leads = num-pins,
+      lead-span = min-max(10.01, 10.64),
+      package-length = min-max(8.788, 9.195),
+    )
+  val W-lp = create-landpattern(W)
+
+  val grid = PadGrid(W-lp)
+
+  val half = num-pins / 2
+
+  #EXPECT(length(rows(grid)) == half)
+  #EXPECT(length(columns(grid)) == 2)
+
+  ; NOTE - `get-column` returns pads in ascending
+  ;   Y order. This is the opposite of how we think
+  ;   of pad ordering so we must reverse the first
+  ;   column but the second column is fine.
+
+  val col0 = get-column(grid, 0)
+  #EXPECT(length(col0) == half)
+  for (p in in-reverse(col0), i in 1 through half) do:
+    val expRef = IndexRef(Ref(`p), i)
+    #EXPECT(ref(p) == expRef)
+
+  val col1 = get-column(grid, 1)
+  #EXPECT(length(col1) == half)
+  for (p in col1, i in (half + 1) through num-pins) do:
+    val expRef = IndexRef(Ref(`p), i)
+    #EXPECT(ref(p) == expRef)
+
+deftest(SOIC) test-error-handling:
+
+  val num-pin-vecs = [
+    0,
+    -1,
+    -10,
+    13,
+    1,
+    3
+  ]
+  for num-pin-vec in num-pin-vecs do:
+    var res = expect-throw({SOIC-N(
+      num-leads = num-pin-vec,
+      lead-span = min-max(7.01, 7.64),
+      package-length = min-max(8.788, 9.195)
+      )})
+    #EXPECT(res is-not None)
+    res = expect-throw({SOIC-W(
+      num-leads = num-pin-vec,
+      lead-span = min-max(10.01, 10.64),
+      package-length = min-max(8.788, 9.195)
+      )})
+    #EXPECT(res is-not None)
+
+  val neg-vecs = [
+    min-max(-0.1, 3.0),
+    min-max(-1.0, -0.9),
+    min-max(-10.64, -10.01),
+  ]
+
+  for neg-vec in neg-vecs do:
+    ; lead-span
+    var res = expect-throw({SOIC-N(
+      num-leads = 8,
+      lead-span = neg-vec,
+      package-length = min-max(8.788, 9.195)
+      )})
+    #EXPECT(res is-not None)
+    res = expect-throw({SOIC-W(
+      num-leads = 8,
+      lead-span = neg-vec,
+      package-length = min-max(8.788, 9.195)
+      )})
+    #EXPECT(res is-not None)
+    ; pkg-len
+    res = expect-throw({SOIC-N(
+      num-leads = 8,
+      lead-span = min-max(8.788, 9.195),
+      package-length = neg-vec
+      )})
+    #EXPECT(res is-not None)
+    res = expect-throw({SOIC-W(
+      num-leads = 8,
+      lead-span = min-max(8.788, 9.195),
+      package-length = neg-vec
+      )})
+    #EXPECT(res is-not None)
+
+  val pitch-vecs = [
+    0.0,
+    -0.1,
+    -1.3
+  ]
+  for pitch-vec in pitch-vecs do:
+    var res = expect-throw({SOIC-N(
+      num-leads = 8,
+      lead-span = min-max(8.788, 9.195),
+      package-length = min-max(8.788, 9.195),
+      pitch = pitch-vec
+      )})
+    #EXPECT(res is-not None)
+    res = expect-throw({SOIC-W(
+      num-leads = 8,
+      lead-span = min-max(8.788, 9.195),
+      package-length = min-max(8.788, 9.195),
+      pitch = pitch-vec
+      )})
+    #EXPECT(res is-not None)

--- a/tests/landpatterns/defchecks.stanza
+++ b/tests/landpatterns/defchecks.stanza
@@ -1,0 +1,137 @@
+#use-added-syntax(jitx)
+defpackage jsl/tests/landpatterns/defchecks:
+  import core
+  import collections
+  import jitx
+  import jitx/commands
+  import jsl/errors
+
+doc: \<DOC>
+Pad Grid - Tool for Checking Landpatterns
+This type provides a means of using the introspection
+tools to discover the generated pads and check
+that they are correct.
+<DOC>
+public defstruct PadGrid :
+  rows:HashTable<Double, Tuple<LandPatternPad>>
+  columns:HashTable<Double, Tuple<LandPatternPad>>
+
+defn update (rows:HashTable<Double, Tuple<LandPatternPad>>, y-pos:Double, pd:LandPatternPad) :
+  val res = get?(rows, y-pos, [])
+  val newPads = to-tuple $ cat(res, [pd])
+  set(rows, y-pos, newPads)
+
+public defn PadGrid (lp-def:LandPattern) -> PadGrid:
+  val rows = HashTable<Double, Tuple<LandPatternPad>>()
+  val cols = HashTable<Double, Tuple<LandPatternPad>>()
+  for lp-pad in pads(lp-def) do:
+    val l = pose(lp-pad)
+    val pos = center(l)
+    update(rows, y(pos), lp-pad)
+    update(cols, x(pos), lp-pad)
+  PadGrid(rows, cols)
+
+
+doc: \<DOC>
+Diff the elements of a series
+This function assumes that the values in `x` are sorted in
+ascending order.
+<DOC>
+public defn diff-series (x:Seqable<Double>) -> Seqable<Double> :
+  val x* = to-tuple(x)
+  for i in 0 to length(x*) seq?:
+    if i == 0:
+      None()
+    else:
+      One(x*[i] - x*[i - 1])
+
+doc: \<DOC>
+Extract the pitch between the sequence of pad rows
+@return Ordered sequence of distance from one pad row to the next.
+If `x` is length N, the returned sequence will be N-1 in length.
+@throws ValueError If there are less than 2 rows in the found grid.
+<DOC>
+public defn row-pitch (x:PadGrid) -> Seqable<Double> :
+  val ys = to-vector<Double>(keys(rows(x)))
+  if length(ys) < 2:
+    throw $ ValueError("Invalid Grid for Pitch Check: # rows = %_" % [length(ys)])
+
+  qsort! $ ys
+  diff-series(ys)
+
+doc: \<DOC>
+Check if all row pitches match the passed tolerance range.
+<DOC>
+public defn check-row-pitch (x:PadGrid, exp-Pitch:Toleranced) -> True|False :
+  val pitches = to-tuple $ row-pitch(x)
+  val ret = for pitch in pitches all?:
+    in-range?(exp-Pitch, pitch)
+  if not ret:
+    println("Row Pitches: %," % [pitches])
+  ret
+
+doc: \<DOC>
+Extract the pitch between the sequence of pad columns
+@return Ordered sequence of distance from one pad column to the next.
+If `x` is length N, the returned sequence will be N-1 in length.
+@throws ValueError If there are less than 2 columns in the found grid.
+<DOC>
+public defn column-pitch (x:PadGrid) -> Seqable<Double> :
+  val xs = to-vector<Double>(keys(columns(x)))
+  if length(xs) < 2:
+    throw $ ValueError("Invalid Grid for Pitch Check: # columns = %_" % [length(xs)])
+
+  qsort! $ xs
+  diff-series(xs)
+
+doc: \<DOC>
+Check if all column pitches match the passed tolerance range.
+<DOC>
+public defn check-column-pitch (x:PadGrid, exp-Pitch:Toleranced) -> True|False :
+  val pitches = to-tuple $ column-pitch(x)
+  val ret = for pitch in pitches all?:
+    in-range?(exp-Pitch, pitch)
+
+  if not ret:
+    println("Column Pitches: %," % [pitches])
+  ret
+
+doc: \<DOC>
+Retrieve the ordered column of Pads by column index
+@param x (Self)
+@param column Which column of pads to extract.
+@return The pads in this column are sorted in ascending ordered by
+the Y coordinate of the pad
+<DOC>
+public defn get-column (x:PadGrid, column:Int) -> Vector<LandPatternPad> :
+  val colX = to-vector<Double>(keys(columns(x)))
+  qsort!(colX)
+  val colPads = to-vector<LandPatternPad>(columns(x)[colX[column]])
+  qsort!({y $ center $ pose(_)}, colPads)
+  colPads
+
+doc: \<DOC>
+Retrieve the ordered row of Pads by row index
+@param x (Self)
+@param row Which row of pads to extract.
+@return The pads in this row are sorted in ascending ordered by
+the X coordinate of the pad
+<DOC>
+public defn get-row (x:PadGrid, row:Int) -> Vector<LandPatternPad> :
+  val rowY = to-vector<Double>(keys(rows(x)))
+  qsort!(rowY)
+  val rowPads = to-vector<LandPatternPad>(rows(x)[rowY[row]])
+  qsort!({x $ center $ pose(_)}, rowPads)
+  rowPads
+
+doc: \<DOC>
+Find a Pad in a Landpattern by Reference or Pin Number
+<DOC>
+public defn find-pad-by-ref (lp-def:LandPattern, pin-id:Int|Ref) -> LandPatternPad|False :
+  val r = match(pin-id):
+    (pinNum:Int): IndexRef(Ref(`p), pinNum)
+    (y): y
+  for p in pads(lp-def) find:
+    ref(p) == r
+
+


### PR DESCRIPTION
This adds a type called `PinGrid` that is used to introspect the copper pads of a landpattern generator.

This also adds tests for the SOIC package grid.

@bhusang  - I think these tools will be generally applicable for most if not all our landpattern generators.

Closes JITX-6901, JITX-6902, and JITX-6909