### PR TITLE
Added `member` docstrings for some of the `pcb-bundle` definitions

### DIFF
--- a/src/bundles/comms.stanza
+++ b/src/bundles/comms.stanza
@@ -11,6 +11,8 @@ I2C Bundle
 Inter-Integrated Circuit (I2C) is a serial communication
 protocol
 @see https://en.wikipedia.org/wiki/I%C2%B2C
+@member sda Synchronous Data Line
+@member scl Synchronous Clock Line
 <DOC>
 public pcb-bundle i2c:
   name = "I2C"
@@ -38,6 +40,29 @@ pcb-bundle smbus-b (pins:Collection<SMBUSPins>):
       SMBALERT#  : make-pin(`smbalert#)
       SMBSUS#    : make-pin(`smbsus#)
 
+doc: \<DOC>
+Configurable SMBus Bundle
+@param pins Optional pins that can be included in the bundle.
+@member smbclk Synchronous Clock Line
+@member smbdat Synchronous Data Line
+@member smbalert# Optional Alert Interrupt - Active Low
+@member smbsus# Optional Suspend Line - Active Low
+
+@snippet
+
+```stanza
+  val b = smbus(SMBALERT#)
+  supports b:
+    b.smbclk => self.CLK
+    b.smbdat => self.DAT
+    b.smbalert# => self.ALERT_n
+```
+
+@snip-note 1 Adding the `SMBALERT#` value to the function definition
+generates a `pcb-bundle` including the base pins `smbclk` and `smbdat`
+as well as the optional `smbalert#` pin.
+
+<DOC>
 public defn smbus (pins:SMBUSPins ...) :
   smbus-b(pins)
 
@@ -46,9 +71,8 @@ Standard SMBUS Generator
 
 This generator will construct an SMBUS bundle with the following pins:
 
-*  `smbclk` - Clock Line
-*  `smbdat` - Data Line
-
+@member smbclk Synchronous Clock Line
+@member smbdat Synchronous Data Line
 <DOC>
 public defn std-smbus () :
   smbus()
@@ -58,6 +82,10 @@ CAN Physical Layer Bundle
 
 This bundle defines the physical layer for the CAN interface
 which consists of a differential pair `H` / `L`
+
+@member H High side of the differential pair for the transmission line
+@member L Low side of the differential pair for the transmission line
+
 <DOC>
 public pcb-bundle can-phy :
   name = "CAN Physical Interface"
@@ -72,6 +100,8 @@ PHY is typically a two wire interface consisting of a
 TX and RX line.
 
 TODO - Add optional error line ?
+@member rx Receive line
+@member tx Transmit line
 <DOC>
 public pcb-bundle can-logical :
   pin rx
@@ -103,6 +133,10 @@ Serial Peripheral Interface is a serial communication protocol.
 
 @param pins User needs to specify which pins will be included in
 the SPI interface. Some devices don't have a `MISO` pin for example.
+@member sck Synchronous Clock Line
+@member cs Chip Select
+@member miso Master In Slave Out
+@member mosi Master Out Slave In
 <DOC>
 public defn spi (pins:SPIPins ...) :
   spi-b(pins)
@@ -113,10 +147,9 @@ Standard SPI Generator
 This generator will construct an SPI bundle with the following
 pins:
 
-*  `sclk` - Clock Line
-*  `miso` - Master In - Slave Out
-*  `mosi` - Master Out - Slave In
-
+@member sck Synchronous Clock Line
+@member miso Master In Slave Out
+@member mosi Master Out Slave In
 <DOC>
 public defn std-spi () :
   spi(SPI-MISO, SPI-MOSI)
@@ -127,11 +160,10 @@ Standard SPI with Chip Select Generator
 This generator will construct an SPI bundle with the following
 pins:
 
-*  `sclk` - Clock Line
-*  `miso` - Master In - Slave Out
-*  `mosi` - Master Out - Slave In
-*  `cs` - Chip Select
-
+@member sck Synchronous Clock Line
+@member cs Chip Select
+@member miso Master In Slave Out
+@member mosi Master Out Slave In
 <DOC>
 public defn spi-with-cs () :
   spi(SPI-MISO, SPI-MOSI, SPI-CS)
@@ -155,6 +187,9 @@ or on flash chips.
   values are 2, 4, and 8
 @param pins Optionally allow for Chip Select pin on this interface.
   Note MISO and MOSI are not supported.
+@member sck Synchronous Clock Line
+@member cs Chip Select
+@member data Variable Width Data Bus depending on `width` parameter
 <DOC>
 public pcb-bundle wide-spi (width:Int, pins:Collection<SPIPins>):
   name = to-wide-name(width)
@@ -168,18 +203,28 @@ public pcb-bundle wide-spi (width:Int, pins:Collection<SPIPins>):
 
 doc: \<DOC>
 Dual SPI Bundle Generator
+@member sck Synchronous Clock Line
+@member cs Chip Select
+@member data Data Bus of width=2
 <DOC>
 public defn dual-spi (pins:SPIPins ...):
   wide-spi(2, pins)
 
 doc: \<DOC>
 Quad SPI Bundle Generator
+@member sck Synchronous Clock Line
+@member cs Chip Select
+@member data Data Bus of width=4
 <DOC>
 public defn quad-spi (pins:SPIPins ...):
   wide-spi(4, pins)
 
 doc: \<DOC>
 Octal SPI Bundle Generator
