### PR TITLE
Add Reference Designators for Package Generators

### DIFF
--- a/examples/landpatterns/SON.stanza
+++ b/examples/landpatterns/SON.stanza
@@ -1,0 +1,77 @@
+#use-added-syntax(jitx)
+defpackage jsl/examples/landpatterns/SON:
+  import core
+  import jitx
+  import jitx/commands
+
+  import jsl/examples/landpatterns/board
+
+  import jsl/symbols/SymbolDefn
+  import jsl/symbols/box-symbol
+
+  import jsl/landpatterns/leads
+  import jsl/landpatterns/packages
+  import jsl/landpatterns/SON
+
+
+defn create-DSG0008A ():
+  SON(
+    num-leads = 8,
+    lead-profile = Lead-Profile(
+      span = min-max(1.9, 2.1),
+      pitch = 0.5,
+      lead = SON-Lead(
+        length = min-max(0.2, 0.4),
+        width = min-max(0.18, 0.32)
+      )
+    ),
+    thermal-lead? = Rectangle(0.9, 1.6),
+    package-body = PackageBody(
+      width = min-max(1.9, 2.1)
+      length = min-max(1.9, 2.1)
+      height = min-max(0.7, 0.8)
+    )
+  )
+
+pcb-component test-DSG0008A:
+
+  pin-properties :
+    [pin:Ref | pads:Ref ... | side:Dir ]
+
+    [VIN | p[8] | Left ]
+    [EN | p[1] | Left ]
+    [MODE | p[3] | Left ]
+    [GND | p[2] | Left ]
+    [EP | p[9] | Left ]
+
+    [PG | p[6] | Right ]
+    [SW | p[7] | Right ]
+    [VOS | p[5] | Right ]
+    [FB | p[4] | Right ]
+
+
+  val b = create-symbol $ BoxSymbol(self)
+  assign-symbol(b)
+
+  val pkg = create-DSG0008A()
+  val lp = create-landpattern(pkg)
+  assign-landpattern(lp)
+
+pcb-module test-design:
+  inst c : test-DSG0008A
+  place(c) at loc(0.0, 0.0) on Top
+
+val board-shape = RoundedRectangle(50.0, 50.0, 0.25)
+
+; Set the top level module (the module to be compile into a schematic and PCB)
+set-current-design("SON-TEST")
+set-rules(default-rules)
+set-board(default-board(board-shape))
+
+set-main-module(test-design)
+
+; Use any helper function from helpers.stanza here. For example:
+; run-check-on-design(my-design)
+
+; View the results
+view-board()

