### PR TITLE
Added signal-ends helper functions

### DIFF
--- a/src/si/signal-ends.stanza
+++ b/src/si/signal-ends.stanza
@@ -1,0 +1,88 @@
+doc: \<DOC>
+@brief Signal Ends
+
+With signal integrity topologies, it is often necessary to expose
+the actual component signal endpoint of a topology without changing
+the design module hierarchy. The functions in this package are
+intended to help in this case.
+
+TODO - Add a specific example here and a diagram.
+We should consider using the USB-C to A converter design and renders
+showing the shortcoming and how this helps us solve that issue.
+
+<DOC>
+#use-added-syntax(jitx)
+defpackage jsl/si/signal-ends:
+  import core
+  import jitx
+  import jitx/commands
+
+public defstruct NoSignalEndError <: Exception:
+  port-name:String
+
+public defn NoSignalEndError (conn:JITXObject) -> NoSignalEndError:
+  NoSignalEndError(to-string(ref(conn)))
+
+defmethod print (o:OutputStream, e:NoSignalEndError) :
+  print(o, "No Signal End Present on Port: %_" % [port-name(e)])
+
+
+doc: \<DOC>
+Set the Signal End Property for a Topology Port
+
+Many times, a module may not expose the end point of a topology on its
+port. We might have pull-up/down resistors, blocking caps, or other
+components in series.
+
+This function allows us to publish the true endpoint of the topology
+via a `property` statement.
+
+This function is typically only used inside the module that is providing
+the endpoint of the topology.
+
+@param conn A public `port` of a `pcb-module` for which we need to publish an endpoint.
+@param sig-end This is the component/module port or abstract port to expose as the signal end.
+
+<DOC>
+public defn set-signal-end (conn:JITXObject, sig-end:JITXObject) :
+  inside pcb-module:
+    property(conn.signal-end) = sig-end
+
+doc: \<DOC>
+Get the Signal End Property of a Topology Port
+
+This function returns the port that is the end of the signal topology
+we are attempting to inspect. This will typically be a port from an internal
+component or abstract port.
+
+@param conn `Pin` object from a `pcb-module`
+@returns The signal end port for this topology. In most applications, this is
+a `Pin` object from a `pcb-component` instance.
+@throws NoSignalEndError When the passed port object does not have a defined
+`signal-end`.
+<DOC>
+public defn get-signal-end (conn:JITXObject) -> JITXObject :
+  inside pcb-module:
+    if not has-property?(conn.signal-end):
+      throw $ NoSignalEndError(conn)
+    property(conn.signal-end)
+
+doc: \<DOC>
+Find the signal end associated with this module port
+
+This function is recursive.
+
+This function searches through a tree of pcb-module ports to find
+the physical signal end port on a component. The first port found that
+does not have a `signal-end` property will be assumed to be the signal end.
+
+@returns The signal end port for this topology. In most applications, this is
+a `Pin` object from a `pcb-component` instance.
+
+<DOC>
+public defn find-signal-end (conn:JITXObject) -> JITXObject :
+  inside pcb-module:
+    if not has-property?(conn.signal-end):
+      conn
+    else:
+      find-signal-end $ get-signal-end(conn)

--- a/stanza.proj
+++ b/stanza.proj
@@ -27,5 +27,6 @@ build-test tests:
     jsl/tests/ensure
     jsl/tests/si/Microstrip
     jsl/tests/si/couplers
+    jsl/tests/si/signal-ends
   pkg: "test-pkgs"
   o: "jsl-tests"

--- a/tests/si/signal-ends.stanza
+++ b/tests/si/signal-ends.stanza
@@ -1,0 +1,84 @@
+#use-added-syntax(jitx,tests)
+defpackage jsl/tests/si/signal-ends:
+  import core
+  import collections
+  import jitx
+  import jitx/commands
+
+  import jsl/si/signal-ends
+
+  import jsl/design/settings
+  import jsl/landpatterns/packages
+  import jsl/landpatterns/two-pin/SMT
+
+  import jsl/symbols/SymbolDefn
+  import jsl/symbols/resistors
+
+  import jsl/tests/utils
+
+pcb-component test-R:
+
+  pin-properties :
+    [pin:Ref | pads:Ref ... | side:Dir | bank:Int]
+    [p[1] | p[1] | Up |  0]
+    [p[2] | p[2] | Down | 0]
+
+  val symb = ResistorSymbol()
+  assign-symbol(create-symbol(symb))
+  val chip-def = chips["1206"]
+  val pkg = SMT-Chip(
+    chip-def,
+    density-level = DensityLevelC
+  )
+
+  val lp = create-landpattern(pkg)
+  assign-landpattern(lp)
+
+
+deftest(signal-ends) test-basic-signal-ends:
+
+  pcb-module inner-mod:
+
+    port sig : pin
+    port gnd : pin
+
+    inst src : test-R
+    net (src.p[2], gnd)
+
+    inst series : test-R
+
+    net (src.p[1], series.p[2])
+    net (series.p[1], sig)
+
+    set-signal-end(sig, src.p[1])
+
+  pcb-module middle-mod:
+    port sig : pin
+    port gnd : pin
+
+    inst inner : inner-mod
+
+    net (gnd, inner.gnd)
+
+    inst R1 : test-R
+
+    net (inner.sig, R1.p[1])
+
+    net (sig, R1.p[2])
+
+    set-signal-end(sig, inner.sig)
+
+  pcb-module outer-mod:
+
+    inst U1 : middle-mod
+
+    val se = get-signal-end(U1.sig)
+    #EXPECT( to-string(ref(se)) == "U1.inner.sig" )
+
+    val se2 = find-signal-end(U1.sig)
+    #EXPECT( to-string(ref(se2)) == "U1.inner.src.p[1]" )
+
+    expect-throw({ get-signal-end(U1.gnd) })
+
+
+  set-main-module(outer-mod)


### PR DESCRIPTION
These functions help when attempting to define constraints on topologies where the true endpoints are hidden in the design hierarchy.