### PR TITLE
Updated the opamp symbol to allow for multi-channel components

### DIFF
--- a/src/symbols/comparator.stanza
+++ b/src/symbols/comparator.stanza
@@ -29,12 +29,10 @@ public defstruct ComparatorSymbol <: OpAmpSymbol :
   )
 
   doc: \<DOC>
-  Input Base Reference
-  The symbol will construct individual `Ref` values from this
-  base `Ref` for the positive and negative inputs to the comparator. By default,
-  the reference `in` will be used, resulting in the default inputs, `in+` and `in-`.
+  Input Base Reference or Explicit Input Refs.
+  @see OpAmpSymbol for more Information.
   <DOC>
-  in-ref:Ref with: (
+  in-ref:Ref|[Ref, Ref] with: (
     default => OPAMP_IN_BASE_REF,
     as-method => true
   )
@@ -58,7 +56,7 @@ with:
 public defn ComparatorSymbol (
   --
   pitch:Double = DEF_OPAMP_PITCH,
-  in-ref:Ref = OPAMP_IN_BASE_REF,
+  in-ref:Ref|[Ref, Ref] = OPAMP_IN_BASE_REF,
   out-ref:Ref = OPAMP_OUT_REF,
   params:OpAmpSymbolParams = get-default-comparator-symbol-params()
   ) -> ComparatorSymbol :

--- a/src/symbols/instrumentation-amp.stanza
+++ b/src/symbols/instrumentation-amp.stanza
@@ -51,12 +51,10 @@ public defstruct InstrumentationAmpSymbol <: OpAmpSymbol :
   )
 
   doc: \<DOC>
-  Input Base Reference
-  The symbol will construct individual `Ref` values from this
-  base `Ref` for the positive and negative inputs to the amp. By default,
-  the reference `in` will be used, resulting in the default inputs, `in+` and `in-`.
+  Input Base Reference or Explicit Input References.
+  @see OpAmpSymbol for more Information.
   <DOC>
