### PR TITLE
[Bugfix] Fixed improper path in `pcb-enum`

### DIFF
--- a/src/design/settings.stanza
+++ b/src/design/settings.stanza
@@ -4,7 +4,7 @@ defpackage jsl/design/settings:
   import jitx
   import jitx/commands
 
-public pcb-enum ocdb/utils/design-vars/DensityLevel:
+public pcb-enum jsl/design/settings/DensityLevel:
   DensityLevelA
   DensityLevelB
   DensityLevelC
@@ -41,7 +41,7 @@ public var HOLE-POSITION-TOLERANCE:  Double = 0.0508 ; The tolerance on placing 
 ; To use to export the BOM of a design:
 ; defpackage ... :
 ;   ...
-;   import ocdb/utils/design-vars
+;   import jsl/design/settings
 ;
 ; ...
 ;


### PR DESCRIPTION
This was referencing a `ocdb` path that was in conflict when attempting to use both JSL and OCDB in the same project. This retargets the `pcb-enum` path.