### PR TITLE
Added keyword argument for PackageBody constructor

### DIFF
--- a/src/landpatterns/SOIC.stanza
+++ b/src/landpatterns/SOIC.stanza
@@ -97,7 +97,7 @@ public defn make-SOIC-narrow-body (
   height:Toleranced = min-max(1.35, 1.75),
   anchor:Anchor = C
   ) -> PackageBody :
-  PackageBody(width, length, height, anchor)
+  #PackageBody(width, length, height, anchor)
 
 doc: \<DOC>
 Create a Wide SOIC PackageBody
@@ -119,7 +119,7 @@ public defn make-SOIC-wide-body (
   height:Toleranced = min-max(2.35, 2.65)
   anchor:Anchor = C
   ) -> PackageBody :
-  PackageBody(width, length, height, anchor)
+  #PackageBody(width, length, height, anchor)
 
 doc: \<DOC>
 SOIC Standard Package Type

--- a/src/landpatterns/packages.stanza
+++ b/src/landpatterns/packages.stanza
@@ -89,6 +89,19 @@ with:
   equalable => true
   hashable => true
   printer => true
+  constructor => #PackageBody
+
+doc: \<DOC>
+Create a Package Body as a rectangular cuboid.
+<DOC>
+public defn PackageBody (
+  --
+  width:Toleranced,
+  length:Toleranced,
+  height:Toleranced,
+  anchor:Anchor = C
+  ):
+  #PackageBody(width, length, height, anchor)
 
 doc: \<DOC>
 Physical Envelope of the package body.

--- a/tests/landpatterns/BGA/package.stanza
+++ b/tests/landpatterns/BGA/package.stanza
@@ -28,9 +28,9 @@ deftest(BGA) test-full-simple :
   )
 
   val body = PackageBody(
-    2.5 +/- 0.1,
-    2.0 +/- 0.1,
-    1.0 +/- 0.1
+    width = 2.5 +/- 0.1,
+    length = 2.0 +/- 0.1,
+    height = 1.0 +/- 0.1
   )
 
   val pkg = BGA(
@@ -128,9 +128,9 @@ deftest(BGA) test-perimeter-simple :
   )
 
   val body = PackageBody(
-    2.0 +/- 0.1,
-    2.0 +/- 0.1,
-    0.71 +/- [0.06, 0.0]
+    width = 2.0 +/- 0.1,
+    length = 2.0 +/- 0.1,
+    height = 0.71 +/- [0.06, 0.0]
   )
 
   val pkg = BGA(

--- a/tests/landpatterns/packages.stanza
+++ b/tests/landpatterns/packages.stanza
@@ -9,7 +9,11 @@ defpackage jsl/tests/landpatterns/packages:
 
 deftest(packages) test-basic:
 
-  val a = PackageBody(min-max(1.0, 2.0), min-max(2.0, 3.0), min-max(4.0, 5.0))
+  val a = PackageBody(
+    width = min-max(1.0, 2.0),
+    length = min-max(2.0, 3.0),
+    height = min-max(4.0, 5.0)
+    )
 
   #EXPECT(width(a) is Toleranced)
   #EXPECT(length(a) is Toleranced)
@@ -21,7 +25,12 @@ deftest(packages) test-basic:
 
   #EXPECT(anchor(a) == C)
 
-  val b = PackageBody(typ(1.0), typ(2.0), typ(3.0), E )
+  val b = PackageBody(
+    width = typ(1.0),
+    length = typ(2.0),
+    height = typ(3.0),
+    anchor = E
+    )
 
   #EXPECT(anchor(b) == E)
 
@@ -37,4 +46,6 @@ deftest(packages) test-ensures:
   for test-vec in test-vecs do:
     val [w,l,h] = test-vec
 
-    expect-throw({PackageBody(w, l, h)})
+    expect-throw(
+      {PackageBody(width = w, length = l, height = h)}
+      )


### PR DESCRIPTION
This forces keyword arguments for the `PackageBody` constructor. For example, instead of: 

```
  val body = PackageBody(
    2.5 +/- 0.1,
    2.0 +/- 0.1,
    1.0 +/- 0.1
  )
```

Where it is not easy to determine which value is the width, length, height - the user  will need to do the following:

```
  val body = PackageBody(
    width = 2.5 +/- 0.1,
    length = 2.0 +/- 0.1,
    height = 1.0 +/- 0.1
  )
```

Which makes it explicit.