-  in-ref:Ref with: (
+  in-ref:Ref|[Ref, Ref] with: (
     default => OPAMP_IN_BASE_REF,
     as-method => true
   )
@@ -100,7 +98,7 @@ public defn InstrumentationAmpSymbol (
   --
   pitch:Double = DEF_IAMP_PITCH,
   rg-pitch:Double = DEF_IAMP_RG_PITCH
-  in-ref:Ref = OPAMP_IN_BASE_REF,
+  in-ref:Ref|[Ref, Ref] = OPAMP_IN_BASE_REF,
   out-ref:Ref = OPAMP_OUT_REF,
   rg-ref:Ref = IAMP_RG_REF_DEF,
   vref-ref:Ref = IAMP_VREF_REF_DEF,

--- a/src/symbols/op-amps.stanza
+++ b/src/symbols/op-amps.stanza
@@ -7,6 +7,7 @@ defpackage jsl/symbols/op-amps:
   import jsl/design/Classable
   import jsl/symbols/SymbolDefn
   import jsl/symbols/SymbolNode
+  import jsl/symbols/pin-refs
 
 doc: \<DOC>
 Op-Amp Triangle Symbol Parameterization
@@ -115,12 +116,20 @@ public defstruct OpAmpSymbol <: SymbolDefn :
   )
 
   doc: \<DOC>
-  Input Base Reference
-  The symbol will construct individual `Ref` values from this
-  base `Ref` for the positive and negative inputs to the opamp. By default,
-  the reference `in` will be used, resulting in the default inputs, `in+` and `in-`.
+  Input Base Reference or Explicit Input References.
+  The symbol needs individual refs for each of the positive and negative input pins.
+  To construct these the user has two options:
+  1.  Pass a base reference from which to construct the positive and negative inputs
+      1.  With this option, the passed reference will be used to construct individual
+          `Ref` values from this base `Ref` for the positive and negative inputs to
+          the opamp.
+      2.  By default, the base Ref `in` will be used, resulting in input pins `in+` and `in-`.
+  2.  Pass two explicit Refs, one for each of the positive and negative inputs.
+      1.  In this case, the user passes an ordered Tuple of `[PosRef, NegRef]` where
+          `PosRef` is the reference for the positive input and `NegReg` is the
+          reference for the negative input.
   <DOC>
-  in-ref:Ref with: (
+  in-ref:Ref|[Ref, Ref] with: (
     default => OPAMP_IN_BASE_REF
   )
   doc: \<DOC>
@@ -141,7 +150,7 @@ with:
 public defn OpAmpSymbol (
   --
   pitch:Double = DEF_OPAMP_PITCH,
-  in-ref:Ref = OPAMP_IN_BASE_REF,
+  in-ref:Ref|[Ref, Ref] = OPAMP_IN_BASE_REF,
   out-ref:Ref = OPAMP_OUT_REF
   params:OpAmpSymbolParams = get-default-opamp-symbol-params()
   ) -> OpAmpSymbol :
@@ -151,10 +160,11 @@ public defmethod name (x:OpAmpSymbol) -> String :
   "OpAmp"
 
 public defn get-input-refs (x:OpAmpSymbol) -> [Ref, Ref]:
-  val base = in-ref(x)
-  val neg-ref = Ref("%_-" % [to-string(base)])
-  val pos-ref = Ref("%_+" % [to-string(base)])
-  [pos-ref, neg-ref]
+  val in-ref-arg = in-ref(x)
+  match(in-ref-arg):
+    (base:Ref): get-signed-refs(base)
+    (exp:[Ref, Ref]):
+      exp
 
 public defn add-opamp-pins (x:OpAmpSymbol, node:SymbolNode) :
 

--- a/src/symbols/pin-refs.stanza
+++ b/src/symbols/pin-refs.stanza
@@ -1,0 +1,28 @@
+#use-added-syntax(jitx)
+doc: \<DOC>
+Pin Reference Helper Functions
+
+This package contains functions to help with the construction
+of the `Ref` names for symbol pins.
+<DOC>
+defpackage jsl/symbols/pin-refs:
+  import core
+  import jitx
+
+doc: \<DOC>
+Produce signed Ref names - usually for symbol pins.
+
+This function expects a base Ref name and then will produce
+two Refs in the format `base+` and `base-`. This is primarily for
+producing different signal inputs and outputs.
+
+@param base The base name of the Refs to be constructed. Both
+constructed refs will have this as a prefix.
+@returns Tuple of two Refs `[PosRef, NegRef]` where `PosRef`
+is the reference for the positive input and `NegReg` is the
+reference for the negative input.
+<DOC>
+public defn get-signed-refs (base:Ref) -> [Ref, Ref]:
+  val neg-ref = Ref("%_-" % [to-string(base)])
+  val pos-ref = Ref("%_+" % [to-string(base)])
+  [pos-ref, neg-ref]


### PR DESCRIPTION
This adds the ability to override the default references used by the input and output pins. This will allow for using multiple opamp packages like dual and quad packages.

@emspin  - I had to make this change so that I could use the box symbol `assign-symbols` function: 

```
pcb-component dual-op-amp :

  manufacturer = "Microchip"
  mpn = "MCP6002"

  pin-properties :
    [pin:Ref | pads:Int ... | side:Dir | bank:Ref ]
    [VOUTA  | 1 | Right | opamp-A ]
    [VINA-  | 2 | Left | opamp-A ]
    [VINA+  | 3 | Left | opamp-A ]

    [VOUTB  | 7 | Right | opamp-B ]
    [VINB-  | 6 | Left | opamp-B ]
    [VINB+  | 5 | Left | opamp-B ]

    [VDD  | 8 | Right | pwr ]
    [VSS  | 4 | Left | pwr ]

  val symb-A = OpAmpSymbol(in-ref = Ref("VINA"), out-ref = Ref("VOUTA"))
  val symb-B = OpAmpSymbol(in-ref = Ref("VINB"), out-ref = Ref("VOUTB"))
  val b = BoxSymbol(self)

  assign-symbols([
    Ref("opamp-A") => create-symbol(symb-A),
    Ref("opamp-B") => create-symbol(symb-B),
    Ref("pwr") => create-symbol(b, Ref("pwr"))
  ])
```