--- a/src/landpatterns/BGA/package.stanza
+++ b/src/landpatterns/BGA/package.stanza
@@ -221,20 +221,13 @@ public defn build-outline (
   val outline = compute-outline(vp, body, density-level)
   add-artwork(vp, Silkscreen("outline", Top), outline, class = "outline")
 
-defn get-outline (vp:VirtualLP) -> Shape:
-  val outlines = to-tuple $ seq{as-VirtualArtwork, _} $ find-by-class(vp, "outline")
-  if length(outlines) != 1:
-    throw $ ValueError("Expected only one element in class 'outline': %," % [outlines])
-
-  shape $ outlines[0]
-
 public defn build-triangle-marker (
   vp:VirtualLP
   --
   pin-1-id:Int|Ref = 1,
   side:Side = Top
   ):
-  val o-sh = get-outline(vp)
+  val o-sh = get-silkscreen-outline!(vp)
 
   val pin-1-pad = get-pad-by-ref!(vp, pin-1-id)
 
@@ -267,7 +260,7 @@ public defn build-pin-1-marker (
   line-width:Double = default-silk-width(),
   mask-clearance:Double = default-mask-clearance(),
   ):
-  val o-sh = get-outline(vp)
+  val o-sh = get-silkscreen-outline!(vp)
   val pin-1-pos = center $ pose $ get-pad-by-ref!(vp, pin-1-id)
 
   val o-box = bounds $ o-sh
@@ -297,3 +290,4 @@ public defmethod build-silkscreen (
   build-outline(vp, package-body(pkg), density-level(pkg))
   build-pin-1-marker(vp, pin-1-id = pin-1-id)
   build-triangle-marker(vp, pin-1-id = pin-1-id)
+  add-reference-designator(vp)

--- a/src/landpatterns/QFN.stanza
+++ b/src/landpatterns/QFN.stanza
@@ -237,12 +237,8 @@ public defn QFN-pin-1-marker (
   add-artwork(vp, Silkscreen("pin-1-marker", side), marker-geom, name = "pin-1-dot", class = "pin1-marker")
 
   if density-level(pkg) == DensityLevelA :
-    val outlines = to-tuple $ seq{as-VirtualArtwork, _} $ find-by-class(vp, "outline")
-    if length(outlines) != 1:
-      throw $ ValueError("Expected only one element in class 'outline': %," % [outlines])
-
-    val outline = outlines[0]
-    val o-box = bounds $ shape(outline)
+    val outline = get-silkscreen-outline!(vp)
+    val o-box = bounds(outline)
 
     val marker = compute-triangle-marker(pad-center, o-box, line-width)
     add-artwork(
@@ -259,5 +255,6 @@ public defmethod build-silkscreen (
   ) -> False:
   QFN-outline(pkg, vp)
   QFN-pin-1-marker(pkg, vp)
+  add-reference-designator(vp)
 
 

--- a/src/landpatterns/SOIC.stanza
+++ b/src/landpatterns/SOIC.stanza
@@ -289,3 +289,4 @@ public defmethod build-silkscreen (
   build-pkg-body-outline(pkg, vp)
   build-smd-pin-1(pkg, vp)
   build-outline-pin-1(pkg, vp)
+  add-reference-designator(vp)

--- a/src/landpatterns/SON.stanza
+++ b/src/landpatterns/SON.stanza
@@ -265,12 +265,8 @@ public defn SON-pin-1-marker (
   add-artwork(vp, Silkscreen("pin-1-marker", side), marker-geom, name = "pin-1-dot", class = "pin1-marker")
 
   if density-level(pkg) == DensityLevelA :
-    val outlines = to-tuple $ seq{as-VirtualArtwork, _} $ find-by-class(vp, "outline")
-    if length(outlines) != 1:
-      throw $ ValueError("Expected only one element in class 'outline': %," % [outlines])
-
-    val outline = outlines[0]
-    val o-box = bounds $ shape(outline)
+    val outline = get-silkscreen-outline!(vp)
+    val o-box = bounds(outline)
 
     val marker = compute-triangle-marker(pad-center, o-box, line-width)
     add-artwork(
@@ -287,5 +283,6 @@ public defmethod build-silkscreen (
   ) -> False:
   SON-outline(pkg, vp)
   SON-pin-1-marker(pkg, vp)
+  add-reference-designator(vp)
 
 

--- a/src/landpatterns/VirtualLP.stanza
+++ b/src/landpatterns/VirtualLP.stanza
@@ -162,10 +162,6 @@ elements (pads, artwork, etc) before writing it to the
 ESIR `pcb-landpattern` definition. Once written to ESIR,
 the landpattern cannot be modified.
 
-NOTE: I'm not supporting `copper` statements yet because
-I'm not sure how or why to use them. They don't seem
-particularly useful
-
 <DOC>
 public defstruct VirtualLP <: VirtualElement :
   doc: \<DOC>

--- a/src/landpatterns/VirtualLP.stanza
+++ b/src/landpatterns/VirtualLP.stanza
@@ -7,6 +7,8 @@ defpackage jsl/landpatterns/VirtualLP:
 
   import jsl/errors
   import jsl/design/Classable
+  import jsl/geometry/box
+  import jsl/landpatterns/courtyard
 
 doc: \<DOC>
 Base Type for the Elements of the Virtual Landpattern Tree
@@ -331,6 +333,14 @@ public defn get-copper (vp:VirtualLP, li:LayerIndex) -> Tuple<VirtualCopper> :
 public defn get-coppers (vp:VirtualLP) -> Tuple<VirtualCopper> :
   to-tuple $ metal(vp)
 
+public defn get-silkscreen-outline! (vp:VirtualLP) -> Shape :
+  val outlines = to-tuple $ seq{as-VirtualArtwork, _} $ find-by-class(vp, "outline")
+  if length(outlines) != 1:
+    throw $ ValueError("Expected only one element in class 'outline': %," % [outlines])
+
+  val outline = outlines[0]
+  shape(outline)
+
 public defn add-artwork (
   vp:VirtualLP,
   ls:LayerSpecifier,
@@ -352,6 +362,45 @@ public defn add-artwork (
   val new-art = for sh in shapes seq:
     VirtualArtwork(ls, sh, class = class)
   append-all(vp, new-art)
+
+doc: \<DOC>
+Create a reference designator in the current virtual landpattern
+
+
+If a courtyard exists - This function will place a reference designator outside the courtyard outline
+of the component, just above the upper-left corner of the bounds of the outline.
+
+If no courtyard exists - then this function places the silkscreen reference designator
+at the VirtualLP node origin.
+
+In either case, this placement is really just an initial placement. The user will
+use the placer in the board view to move it to a more reasonable
+location.
+
+@param vp Land Pattern Node where content will be drawn.
+@param ls Layer to draw the reference designator. By default this is the top silkscreen.
+@param text-size Size of designator text height in mm. Default is 1.0 mm.
+@param font Optional Font to use. See the `Text` object in JITX runtime.
+
+<DOC>
+public defn add-reference-designator (
+  vp:VirtualLP,
+  ls:LayerSpecifier = Silkscreen("F-SilkS", Top)
+  text-size:Double = 1.0,
+  font:String = ""
+  ) -> False :
+
+  val o-box? = get-courtyard-boundary(vp)
+  val pos = match(o-box?):
+    (_:False):
+      ; Drop at the origin if there is no courtyard
+      loc(0.0, 0.0)
+    (o-box:Box):
+      val text-margin = 0.25
+      loc(left(o-box), up(o-box) + text-margin)
+
+  val sh = Text(">REF", text-size, SW, pos, font, TrueTypeFont, false, false)
+  add-artwork(vp, ls, [sh], class = "ref-des")
 
 doc: \<DOC>
 Add a `VirtualArtwork` instance to the landpattern

--- a/src/landpatterns/dual-row.stanza
+++ b/src/landpatterns/dual-row.stanza
@@ -298,25 +298,20 @@ public defn build-outline-pin-1 (
   side:Side = Top
   ):
 
-  val outlines = to-tuple $ seq{as-VirtualArtwork, _} $ find-by-class(vp, "outline")
-  if length(outlines) != 1:
-    throw $ ValueError("Expected only one element in class 'outline': %," % [outlines])
+  val outline = get-silkscreen-outline!(vp)
 
-  val outline = outlines[0]
-
-  val pin-1-pad = get-pad-by-ref!(vp, pin-1-id)
   ; Find the corner of the outline nearest to pad 1
-  val o-sh = shape(outline)
+  val pin-1-pad = get-pad-by-ref!(vp, pin-1-id)
 
   ; The Outline is typically a line rectangle which creates a
   ;  single line. We use this to determine the line width
   ;  so that we can place the marker in the mid-line
-  val line-width = match(o-sh):
+  val line-width = match(outline):
     (x:Line): width(x)
     ; TODO - this probably should be a setting
     (_): 0.1
 
-  val o-box = bounds $ o-sh
+  val o-box = bounds(outline)
 
   val pin-1-pos = center $ pose(pin-1-pad)
 

--- a/src/landpatterns/headers.stanza
+++ b/src/landpatterns/headers.stanza
@@ -179,3 +179,4 @@ public defmethod build-silkscreen (
   ):
   val outline = compute-outline(vp, density-level(pkg))
   add-artwork(vp, Silkscreen("outline", Top), outline, class = "outline")
+  add-reference-designator(vp)

--- a/src/landpatterns/two-pin/SMT.stanza
+++ b/src/landpatterns/two-pin/SMT.stanza
@@ -344,6 +344,8 @@ public defmethod build-silkscreen (
   vp:VirtualLP
   ):
   build-SMT-outline(pkg, vp)
+  add-reference-designator(vp)
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;   Resistor

--- a/src/landpatterns/two-pin/radial.stanza
+++ b/src/landpatterns/two-pin/radial.stanza
@@ -296,3 +296,4 @@ public defmethod build-silkscreen (
   build-radial-outline(pkg, vp)
   if polarized?(pkg):
     build-polarity-marker(pkg, vp)
+  add-reference-designator(vp)


### PR DESCRIPTION
This adds a new feature to generate an initial reference designator placement in landpattern generators. 

I've added an example for the SON package. 
I've added some refactors to reduce code duplication.

Examples should now show this:

![Screenshot 2024-06-10 at 1 46 57 PM](https://github.com/JITx-Inc/jsl/assets/622392/d4278c2b-09fc-4053-903b-2a2ed29aeb7e)

With a U1 or similar ref-des