+
+@member sck Synchronous Clock Line
+@member cs Chip Select
+@member data Data Bus of width=8
 <DOC>
 public defn octal-spi (pins:SPIPins ...):
   wide-spi(8, pins)
@@ -220,6 +265,14 @@ UART Bundle Generator
 Universal Asynchronous Receiver/Transmitter
 Constructs a bundle with the passed pin configuration
 @see https://en.wikipedia.org/wiki/Universal_asynchronous_receiver-transmitter
+
+@member tx Transmit Data Line
+@member rx Receive Data Line
+@member cts Clear to Send Line
+@member rts Ready to Send Line
+@member dtr Data Terminal Ready Line
+@member ri Ring Indicator Line
+@member ck Clock Line
 <DOC>
 public defn uart (pins:UARTPins ...):
   uart-b(pins)
@@ -229,8 +282,8 @@ Minimal UART Bundle Generator
 
 This generator constructs a UART bundle consisting of:
 
-*  `tx` - Transit Data Line
-*  `rx` - Receive Data Line
+@member tx Transmit Data Line
+@member rx Receive Data Line
 <DOC>
 public defn minimal-uart () :
   uart(UART-RX, UART-TX)

--- a/src/bundles/debug.stanza
+++ b/src/bundles/debug.stanza
@@ -12,6 +12,11 @@ Typically used for debugging/testing integrated circuits.
 This bundle does not include `TRSTN` or Target Reset. Use a
 separate `reset` bundle to provide that interface on a connector
 or microcontroller.
+
+@member tck Synchronous Clock Line
+@member tdi Data Input Line
+@member tdo Data Output Line
+@member tms State Select Line
 <DOC>
 public pcb-bundle jtag :
   name = "JTAG"
@@ -34,15 +39,9 @@ pcb-bundle swd-b (pins:Collection<SWDPins>):
 doc: \<DOC>
 Serial Wire Debug Bundle Generator
 
-This bundle includes the pins:
-
-`swdio` - Data line
-`swdclk` - Clock line
-
-This bundle can optionally include:
-
-`swo` - Trace Data Line
-
+@member swdio Synchronous Bidir Data Line
+@member swdclk Synchronous Clock Line
+@member swo Optional Trace Data Line
 <DOC>
 public defn swd (pins:SWDPins ...):
   swd-b(pins)

--- a/src/bundles/general.stanza
+++ b/src/bundles/general.stanza
@@ -19,6 +19,8 @@ The differential pair is a foundation bundle type used in various
 derived bundles. Many utilities are built to reference `diff-pair`
 bundle types. It is highly suggested to use this type when constructing
 ports/bundles.
+@member P Positive side of the differential pair
+@member N Negative side of the differential pair
 <DOC>
 public pcb-bundle diff-pair :
   name = "Differential Signal Pair"
@@ -33,6 +35,9 @@ differential pair through a component - for example, an ESD
 diode protection device like a TI, TPD4E05.
 
 No directionality is implied by this bundle.
+@member A Differential Pair Port
+@member B Differential Pair Port
+
 <DOC>
 public pcb-bundle dual-pair :
   name = "Dual Pair Bundle"
@@ -45,6 +50,9 @@ Two Differential Pairs - a Lane Pair
 It is very common in communication standards to have a
 TX diff-pair and an RX diff-pair with
 The lane pair is a directed differential pair lane
+
+@member TX Transmit Pair
+@member RX Receive Pair
 <DOC>
 public pcb-bundle lane-pair :
   name = "Lane Pair Bundle"
@@ -63,6 +71,9 @@ Example:
 ESD Protection devices often have two pins that are intended
 to be shorted together to provide an ESD protected trace with
 minimal affect on the impedance of the trace.
+
+@member A SinglePin Port
+@member B SinglePin Port
 <DOC>
 public pcb-bundle pass-through :
   pin A
@@ -73,6 +84,9 @@ Power Bundle define a DC power source
 
 The power bundle defines the two reference voltages
 of a DC power source.
+
+@member V+ Positive Voltage of the Power Bundle
+@member V- Negative Voltage of the Power Bundle
 <DOC>
 public pcb-bundle power :
   name = "DC Power"
@@ -83,17 +97,42 @@ public pcb-bundle power :
 ; General IO Classes
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+doc: \<DOC>
+GPIO Interface Bundle
+
+@member p GPIO Pin
+<DOC>
 public pcb-bundle gpio :
   pin p
 
+doc: \<DOC>
+Timer Interface Bundle
+
+@member p Timer Pin
+<DOC>
 public pcb-bundle timer :
   pin p
 
+doc: \<DOC>
+Single-Ended ADC Interface Bundle
+
+@member p ADC Pin
+<DOC>
 public pcb-bundle adc :
   pin p
 
+doc: \<DOC>
+Single-Ended DAC Interface Bundle
+
+@member p DAC Pin
+<DOC>
 public pcb-bundle dac :
   pin p
 
+doc: \<DOC>
+Reset Interface Bundle
+
+@member p Reset Pin
+<DOC>
 public pcb-bundle reset :
   pin p


### PR DESCRIPTION
This is primarily to serve an example for Tristan.