### PR TITLE
PROD-132/Jsl/layerstack access functions

### DIFF
--- a/src/layerstack.stanza
+++ b/src/layerstack.stanza
@@ -10,21 +10,18 @@ defpackage jsl/layerstack:
 doc: \<DOC>
 Base class for Defining the Layer Material
 <DOC>
-public-when(TESTING) defstruct LayerMaterial <: Hashable & Equalable :
+public defstruct LayerMaterial <: Hashable & Equalable :
   name:Maybe<String>
   type:MaterialType
   description:Maybe<String>
   material-def:Maybe<JITXDef> with: (
     setter => set-material-def
   )
+with:
+  equalable => true
+  hashable => true
 
 defmulti create-material (x:LayerMaterial) -> JITXDef
-
-defmethod equal? (ma:LayerMaterial, mb:LayerMaterial) :
-  name(ma) == name(mb) and
-  type(ma) == type(mb) and
-  material-def(ma) == material-def(mb)
-
 
 ; I need these accessors because the `name` and `type` tokens
 ;  will get consumed by the macro before they can call the functions.
@@ -36,7 +33,7 @@ defn make-name (x:LayerMaterial):
       (_:None): false
       (v:One<String>): name = value(v)
 
-public-when(TESTING) defn get-type (x:LayerMaterial) -> MaterialType:
+public defn get-type (x:LayerMaterial) -> MaterialType:
   type(x)
 
 defn make-description (x:LayerMaterial) :
@@ -221,7 +218,7 @@ public val SoldermaskMaterial = DielectricMaterial(
 )
 
 public defstruct LayerSpec <: Equalable :
-  name:Maybe<String> with: (setter => set-name)
+  name:Maybe<String> with: (setter => set-name?)
   description:Maybe<String>
   material:LayerMaterial
   thickness:Double with: (
@@ -230,11 +227,10 @@ public defstruct LayerSpec <: Equalable :
 with:
   constructor => #LayerSpec
   printer => true
+  equalable => true
 
-defmethod equal? (la:LayerSpec, lb:LayerSpec) :
-  name(la) == name(lb) and
-  material(la) == material(lb) and
-  thickness(la) == thickness(lb)
+public defn set-name (l:LayerSpec, name:String) :
+  set-name?(l One(name))
 
 public defn LayerSpec (
   --
@@ -247,37 +243,25 @@ public defn LayerSpec (
 
 doc: \<DOC>
 Create a Copper layer
-  Usage: Copper(name, thickness) : specify the thickness directly
-         Copper(name, weight, weight? = true) : specify weight in order to compute thickness
-         Copper(weight, AluminumMaterial, weight? = true) : without name
+  Usage: Copper(0.3) : specify thickness 
+         Copper(0.3, name = "Cu") : specify thickness and name
+         Copper(0.3, AluminumMaterial, name = "Cu") : specify thickness, material and name
+@param thickness : layer thickness in mm
+@param material : optional positional argument
+@param name : optional named argument
 <DOC>
-public defn Copper (name:String, thickness:Double, material:ConductorMaterial = CopperMaterial
-    -- weight?:True|False = false) -> LayerSpec :
-  if weight? :
-    val weight = thickness
-    LayerSpec(name = name, thickness = compute-thickness(material, weight), material = material)
-  else : 
-    LayerSpec(name = name, thickness = thickness, material = material)
-
-public defn Copper (thickness:Double, material:ConductorMaterial = CopperMaterial
-    -- weight?:True|False = false) -> LayerSpec :
-  if weight? :
-    val weight = thickness
-    LayerSpec(thickness = compute-thickness(material, weight), material = material)
-  else :
-    LayerSpec(thickness = thickness, material = material)
-
-public defn FR4 (name:String, thickness:Double, material:DielectricMaterial = FR4-Material) -> LayerSpec :
-  LayerSpec(name = name, material = material, thickness = thickness)
-
-public defn FR4 (thickness:Double, material:DielectricMaterial = FR4-Material) -> LayerSpec :
-  LayerSpec(material = material, thickness = thickness)
-
-public defn Soldermask (name:String, thickness:Double, material:DielectricMaterial = SoldermaskMaterial) -> LayerSpec :
-  LayerSpec(name = name, material = material, thickness = thickness)
-
-public defn Soldermask (thickness:Double, material:DielectricMaterial = SoldermaskMaterial) -> LayerSpec :
-  LayerSpec(material = material, thickness = thickness)
+#for (
+  func-name in [Copper FR4 Soldermask]
+  material-type in [ConductorMaterial DielectricMaterial DielectricMaterial ]
+  material-default in [CopperMaterial FR4-Material SoldermaskMaterial]
+) :
+  public defn func-name (thickness:Double, material:material-type = material-default
+      -- name:String = ?) -> LayerSpec :
+    match(name):
+      (name:One) :
+        LayerSpec(name = value(name), thickness = thickness, material = material)
+      (_):
+        LayerSpec(thickness = thickness, material = material)
 
 defn get-name (x:LayerSpec) -> Maybe<String> :
   name(x)
@@ -319,20 +303,9 @@ public defn LayerStack (
 defmethod write (o:OutputStream, s:LayerStack) :
   println(o, "LayerStack: %_" % [value?(name(s))])
   println(o, "  Layers: %_ copper layers %_ total layers" % [get-conductor-count(s) length(layers(s))])
-  for [idx, l] in enumerate(layers(s)) do:
+  for (l in layers(s), idx in 0 to false) do :
     println(o, "    %_ : %_ | %_ | %_" %
       [idx, value?(name(l)) get-type(material(l)) thickness(l)])
-
-doc:\<DOC>
-  Usage: for [idx, line] in enumerate(lines) do: 
-           println(“Line %: %_” % [idx, line])
-<DOC>
-defn enumerate<?T> (s:Seqable<?T>) -> Seq<[Int, T]> :
-  var i = 0
-  for x in s seq :
-    next where:
-      val next = [i, x]
-      i = i + 1
 
 doc:\<DOC>
   Get a layer by index
@@ -446,13 +419,13 @@ layers, and 2 more copper layers. This constructs a symmetric stackup.
 ```
 val stack = LayerStack(name = "6-Layer Symmetric Stackup")
 
-val copper-1oz = Copper("cu", 1.0, weight = true)
-val core-FR4 = FR4("core", 1.0)
-val prepreg-FR4 = FR4("prepreg", 0.5)
+val copper-1mm = Copper(1.0, name = "cu")
+val core-FR4 = FR4(1.0, name = "core")
+val prepreg-FR4 = FR4(0.5, name = "prepreg")
 
-add-symmetric(copper-1oz, core-FR4,
-  add-symmetric(copper-1oz, prepreg-FR4,
-    add-symmetric(copper-1oz, core-FR4, stack)
+add-symmetric(copper-1mm, core-FR4,
+  add-symmetric(copper-1mm, prepreg-FR4,
+    add-symmetric(copper-1mm, core-FR4, stack)
   )
 )
 ```

--- a/src/layerstack.stanza
+++ b/src/layerstack.stanza
@@ -236,20 +236,25 @@ public defn LayerSpec (
 
 doc: \<DOC>
 Create a Copper layer
+  Usage: Copper(name, thickness) : specify the thickness directly
+         Copper(name, weight, weight? = true) : specify weight in order to compute thickness
+         Copper(weight, AluminumMaterial, weight? = true) : without name
 <DOC>
-public defn Copper (name:String, weight:Double, material:ConductorMaterial = CopperMaterial
-    -- is-thickness?:True|False = false) -> LayerSpec :
-  if not is-thickness? :
+public defn Copper (name:String, thickness:Double, material:ConductorMaterial = CopperMaterial
+    -- weight?:True|False = false) -> LayerSpec :
+  if weight? :
+    val weight = thickness
     LayerSpec(name = name, thickness = compute-thickness(material, weight), material = material)
   else : 
-    LayerSpec(name = name, thickness = weight, material = material)
+    LayerSpec(name = name, thickness = thickness, material = material)
 
-public defn Copper (weight:Double, material:ConductorMaterial = CopperMaterial
-    -- is-thickness?:True|False = false) -> LayerSpec :
-  if not is-thickness? :
+public defn Copper (thickness:Double, material:ConductorMaterial = CopperMaterial
+    -- weight?:True|False = false) -> LayerSpec :
+  if weight? :
+    val weight = thickness
     LayerSpec(thickness = compute-thickness(material, weight), material = material)
   else :
-    LayerSpec(thickness = weight, material = material)
+    LayerSpec(thickness = thickness, material = material)
 
 public defn FR4 (name:String, thickness:Double, material:DielectricMaterial = FR4-Material) -> LayerSpec :
   LayerSpec(name = name, material = material, thickness = thickness)
@@ -412,7 +417,7 @@ layers, and 2 more copper layers. This constructs a symmetric stackup.
 ```
 val stack = LayerStack(name = "6-Layer Symmetric Stackup")
 
-val copper-1oz = Copper("cu", 1.0)
+val copper-1oz = Copper("cu", 1.0, weight = true)
 val core-FR4 = FR4("core", 1.0)
 val prepreg-FR4 = FR4("prepreg", 0.5)
 

--- a/src/layerstack.stanza
+++ b/src/layerstack.stanza
@@ -237,11 +237,19 @@ public defn LayerSpec (
 doc: \<DOC>
 Create a Copper layer
 <DOC>
-public defn Copper (name:String, weight:Double, material:ConductorMaterial = CopperMaterial) -> LayerSpec :
-  LayerSpec(name = name, thickness = compute-thickness(material, weight), material = material)
+public defn Copper (name:String, weight:Double, material:ConductorMaterial = CopperMaterial
+    -- is-thickness?:True|False = false) -> LayerSpec :
+  if not is-thickness? :
+    LayerSpec(name = name, thickness = compute-thickness(material, weight), material = material)
+  else : 
+    LayerSpec(name = name, thickness = weight, material = material)
 
-public defn Copper (weight:Double, material:ConductorMaterial = CopperMaterial) -> LayerSpec :
-  LayerSpec(thickness = compute-thickness(material, weight), material = material)
+public defn Copper (weight:Double, material:ConductorMaterial = CopperMaterial
+    -- is-thickness?:True|False = false) -> LayerSpec :
+  if not is-thickness? :
+    LayerSpec(thickness = compute-thickness(material, weight), material = material)
+  else :
+    LayerSpec(thickness = weight, material = material)
 
 public defn FR4 (name:String, thickness:Double, material:DielectricMaterial = FR4-Material) -> LayerSpec :
   LayerSpec(name = name, material = material, thickness = thickness)
@@ -278,7 +286,7 @@ public defstruct LayerStack :
   description:Maybe<String>
 
   layers:Vector<LayerSpec> with: (
-    updater => sub-layers
+    setter => set-layers
   )
 with:
   constructor => #LayerStack
@@ -300,21 +308,23 @@ public defn get (stack:LayerStack, idx:Int) -> LayerSpec :
   layers(stack)[idx]
 
 doc:\<DOC>
-  Usage: stack.copper[idx]
+  Modify a layer by index
+  Usage: stack[idx] - new-layer
 <DOC>
-public defn dot (stack:LayerStack, name:Symbol) -> Tuple<LayerSpec> :
-  if name == `copper :
-    to-tuple $ for l in layers(stack) filter:
-      material(l) is ConductorMaterial
-  else :
-    throw $ ValueError("dot for field %_ not supported" % [name])
+public defn set (stack:LayerStack, idx:Int, layer:LayerSpec) -> False :
+  layers(stack)[idx] = layer
+  ;<A>
+  set-layers(stack new-layers) where :
+    val new-layers = to-tuple $ cat-all $
+      [layers(stack)[0 to idx] [layer] layers(stack)[(idx + 1) to false]]
+  ;<A>
 
 doc:\<DOC>
-  Get a layer by index
-  Usage: stack[idx].name = new-name
+  Get the idx-th conductor layer
+  Usage: conductors(stack)[idx]
 <DOC>
-public defn set-name (stack:LayerStack, idx:Int, new-name:String) :
-  set-name(layers(stack)[idx] One(new-name))
+public defn conductors (stack:LayerStack) -> Tuple<LayerSpec> :
+  to-tuple $ filter({material(_) is ConductorMaterial} layers(stack))
 
 doc: \<DOC>
 Add one or more layers to the top of the board stackup.

--- a/src/layerstack.stanza
+++ b/src/layerstack.stanza
@@ -229,6 +229,8 @@ with:
   printer => true
   equalable => true
 
+public defn get-name (x:LayerSpec) -> Maybe<String> :
+  name(x)
 public defn set-name (l:LayerSpec, name:String) :
   set-name?(l One(name))
 
@@ -246,25 +248,33 @@ Create a Copper layer
   Usage: Copper(0.3) : specify thickness 
          Copper(0.3, name = "Cu") : specify thickness and name
          Copper(0.3, AluminumMaterial, name = "Cu") : specify thickness, material and name
-@param thickness : layer thickness in mm
-@param material : optional positional argument
-@param name : optional named argument
+@param thickness thickness of the layer in mm - required argument
+@param material material of the layer - optional positional argument
+@param name name of the layer - optional named argument
 <DOC>
-#for (
-  func-name in [Copper FR4 Soldermask]
-  material-type in [ConductorMaterial DielectricMaterial DielectricMaterial ]
-  material-default in [CopperMaterial FR4-Material SoldermaskMaterial]
-) :
-  public defn func-name (thickness:Double, material:material-type = material-default
-      -- name:String = ?) -> LayerSpec :
-    match(name):
-      (name:One) :
-        LayerSpec(name = value(name), thickness = thickness, material = material)
-      (_):
-        LayerSpec(thickness = thickness, material = material)
+public defn Copper (thickness:Double, material:ConductorMaterial = CopperMaterial
+    -- name:String = ?) -> LayerSpec :
+  match(name):
+    (name:One) :
+      LayerSpec(name = value(name), thickness = thickness, material = material)
+    (_):
+      LayerSpec(thickness = thickness, material = material)
 
-defn get-name (x:LayerSpec) -> Maybe<String> :
-  name(x)
+public defn FR4 (thickness:Double, material:DielectricMaterial = FR4-Material
+    -- name:String = ?) -> LayerSpec :
+  match(name):
+    (name:One) :
+      LayerSpec(name = value(name), thickness = thickness, material = material)
+    (_):
+      LayerSpec(thickness = thickness, material = material)
+
+public defn Soldermask (thickness:Double, material:DielectricMaterial = SoldermaskMaterial
+    -- name:String = ?) -> LayerSpec :
+  match(name):
+    (name:One) :
+      LayerSpec(name = value(name), thickness = thickness, material = material)
+    (_):
+      LayerSpec(thickness = thickness, material = material)
 
 public defn make-layer-statement (x:LayerSpec) :
   val name? = get-name(x)
@@ -286,7 +296,7 @@ public defstruct LayerStack :
   description:Maybe<String>
 
   layers:Vector<LayerSpec> with: (
-    setter => sub-layers
+    updater => sub-layers
   )
 with:
   constructor => #LayerStack
@@ -302,7 +312,7 @@ public defn LayerStack (
 
 defmethod write (o:OutputStream, s:LayerStack) :
   println(o, "LayerStack: %_" % [value?(name(s))])
-  println(o, "  Layers: %_ copper layers %_ total layers" % [get-conductor-count(s) length(layers(s))])
+  println(o, "  Layers: %_ conductor layers %_ total layers" % [get-conductor-count(s) length(layers(s))])
   for (l in layers(s), idx in 0 to false) do :
     println(o, "    %_ : %_ | %_ | %_" %
       [idx, value?(name(l)) get-type(material(l)) thickness(l)])
@@ -343,7 +353,6 @@ on top of that.
 @return The modified layer stack object
 
 <DOC>
-
 public defn add-top (l-set:LayerSpec|Collection<LayerSpec>, s:LayerStack) -> LayerStack :
   ; I don't have a way to insert layers in the front
   ;  So I reverse the layers and then append them to the new "back" (front)

--- a/src/layerstack.stanza
+++ b/src/layerstack.stanza
@@ -10,7 +10,7 @@ defpackage jsl/layerstack:
 doc: \<DOC>
 Base class for Defining the Layer Material
 <DOC>
-defstruct LayerMaterial <: Hashable:
+public-when(TESTING) defstruct LayerMaterial <: Hashable & Equalable :
   name:Maybe<String>
   type:MaterialType
   description:Maybe<String>
@@ -30,7 +30,7 @@ defn make-name (x:LayerMaterial):
       (_:None): false
       (v:One<String>): name = value(v)
 
-defn get-type (x:LayerMaterial) -> MaterialType:
+public-when(TESTING) defn get-type (x:LayerMaterial) -> MaterialType:
   type(x)
 
 defn make-description (x:LayerMaterial) :
@@ -214,8 +214,8 @@ public val SoldermaskMaterial = DielectricMaterial(
   is-soldermask = true
 )
 
-public defstruct LayerSpec:
-  name:Maybe<String>
+public defstruct LayerSpec <: Equalable :
+  name:Maybe<String> with: (setter => set-name)
   description:Maybe<String>
   material:LayerMaterial
   thickness:Double with: (
@@ -292,6 +292,29 @@ public defn LayerStack (
   ) -> LayerStack:
   #LayerStack(name, description, to-vector<LayerSpec>(initial-layers))
 
+doc:\<DOC>
+  Get a layer by index
+  Usage: stack[idx]
+<DOC>
+public defn get (stack:LayerStack, idx:Int) -> LayerSpec :
+  layers(stack)[idx]
+
+doc:\<DOC>
+  Usage: stack.copper[idx]
+<DOC>
+public defn dot (stack:LayerStack, name:Symbol) -> Tuple<LayerSpec> :
+  if name == `copper :
+    to-tuple $ for l in layers(stack) filter:
+      material(l) is ConductorMaterial
+  else :
+    throw $ ValueError("dot for field %_ not supported" % [name])
+
+doc:\<DOC>
+  Get a layer by index
+  Usage: stack[idx].name = new-name
+<DOC>
+public defn set-name (stack:LayerStack, idx:Int, new-name:String) :
+  set-name(layers(stack)[idx] One(new-name))
 
 doc: \<DOC>
 Add one or more layers to the top of the board stackup.

--- a/src/layerstack.stanza
+++ b/src/layerstack.stanza
@@ -247,19 +247,37 @@ doc: \<DOC>
 Create a Copper layer
   Usage: Copper(0.3) : specify thickness 
          Copper(0.3, name = "Cu") : specify thickness and name
-         Copper(0.3, AluminumMaterial, name = "Cu") : specify thickness, material and name
-@param thickness thickness of the layer in mm - required argument
-@param material material of the layer - optional positional argument
-@param name name of the layer - optional named argument
+         Copper(0.3, CustomCuMaterial, name = "PWR") : specify thickness, material and name
+@param thickness thickness of the layer in mm
+@param material material of the layer. The default is the generic {@link CopperMaterial} definition.
+@param name name of the layer - by default this is `None()` implying no name.
+@param description Descriptive text for this layer. By default this is `None()` implying no description
 <DOC>
 public defn Copper (thickness:Double, material:ConductorMaterial = CopperMaterial
     -- name:String = ?, description:String = ?) -> LayerSpec :
   #LayerSpec(name, description, material, thickness) 
 
+doc: \<DOC>
+Create a Generic FR4 layer
+  Usage: FR4(1.0) : specify thickness in mm
+         FR4(1.2, name = "core-1") : specify thickness and name
+         FR4(0.3, Isola370, name = "prepreg") : specify thickness, material and name
+@param thickness thickness of the layer in mm
+@param material material of the layer. The default is the generic {@link FR4-Material} definition.
+@param name name of the layer - by default this is `None()` implying no name.
+@param description Descriptive text for this layer. By default this is `None()` implying no description
+<DOC>
 public defn FR4 (thickness:Double, material:DielectricMaterial = FR4-Material
     -- name:String = ?, description:String = ?) -> LayerSpec :
   #LayerSpec(name, description, material, thickness) 
 
+doc: \<DOC>
+Create a Generic Soldermask layer
+@param thickness thickness of the layer in mm
+@param material material of the layer. The default is the generic {@link SoldermaskMaterial} definition.
+@param name name of the layer - by default this is `None()` implying no name.
+@param description Descriptive text for this layer. By default this is `None()` implying no description
+<DOC>
 public defn Soldermask (thickness:Double, material:DielectricMaterial = SoldermaskMaterial
     -- name:String = ?, description:String = ?) -> LayerSpec :
   #LayerSpec(name, description, material, thickness) 
@@ -364,7 +382,7 @@ layer stack.
 that if this value is a collection, then the layers will be added to
 the stack one at a time. For example:
 
-```
+```stanza
 add-bottom( [dielectric, copper], stack)
 ```
 
@@ -401,16 +419,16 @@ layers, and 2 more copper layers. This constructs a symmetric stackup.
 
 @snippet
 
-```
+```stanza
 val stack = LayerStack(name = "6-Layer Symmetric Stackup")
 
-val copper-1mm = Copper(1.0, name = "cu")
+val copper-35um = Copper(0.035, name = "cu")
 val core-FR4 = FR4(1.0, name = "core")
 val prepreg-FR4 = FR4(0.5, name = "prepreg")
 
-add-symmetric(copper-1mm, core-FR4,
-  add-symmetric(copper-1mm, prepreg-FR4,
-    add-symmetric(copper-1mm, core-FR4, stack)
+add-symmetric(copper-35um, core-FR4,
+  add-symmetric(copper-35um, prepreg-FR4,
+    add-symmetric(copper-35um, core-FR4, stack)
   )
 )
 ```
@@ -525,7 +543,7 @@ defn make-name (x:LayerStack) :
         name = value(d)
 
 defn make-description (x:LayerStack) :
-  ; I can't use the `description` string in the pcb-stackup definition
+  ; I can't use the `description` symbol in the pcb-stackup definition
   ;  because the macro overrides it.
   val v? = description(x)
   inside pcb-stackup:

--- a/src/layerstack.stanza
+++ b/src/layerstack.stanza
@@ -286,7 +286,7 @@ public defstruct LayerStack :
   description:Maybe<String>
 
   layers:Vector<LayerSpec> with: (
-    setter => set-layers
+    setter => sub-layers
   )
 with:
   constructor => #LayerStack
@@ -313,18 +313,6 @@ doc:\<DOC>
 <DOC>
 public defn get (stack:LayerStack, idx:Int) -> LayerSpec :
   layers(stack)[idx]
-
-doc:\<DOC>
-  Modify a layer by index
-  Usage: stack[idx] - new-layer
-<DOC>
-public defn set (stack:LayerStack, idx:Int, layer:LayerSpec) -> False :
-  layers(stack)[idx] = layer
-  ;<A>
-  set-layers(stack new-layers) where :
-    val new-layers = to-tuple $ cat-all $
-      [layers(stack)[0 to idx] [layer] layers(stack)[(idx + 1) to false]]
-  ;<A>
 
 doc:\<DOC>
   Get the idx-th conductor layer

--- a/src/layerstack.stanza
+++ b/src/layerstack.stanza
@@ -253,28 +253,16 @@ Create a Copper layer
 @param name name of the layer - optional named argument
 <DOC>
 public defn Copper (thickness:Double, material:ConductorMaterial = CopperMaterial
-    -- name:String = ?) -> LayerSpec :
-  match(name):
-    (name:One) :
-      LayerSpec(name = value(name), thickness = thickness, material = material)
-    (_):
-      LayerSpec(thickness = thickness, material = material)
+    -- name:String = ?, description:String = ?) -> LayerSpec :
+  #LayerSpec(name, description, material, thickness) 
 
 public defn FR4 (thickness:Double, material:DielectricMaterial = FR4-Material
-    -- name:String = ?) -> LayerSpec :
-  match(name):
-    (name:One) :
-      LayerSpec(name = value(name), thickness = thickness, material = material)
-    (_):
-      LayerSpec(thickness = thickness, material = material)
+    -- name:String = ?, description:String = ?) -> LayerSpec :
+  #LayerSpec(name, description, material, thickness) 
 
 public defn Soldermask (thickness:Double, material:DielectricMaterial = SoldermaskMaterial
-    -- name:String = ?) -> LayerSpec :
-  match(name):
-    (name:One) :
-      LayerSpec(name = value(name), thickness = thickness, material = material)
-    (_):
-      LayerSpec(thickness = thickness, material = material)
+    -- name:String = ?, description:String = ?) -> LayerSpec :
+  #LayerSpec(name, description, material, thickness) 
 
 public defn make-layer-statement (x:LayerSpec) :
   val name? = get-name(x)

--- a/src/layerstack.stanza
+++ b/src/layerstack.stanza
@@ -20,6 +20,12 @@ public-when(TESTING) defstruct LayerMaterial <: Hashable & Equalable :
 
 defmulti create-material (x:LayerMaterial) -> JITXDef
 
+defmethod equal? (ma:LayerMaterial, mb:LayerMaterial) :
+  name(ma) == name(mb) and
+  type(ma) == type(mb) and
+  material-def(ma) == material-def(mb)
+
+
 ; I need these accessors because the `name` and `type` tokens
 ;  will get consumed by the macro before they can call the functions.
 
@@ -225,6 +231,11 @@ with:
   constructor => #LayerSpec
   printer => true
 
+defmethod equal? (la:LayerSpec, lb:LayerSpec) :
+  name(la) == name(lb) and
+  material(la) == material(lb) and
+  thickness(la) == thickness(lb)
+
 public defn LayerSpec (
   --
   name:String = ?,
@@ -304,6 +315,24 @@ public defn LayerStack (
   initial-layers:Seqable<LayerSpec> = []
   ) -> LayerStack:
   #LayerStack(name, description, to-vector<LayerSpec>(initial-layers))
+
+defmethod write (o:OutputStream, s:LayerStack) :
+  println(o, "LayerStack: %_" % [value?(name(s))])
+  println(o, "  Layers: %_ copper layers %_ total layers" % [get-conductor-count(s) length(layers(s))])
+  for [idx, l] in enumerate(layers(s)) do:
+    println(o, "    %_ : %_ | %_ | %_" %
+      [idx, value?(name(l)) get-type(material(l)) thickness(l)])
+
+doc:\<DOC>
+  Usage: for [idx, line] in enumerate(lines) do: 
+           println(“Line %: %_” % [idx, line])
+<DOC>
+defn enumerate<?T> (s:Seqable<?T>) -> Seq<[Int, T]> :
+  var i = 0
+  for x in s seq :
+    next where:
+      val next = [i, x]
+      i = i + 1
 
 doc:\<DOC>
   Get a layer by index

--- a/tests/layerstack.stanza
+++ b/tests/layerstack.stanza
@@ -11,13 +11,13 @@ defpackage jsl/tests/layerstack:
 deftest(layerstack) test-basic-symmetric:
   val stack = LayerStack(name = "Carl's Crazy Stack")
 
-  val copper-1oz = Copper("cu", 1.0)
-  val core-FR4 = FR4("core", 1.0)
-  val prepreg-FR4 = FR4("prepreg", 0.5)
+  val copper-1mm = Copper(1.0, name = "cu")
+  val core-FR4 = FR4(1.0, name = "core")
+  val prepreg-FR4 = FR4(0.5, name = "prepreg")
 
-  add-symmetric(copper-1oz, core-FR4,
-    add-symmetric(copper-1oz, prepreg-FR4,
-      add-symmetric(copper-1oz, core-FR4, stack)
+  add-symmetric(copper-1mm, core-FR4,
+    add-symmetric(copper-1mm, prepreg-FR4,
+      add-symmetric(copper-1mm, core-FR4, stack)
     )
   )
 
@@ -46,11 +46,11 @@ deftest(layerstack) test-validate:
 
   val stack = LayerStack(name = "TwoCoppers")
 
-  val copper-1oz = Copper("cu", 1.0)
-  val core-FR4 = FR4("core", 1.0)
+  val copper-1mm = Copper(1.0, name = "cu")
+  val core-FR4 = FR4(1.0, name = "core")
 
-  add-symmetric(copper-1oz, core-FR4, stack)
-  add-top(copper-1oz, stack)
+  add-symmetric(copper-1mm, core-FR4, stack)
+  add-top(copper-1mm, stack)
 
   expect-throw({validate!(stack)})
 
@@ -58,7 +58,7 @@ deftest(layerstack) test-validate:
 
   val stack2 = LayerStack(name = "TwoDielectrics")
 
-  add-symmetric(copper-1oz, core-FR4, stack2)
+  add-symmetric(copper-1mm, core-FR4, stack2)
   add-bottom(core-FR4, stack2)
   add-bottom(core-FR4, stack2)
 
@@ -81,14 +81,13 @@ deftest(layerstack) test-compute-thickness:
 deftest(layerstack) test-get-conductor:
   val stack = LayerStack(name = "6-layer")
 
-  val w = 1.0
-  val copper-1oz = Copper("cu", w, weight? = true)
-  val core-FR4 = FR4("core", 1.0)
-  val prepreg-FR4 = FR4("prepreg", 0.5)
+  val copper-1mm = Copper(1.0, name = "cu")
+  val core-FR4 = FR4(1.0, name = "core")
+  val prepreg-FR4 = FR4(0.5, name = "prepreg")
 
-  add-symmetric(copper-1oz, core-FR4,
-    add-symmetric(copper-1oz, prepreg-FR4,
-      add-symmetric(copper-1oz, core-FR4, stack)
+  add-symmetric(copper-1mm, core-FR4,
+    add-symmetric(copper-1mm, prepreg-FR4,
+      add-symmetric(copper-1mm, core-FR4, stack)
     )
   )
 
@@ -116,10 +115,7 @@ deftest(layerstack) test-get-conductor:
   #EXPECT(name(cu-2) is-not None)
   #EXPECT(value!(name(cu-2)) == "cu")
   #EXPECT(description(cu-2) is None)
-
-  val exp-thick = 0.0348 ; mm
-  #EXPECT(almost-equal?(thickness(cu-2), exp-thick, 0.001))
-
+  #EXPECT(thickness(cu-2) == 1.0)
 
   ; Check the `get-copper` under failure cases:
 
@@ -131,11 +127,10 @@ deftest(layerstack) test-with-soldermask:
 
   val stack = LayerStack(name = "2-layer")
 
-  val w = 2.0
-  val copper-1oz = Copper("cu", w, weight? = true)
-  val core-FR4 = FR4("core", 1.0)
+  val copper-1mm = Copper(2.0, name = "cu")
+  val core-FR4 = FR4(1.0, name = "core")
 
-  add-symmetric(copper-1oz, core-FR4, stack)
+  add-symmetric(copper-1mm, core-FR4, stack)
   add-soldermask(Soldermask(0.025), stack)
 
   validate!(stack)
@@ -171,16 +166,16 @@ My Crazy Stack - each layer is different for testing
  10 - copper-3oz
 ;<note>
 val test-stack = LayerStack(name = "My Crazy Stack")
-val copper-1oz = Copper("cu1", 1.0, weight? = true)
-val copper-2oz = Copper("cu2", 2.0, weight? = true)
-val copper-3oz = Copper("cu3", 3.0, weight? = true)
-val core-FR4-1 = FR4("core1", 1.0)
-val core-FR4-2 = FR4("core2", 2.0)
-val prepreg-FR4 = FR4("prepreg", 0.5)
+val copper-1mm = Copper(1.0, name = "cu1")
+val copper-2mm = Copper(2.0, name = "cu2")
+val copper-3mm = Copper(3.0, name = "cu3")
+val core-FR4-1 = FR4(1.0, name = "core1")
+val core-FR4-2 = FR4(2.0, name = "core2")
+val prepreg-FR4 = FR4(0.5, name = "prepreg")
 
-add-symmetric(copper-3oz, core-FR4-2,
-  add-symmetric(copper-2oz, prepreg-FR4,
-    add-symmetric(copper-1oz, core-FR4-1, test-stack)
+add-symmetric(copper-3mm, core-FR4-2,
+  add-symmetric(copper-2mm, prepreg-FR4,
+    add-symmetric(copper-1mm, core-FR4-1, test-stack)
   )
 )
 validate!(test-stack)
@@ -188,47 +183,55 @@ print("%~" % [test-stack])
 
 ; Test: test-stack[0]
 deftest(layerstack) test-get :
-  #EXPECT(test-stack[0] == copper-3oz)
+  #EXPECT(test-stack[0] == copper-3mm)
   #EXPECT(test-stack[1] == core-FR4-2)
-  #EXPECT(test-stack[2] == copper-2oz)
+  #EXPECT(test-stack[2] == copper-2mm)
   #EXPECT(test-stack[3] == prepreg-FR4)
 
 ; Test: conductors(test-stack)[0]
 deftest(layerstack) test-conductors :
-  #EXPECT(conductors(test-stack)[0] == copper-3oz)
-  #EXPECT(conductors(test-stack)[1] == copper-2oz)
-  #EXPECT(conductors(test-stack)[2] == copper-1oz)
-  #EXPECT(conductors(test-stack)[3] == copper-1oz)
-  #EXPECT(conductors(test-stack)[4] == copper-2oz)
-  #EXPECT(conductors(test-stack)[5] == copper-3oz)
+  #EXPECT(conductors(test-stack)[0] == copper-3mm)
+  #EXPECT(conductors(test-stack)[1] == copper-2mm)
+  #EXPECT(conductors(test-stack)[2] == copper-1mm)
+  #EXPECT(conductors(test-stack)[3] == copper-1mm)
+  #EXPECT(conductors(test-stack)[4] == copper-2mm)
+  #EXPECT(conductors(test-stack)[5] == copper-3mm)
 
 ; Test: set-name(test-stack[0] One("cu3-new"))
 deftest(layerstack) test-set-name :
-  val copper-3oz = Copper("cu3", 3.0, weight? = true)
-  #EXPECT(test-stack[0] == copper-3oz)
-  val copper-3oz-new = Copper("cu3-new", 3.0, weight? = true)
-  set-name(test-stack[0] One("cu3-new"))
+  val copper-3mm = Copper(3.0, name = "cu3")
+  #EXPECT(test-stack[0] == copper-3mm)
+  val copper-3mm-new = Copper(3.0, name = "cu3-new")
+  set-name(test-stack[0] "cu3-new")
   ;Verify that the layer has the new name
-  #EXPECT(test-stack[0] == copper-3oz-new)
+  #EXPECT(test-stack[0] == copper-3mm-new)
 
 ; Test: test-stack[0] = new-stack
 deftest(layerstack) test-set :
-  #EXPECT(test-stack[0] == copper-3oz)
-  test-stack[0] = copper-1oz
-  #EXPECT(test-stack[0] == copper-1oz)
+  #EXPECT(test-stack[0] == copper-3mm)
+  test-stack[0] = copper-1mm
+  #EXPECT(test-stack[0] == copper-1mm)
 
   #EXPECT(test-stack[1] == core-FR4-2)
   test-stack[1] = core-FR4-1
   #EXPECT(test-stack[1] == core-FR4-1)
 
+; Test: 
+;     Copper(0.3) : specify thickness 
+;     Copper(0.3, name = "Cu") : specify thickness and name
+;     Copper(0.3, AluminumMaterial, name = "Cu") : specify thickness, material and name
+deftest(layerstack) test-copper-optional-arguments :
+  val copper-1mm = Copper(1.0)
+  val copper-1mm-explicit = Copper(1.0, CopperMaterial)
+  #EXPECT(copper-1mm == copper-1mm-explicit)
 
-deftest(layerstack) test-thinkness-argument :
-  val copper-1oz-with-weight = Copper("cu", 1.0, weight? = true)
-  val thickness = thickness(copper-1oz-with-weight)
-  val copper-1oz-with-thickness = Copper("cu", thickness)
-  #EXPECT(copper-1oz-with-weight == copper-1oz-with-thickness)
+  val copper-1mm-with-name = Copper(1.0, name = "new-Cu")
+  set-name(copper-1mm "new-Cu")
+  #EXPECT(copper-1mm-with-name == copper-1mm)
   
-  val aluminum-1oz-with-weight = Copper(1.0, AluminumMaterial, weight? = true)
-  val aluminum-thickness = /thickness(aluminum-1oz-with-weight)
-  val aluminum-1oz-with-thickness = Copper(aluminum-thickness, AluminumMaterial)
-  #EXPECT(aluminum-1oz-with-weight == aluminum-1oz-with-thickness)
+  val aluminum-1mm = Copper(1.0, AluminumMaterial)
+  val aluminum-1mm-with-name = Copper(1.0, AluminumMaterial, name = "alum")
+  set-name(aluminum-1mm "alum")
+   #EXPECT(aluminum-1mm-with-name == aluminum-1mm)
+ 
+

--- a/tests/layerstack.stanza
+++ b/tests/layerstack.stanza
@@ -11,13 +11,18 @@ defpackage jsl/tests/layerstack:
 deftest(layerstack) test-basic-symmetric:
   val stack = LayerStack(name = "Carl's Crazy Stack")
 
-  val copper-1mm = Copper(1.0, name = "cu")
-  val core-FR4 = FR4(1.0, name = "core")
-  val prepreg-FR4 = FR4(0.5, name = "prepreg")
+  ;Realistic thickness for testing:
+  ;    weight 0.5oz -> thickness 17.4um = 0.0174mm
+  ;    weight 1oz -> thickness 35um = 0.035mm
+  ;    weight 2oz -> thickness 70um = 0.070mm
+  ;    weight 3oz -> thickness 105um = 0.105mm
+  val copper-35um = Copper(0.035, name = "cu")
+  val core-FR4 = FR4(0.035, name = "core")
+  val prepreg-FR4 = FR4(0.0175, name = "prepreg")
 
-  add-symmetric(copper-1mm, core-FR4,
-    add-symmetric(copper-1mm, prepreg-FR4,
-      add-symmetric(copper-1mm, core-FR4, stack)
+  add-symmetric(copper-35um, core-FR4,
+    add-symmetric(copper-35um, prepreg-FR4,
+      add-symmetric(copper-35um, core-FR4, stack)
     )
   )
 
@@ -46,11 +51,11 @@ deftest(layerstack) test-validate:
 
   val stack = LayerStack(name = "TwoCoppers")
 
-  val copper-1mm = Copper(1.0, name = "cu")
-  val core-FR4 = FR4(1.0, name = "core")
+  val copper-35um = Copper(0.035, name = "cu")
+  val core-FR4 = FR4(0.035, name = "core")
 
-  add-symmetric(copper-1mm, core-FR4, stack)
-  add-top(copper-1mm, stack)
+  add-symmetric(copper-35um, core-FR4, stack)
+  add-top(copper-35um, stack)
 
   expect-throw({validate!(stack)})
 
@@ -58,7 +63,7 @@ deftest(layerstack) test-validate:
 
   val stack2 = LayerStack(name = "TwoDielectrics")
 
-  add-symmetric(copper-1mm, core-FR4, stack2)
+  add-symmetric(copper-35um, core-FR4, stack2)
   add-bottom(core-FR4, stack2)
   add-bottom(core-FR4, stack2)
 
@@ -81,13 +86,13 @@ deftest(layerstack) test-compute-thickness:
 deftest(layerstack) test-get-conductor:
   val stack = LayerStack(name = "6-layer")
 
-  val copper-1mm = Copper(1.0, name = "cu")
-  val core-FR4 = FR4(1.0, name = "core")
-  val prepreg-FR4 = FR4(0.5, name = "prepreg")
+  val copper-35um = Copper(0.035, name = "cu")
+  val core-FR4 = FR4(0.035, name = "core")
+  val prepreg-FR4 = FR4(0.0175, name = "prepreg")
 
-  add-symmetric(copper-1mm, core-FR4,
-    add-symmetric(copper-1mm, prepreg-FR4,
-      add-symmetric(copper-1mm, core-FR4, stack)
+  add-symmetric(copper-35um, core-FR4,
+    add-symmetric(copper-35um, prepreg-FR4,
+      add-symmetric(copper-35um, core-FR4, stack)
     )
   )
 
@@ -105,17 +110,17 @@ deftest(layerstack) test-get-conductor:
   #EXPECT(name(prepreg-2) is-not None)
   #EXPECT(value!(name(prepreg-2)) == "prepreg")
   #EXPECT(description(prepreg-2) is None)
-  #EXPECT(thickness(prepreg-2) == 0.5)
+  #EXPECT(thickness(prepreg-2) == 0.0175)
 
   #EXPECT(name(core-2) is-not None)
   #EXPECT(value!(name(core-2)) == "core")
   #EXPECT(description(core-2) is None)
-  #EXPECT(thickness(core-2) == 1.0)
+  #EXPECT(thickness(core-2) == 0.035)
 
   #EXPECT(name(cu-2) is-not None)
   #EXPECT(value!(name(cu-2)) == "cu")
   #EXPECT(description(cu-2) is None)
-  #EXPECT(thickness(cu-2) == 1.0)
+  #EXPECT(thickness(cu-2) == 0.035)
 
   ; Check the `get-copper` under failure cases:
 
@@ -127,10 +132,10 @@ deftest(layerstack) test-with-soldermask:
 
   val stack = LayerStack(name = "2-layer")
 
-  val copper-1mm = Copper(2.0, name = "cu")
-  val core-FR4 = FR4(1.0, name = "core")
+  val copper-35um = Copper(0.035, name = "cu")
+  val core-FR4 = FR4(0.035, name = "core")
 
-  add-symmetric(copper-1mm, core-FR4, stack)
+  add-symmetric(copper-35um, core-FR4, stack)
   add-soldermask(Soldermask(0.025), stack)
 
   validate!(stack)
@@ -153,29 +158,29 @@ deftest(layerstack) test-with-soldermask:
 ;============================================================================
 ;<note>
 My Crazy Stack - each layer is different for testing
- 0 - copper-3oz
+ 0 - copper-105um
  1 - core-FR4-2
- 2 - copper-2oz
+ 2 - copper-70um
  3 - prepreg-FR4
- 4 - copper-1oz
+ 4 - copper-35um
  5 - core-FR4-1
- 6 - copper-1oz
+ 6 - copper-35um
  7 - prepreg-FR4
- 8 - copper-2oz
+ 8 - copper-70um
  9 - core-FR4-2
- 10 - copper-3oz
+ 10 - copper-105um
 ;<note>
 val test-stack = LayerStack(name = "My Crazy Stack")
-val copper-1mm = Copper(1.0, name = "cu1")
-val copper-2mm = Copper(2.0, name = "cu2")
-val copper-3mm = Copper(3.0, name = "cu3")
-val core-FR4-1 = FR4(1.0, name = "core1")
-val core-FR4-2 = FR4(2.0, name = "core2")
-val prepreg-FR4 = FR4(0.5, name = "prepreg")
+val copper-35um = Copper(0.035, name = "cu1")
+val copper-70um = Copper(0.070, name = "cu2")
+val copper-105um = Copper(0.105, name = "cu3")
+val core-FR4-1 = FR4(0.035, name = "core1")
+val core-FR4-2 = FR4(0.070, name = "core2")
+val prepreg-FR4 = FR4(0.0175, name = "prepreg")
 
-add-symmetric(copper-3mm, core-FR4-2,
-  add-symmetric(copper-2mm, prepreg-FR4,
-    add-symmetric(copper-1mm, core-FR4-1, test-stack)
+add-symmetric(copper-105um, core-FR4-2,
+  add-symmetric(copper-70um, prepreg-FR4,
+    add-symmetric(copper-35um, core-FR4-1, test-stack)
   )
 )
 validate!(test-stack)
@@ -183,45 +188,45 @@ print("%~" % [test-stack])
 
 ; Test: test-stack[0]
 deftest(layerstack) test-get :
-  #EXPECT(test-stack[0] == copper-3mm)
+  #EXPECT(test-stack[0] == copper-105um)
   #EXPECT(test-stack[1] == core-FR4-2)
-  #EXPECT(test-stack[2] == copper-2mm)
+  #EXPECT(test-stack[2] == copper-70um)
   #EXPECT(test-stack[3] == prepreg-FR4)
 
 ; Test: conductors(test-stack)[0]
 deftest(layerstack) test-conductors :
-  #EXPECT(conductors(test-stack)[0] == copper-3mm)
-  #EXPECT(conductors(test-stack)[1] == copper-2mm)
-  #EXPECT(conductors(test-stack)[2] == copper-1mm)
-  #EXPECT(conductors(test-stack)[3] == copper-1mm)
-  #EXPECT(conductors(test-stack)[4] == copper-2mm)
-  #EXPECT(conductors(test-stack)[5] == copper-3mm)
+  #EXPECT(conductors(test-stack)[0] == copper-105um)
+  #EXPECT(conductors(test-stack)[1] == copper-70um)
+  #EXPECT(conductors(test-stack)[2] == copper-35um)
+  #EXPECT(conductors(test-stack)[3] == copper-35um)
+  #EXPECT(conductors(test-stack)[4] == copper-70um)
+  #EXPECT(conductors(test-stack)[5] == copper-105um)
 
 ; Test: set-name(test-stack[0] One("cu3-new"))
 deftest(layerstack) test-set-name :
-  val copper-3mm = Copper(3.0, name = "cu3")
-  #EXPECT(test-stack[0] == copper-3mm)
-  val copper-3mm-new = Copper(3.0, name = "cu3-new")
+  val copper-105um = Copper(0.105, name = "cu3")
+  #EXPECT(test-stack[0] == copper-105um)
+  val copper-105um-new = Copper(0.105, name = "cu3-new")
   set-name(test-stack[0] "cu3-new")
   ;Verify that the layer has the new name
-  #EXPECT(test-stack[0] == copper-3mm-new)
+  #EXPECT(test-stack[0] == copper-105um-new)
 
 ; Test: 
-;     Copper(0.3) : specify thickness 
-;     Copper(0.3, name = "Cu") : specify thickness and name
-;     Copper(0.3, AluminumMaterial, name = "Cu") : specify thickness, material and name
+;     Copper(0.035) : specify thickness 
+;     Copper(0.035, name = "Cu") : specify thickness and name
+;     Copper(0.035, AluminumMaterial, name = "Cu") : specify thickness, material and name
 deftest(layerstack) test-copper-optional-arguments :
-  val copper-1mm = Copper(1.0)
-  val copper-1mm-explicit = Copper(1.0, CopperMaterial)
-  #EXPECT(copper-1mm == copper-1mm-explicit)
+  val copper-35um = Copper(0.035)
+  val copper-35um-explicit = Copper(0.035, CopperMaterial)
+  #EXPECT(copper-35um == copper-35um-explicit)
 
-  val copper-1mm-with-name = Copper(1.0, name = "new-Cu")
-  set-name(copper-1mm "new-Cu")
-  #EXPECT(copper-1mm-with-name == copper-1mm)
+  val copper-35um-with-name = Copper(0.035, name = "new-Cu")
+  set-name(copper-35um "new-Cu")
+  #EXPECT(copper-35um-with-name == copper-35um)
   
-  val aluminum-1mm = Copper(1.0, AluminumMaterial)
-  val aluminum-1mm-with-name = Copper(1.0, AluminumMaterial, name = "alum")
-  set-name(aluminum-1mm "alum")
-   #EXPECT(aluminum-1mm-with-name == aluminum-1mm)
+  val aluminum-35um = Copper(0.035, AluminumMaterial)
+  val aluminum-35um-with-name = Copper(0.035, AluminumMaterial, name = "alum")
+  set-name(aluminum-35um "alum")
+   #EXPECT(aluminum-35um-with-name == aluminum-35um)
  
 

--- a/tests/layerstack.stanza
+++ b/tests/layerstack.stanza
@@ -6,6 +6,7 @@ defpackage jsl/tests/layerstack:
 
   import jsl/layerstack
   import jsl/tests/utils
+  import jsl/errors
 
 deftest(layerstack) test-basic-symmetric:
   val stack = LayerStack(name = "Carl's Crazy Stack")
@@ -154,3 +155,176 @@ deftest(layerstack) test-with-soldermask:
   #EXPECT(sm2? is-not None)
   #EXPECT(core-1? is-not None)
 
+;============================================================================
+;<note>
+LayerStack: Carl's Crazy Stack
+  Layers: 6 copper layers 11 total layers
+    name: cu | Conductor | 0.0347949234160219
+    name: core | Dielectric | 1.0
+    name: cu | Conductor | 0.0347949234160219
+    name: prepreg | Dielectric | 0.5
+    name: cu | Conductor | 0.0347949234160219
+    name: core | Dielectric | 1.0
+    name: cu | Conductor | 0.0347949234160219
+    name: prepreg | Dielectric | 0.5
+    name: cu | Conductor | 0.0347949234160219
+    name: core | Dielectric | 1.0
+    name: cu | Conductor | 0.0347949234160219
+
+add-symmetric : add dielectic on both sides and then copper on both sides
+
+ 0 - copper-3oz
+ 1 - core-FR4-2
+ 2 - copper-2oz
+ 3 - prepreg-FR4
+ 4 - copper-1oz
+ 5 - core-FR4-1
+ 6 - copper-1oz
+ 7 - prepreg-FR4
+ 8 - copper-2oz
+ 9 - core-FR4-2
+ 10 - copper-3oz
+;<note>
+val test-stack = LayerStack(name = "Liang's Crazy Stack")
+val copper-1oz = Copper("cu1", 1.0)
+val copper-2oz = Copper("cu2", 2.0)
+val copper-3oz = Copper("cu3", 3.0)
+val core-FR4-1 = FR4("core1", 1.0)
+val core-FR4-2 = FR4("core2", 2.0)
+val prepreg-FR4 = FR4("prepreg", 0.5)
+
+add-symmetric(copper-3oz, core-FR4-2,
+  add-symmetric(copper-2oz, prepreg-FR4,
+    add-symmetric(copper-1oz, core-FR4-1, test-stack)
+  )
+)
+validate!(test-stack)
+
+;<note>
+  LayerSpec(
+    name = One("cu"), 
+    description = None, 
+    material = ConductorMaterial(
+      name = One("Copper (Cu)"), 
+      type = Conductor,
+      description = None, 
+      material-def = None,
+      density = 0.00877,
+      roughness = One(0.006)), 
+    thickness = 0.0347949234160219)
+  LayerSpec(
+    name = One("core"),
+    description = None,
+    material = DielectricMaterial(
+      name = One("FR4 (Generic)"),
+      type = Dielectric,
+      description = One("Generic FR4 for Ease of Use. For SI - you probably want to define your own"),
+      material-def = None,
+      dielectric-coefficient = One(4.26),
+      loss-tangent = One(0.25),
+      is-soldermask = false),
+    thickness = 1.0)
+;<note>
+defmethod write (o:OutputStream, s:LayerStack) :
+  println(o, "LayerStack: %_" % [value?(name(s))])
+  println(o, "  Layers: %_ copper layers %_ total layers" % [get-conductor-count(s) length(layers(s))])
+  for [idx, l] in enumerate(layers(s)) do:
+    println(o, "    %_ : %_ | %_ | %_" %
+      [idx, value?(name(l)) get-type(material(l)) thickness(l)])
+print("%~" % [test-stack])
+
+doc:\<DOC>
+  Usage: for [idx, line] in enumerate(lines) do: 
+           println(“Line %: %_” % [idx, line])
+<DOC>
+defn enumerate<?T> (s:Seqable<?T>) -> Seq<[Int, T]> :
+  var i = 0
+  for x in s seq :
+    next where:
+      val next = [i, x]
+      i = i + 1
+
+defmethod equal? (la:LayerSpec, lb:LayerSpec) :
+  name(la) == name(lb) and
+  material(la) == material(lb) and
+  thickness(la) == thickness(lb)
+
+defmethod equal? (ma:LayerMaterial, mb:LayerMaterial) :
+  name(ma) == name(mb) and
+  type(ma) == type(mb) and
+  material-def(ma) == material-def(mb)
+
+;<A>
+ 0 - copper-3oz
+ 1 - core-FR4-2
+ 2 - copper-2oz
+ 3 - prepreg-FR4
+ 4 - copper-1oz
+ 5 - core-FR4-1
+ 6 - copper-1oz
+ 7 - prepreg-FR4
+ 8 - copper-2oz
+ 9 - core-FR4-2
+ 10 - copper-3oz
+;<A>
+
+; Test: test-stack[0]
+deftest(layerstack) test-get :
+  #EXPECT(test-stack[0] == copper-3oz)
+  #EXPECT(test-stack[1] == core-FR4-2)
+  #EXPECT(test-stack[2] == copper-2oz)
+  #EXPECT(test-stack[3] == prepreg-FR4)
+
+; Test: test-stack.copper[0]
+deftest(layerstack) test-dot :
+  #EXPECT(test-stack.copper[0] == copper-3oz)
+  #EXPECT(test-stack.copper[1] == copper-2oz)
+  #EXPECT(test-stack.copper[2] == copper-1oz)
+  #EXPECT(test-stack.copper[3] == copper-1oz)
+  #EXPECT(test-stack.copper[4] == copper-2oz)
+  #EXPECT(test-stack.copper[5] == copper-3oz)
+
+; test-stack[0].name = new-name
+; test-stack[0][name] = new-name
+;     defmethod set (this, k:K, v:V) :
+;       put(TableItem<K,V>(key-hash(k), k, v))
+
+; Test: set-name(test-stack[0] One("cu3-new"))
+deftest(layerstack) test-set-name :
+  val copper-3oz = Copper("cu3", 3.0)
+  #EXPECT(test-stack[0] == copper-3oz)
+  val copper-3oz-new = Copper("cu3-new", 3.0)
+  set-name(test-stack[0] One("cu3-new"))
+  #EXPECT(test-stack[0] == copper-3oz-new)
+
+defn set (spec:LayerSpec, field:Symbol, new-name:String) :
+  if field == `name :
+    set-name(spec One(new-name))
+  else :
+    throw(ValueError("No Setter for Field %_" % [field]))
+
+; Test: test-stack[0][`name] = "cu3-new"
+deftest(layerstack) test-set-name2 :
+  val copper-3oz = Copper("cu3", 3.0)
+  #EXPECT(test-stack[0] == copper-3oz)
+  val copper-3oz-new = Copper("cu3-new", 3.0)
+  test-stack[0][`name] = "cu3-new"
+   ;Verify that the layer has the new name
+  #EXPECT(test-stack[0] == copper-3oz-new)
+
+;<A>
+defn dot (spec:LayerSpec, field:Symbol, new-name:String) :
+  if field == `name :
+    set-name(spec One(new-name))
+  else :
+    throw(ValueError("No Setter for Field %_" % [field]))
+
+; Test: test-stack[0].name = "cu3-new"
+deftest(layerstack) test-set-name3 :
+  val copper-3oz = Copper("cu3", 3.0)
+  #EXPECT(test-stack[0] == copper-3oz)
+  val copper-3oz-new = Copper("cu3-new", 3.0)
+  test-stack[0].name = "cu3-new"
+  ;Verify that the layer has the new name
+  #EXPECT(test-stack[0] == copper-3oz-new)
+;<A>

--- a/tests/layerstack.stanza
+++ b/tests/layerstack.stanza
@@ -17,8 +17,8 @@ deftest(layerstack) test-basic-symmetric:
   ;    weight 2oz -> thickness 70um = 0.070mm
   ;    weight 3oz -> thickness 105um = 0.105mm
   val copper-35um = Copper(0.035, name = "cu")
-  val core-FR4 = FR4(0.035, name = "core")
-  val prepreg-FR4 = FR4(0.0175, name = "prepreg")
+  val core-FR4 = FR4(1.0, name = "core")
+  val prepreg-FR4 = FR4(0.5, name = "prepreg")
 
   add-symmetric(copper-35um, core-FR4,
     add-symmetric(copper-35um, prepreg-FR4,
@@ -52,7 +52,7 @@ deftest(layerstack) test-validate:
   val stack = LayerStack(name = "TwoCoppers")
 
   val copper-35um = Copper(0.035, name = "cu")
-  val core-FR4 = FR4(0.035, name = "core")
+  val core-FR4 = FR4(1.5, name = "core")
 
   add-symmetric(copper-35um, core-FR4, stack)
   add-top(copper-35um, stack)
@@ -87,8 +87,8 @@ deftest(layerstack) test-get-conductor:
   val stack = LayerStack(name = "6-layer")
 
   val copper-35um = Copper(0.035, name = "cu")
-  val core-FR4 = FR4(0.035, name = "core")
-  val prepreg-FR4 = FR4(0.0175, name = "prepreg")
+  val core-FR4 = FR4(1.2, name = "core")
+  val prepreg-FR4 = FR4(0.6, name = "prepreg")
 
   add-symmetric(copper-35um, core-FR4,
     add-symmetric(copper-35um, prepreg-FR4,
@@ -110,12 +110,12 @@ deftest(layerstack) test-get-conductor:
   #EXPECT(name(prepreg-2) is-not None)
   #EXPECT(value!(name(prepreg-2)) == "prepreg")
   #EXPECT(description(prepreg-2) is None)
-  #EXPECT(thickness(prepreg-2) == 0.0175)
+  #EXPECT(thickness(prepreg-2) == 0.6)
 
   #EXPECT(name(core-2) is-not None)
   #EXPECT(value!(name(core-2)) == "core")
   #EXPECT(description(core-2) is None)
-  #EXPECT(thickness(core-2) == 0.035)
+  #EXPECT(thickness(core-2) == 1.2)
 
   #EXPECT(name(cu-2) is-not None)
   #EXPECT(value!(name(cu-2)) == "cu")
@@ -133,7 +133,7 @@ deftest(layerstack) test-with-soldermask:
   val stack = LayerStack(name = "2-layer")
 
   val copper-35um = Copper(0.035, name = "cu")
-  val core-FR4 = FR4(0.035, name = "core")
+  val core-FR4 = FR4(1.4, name = "core")
 
   add-symmetric(copper-35um, core-FR4, stack)
   add-soldermask(Soldermask(0.025), stack)
@@ -174,9 +174,9 @@ val test-stack = LayerStack(name = "My Crazy Stack")
 val copper-35um = Copper(0.035, name = "cu1")
 val copper-70um = Copper(0.070, name = "cu2")
 val copper-105um = Copper(0.105, name = "cu3")
-val core-FR4-1 = FR4(0.035, name = "core1")
-val core-FR4-2 = FR4(0.070, name = "core2")
-val prepreg-FR4 = FR4(0.0175, name = "prepreg")
+val core-FR4-1 = FR4(1.0, name = "core1")
+val core-FR4-2 = FR4(1.2, name = "core2")
+val prepreg-FR4 = FR4(0.4, name = "prepreg")
 
 add-symmetric(copper-105um, core-FR4-2,
   add-symmetric(copper-70um, prepreg-FR4,

--- a/tests/layerstack.stanza
+++ b/tests/layerstack.stanza
@@ -206,16 +206,6 @@ deftest(layerstack) test-set-name :
   ;Verify that the layer has the new name
   #EXPECT(test-stack[0] == copper-3mm-new)
 
-; Test: test-stack[0] = new-stack
-deftest(layerstack) test-set :
-  #EXPECT(test-stack[0] == copper-3mm)
-  test-stack[0] = copper-1mm
-  #EXPECT(test-stack[0] == copper-1mm)
-
-  #EXPECT(test-stack[1] == core-FR4-2)
-  test-stack[1] = core-FR4-1
-  #EXPECT(test-stack[1] == core-FR4-1)
-
 ; Test: 
 ;     Copper(0.3) : specify thickness 
 ;     Copper(0.3, name = "Cu") : specify thickness and name

--- a/tests/layerstack.stanza
+++ b/tests/layerstack.stanza
@@ -157,22 +157,7 @@ deftest(layerstack) test-with-soldermask:
 
 ;============================================================================
 ;<note>
-LayerStack: Carl's Crazy Stack
-  Layers: 6 copper layers 11 total layers
-    name: cu | Conductor | 0.0347949234160219
-    name: core | Dielectric | 1.0
-    name: cu | Conductor | 0.0347949234160219
-    name: prepreg | Dielectric | 0.5
-    name: cu | Conductor | 0.0347949234160219
-    name: core | Dielectric | 1.0
-    name: cu | Conductor | 0.0347949234160219
-    name: prepreg | Dielectric | 0.5
-    name: cu | Conductor | 0.0347949234160219
-    name: core | Dielectric | 1.0
-    name: cu | Conductor | 0.0347949234160219
-
-add-symmetric : add dielectic on both sides and then copper on both sides
-
+My Crazy Stack - each layer is different for testing
  0 - copper-3oz
  1 - core-FR4-2
  2 - copper-2oz
@@ -185,7 +170,7 @@ add-symmetric : add dielectic on both sides and then copper on both sides
  9 - core-FR4-2
  10 - copper-3oz
 ;<note>
-val test-stack = LayerStack(name = "Liang's Crazy Stack")
+val test-stack = LayerStack(name = "My Crazy Stack")
 val copper-1oz = Copper("cu1", 1.0)
 val copper-2oz = Copper("cu2", 2.0)
 val copper-3oz = Copper("cu3", 3.0)
@@ -200,31 +185,6 @@ add-symmetric(copper-3oz, core-FR4-2,
 )
 validate!(test-stack)
 
-;<note>
-  LayerSpec(
-    name = One("cu"), 
-    description = None, 
-    material = ConductorMaterial(
-      name = One("Copper (Cu)"), 
-      type = Conductor,
-      description = None, 
-      material-def = None,
-      density = 0.00877,
-      roughness = One(0.006)), 
-    thickness = 0.0347949234160219)
-  LayerSpec(
-    name = One("core"),
-    description = None,
-    material = DielectricMaterial(
-      name = One("FR4 (Generic)"),
-      type = Dielectric,
-      description = One("Generic FR4 for Ease of Use. For SI - you probably want to define your own"),
-      material-def = None,
-      dielectric-coefficient = One(4.26),
-      loss-tangent = One(0.25),
-      is-soldermask = false),
-    thickness = 1.0)
-;<note>
 defmethod write (o:OutputStream, s:LayerStack) :
   println(o, "LayerStack: %_" % [value?(name(s))])
   println(o, "  Layers: %_ copper layers %_ total layers" % [get-conductor-count(s) length(layers(s))])
@@ -254,20 +214,6 @@ defmethod equal? (ma:LayerMaterial, mb:LayerMaterial) :
   type(ma) == type(mb) and
   material-def(ma) == material-def(mb)
 
-;<A>
- 0 - copper-3oz
- 1 - core-FR4-2
- 2 - copper-2oz
- 3 - prepreg-FR4
- 4 - copper-1oz
- 5 - core-FR4-1
- 6 - copper-1oz
- 7 - prepreg-FR4
- 8 - copper-2oz
- 9 - core-FR4-2
- 10 - copper-3oz
-;<A>
-
 ; Test: test-stack[0]
 deftest(layerstack) test-get :
   #EXPECT(test-stack[0] == copper-3oz)
@@ -275,19 +221,14 @@ deftest(layerstack) test-get :
   #EXPECT(test-stack[2] == copper-2oz)
   #EXPECT(test-stack[3] == prepreg-FR4)
 
-; Test: test-stack.copper[0]
-deftest(layerstack) test-dot :
-  #EXPECT(test-stack.copper[0] == copper-3oz)
-  #EXPECT(test-stack.copper[1] == copper-2oz)
-  #EXPECT(test-stack.copper[2] == copper-1oz)
-  #EXPECT(test-stack.copper[3] == copper-1oz)
-  #EXPECT(test-stack.copper[4] == copper-2oz)
-  #EXPECT(test-stack.copper[5] == copper-3oz)
-
-; test-stack[0].name = new-name
-; test-stack[0][name] = new-name
-;     defmethod set (this, k:K, v:V) :
-;       put(TableItem<K,V>(key-hash(k), k, v))
+; Test: conductors(test-stack)[0]
+deftest(layerstack) test-conductors :
+  #EXPECT(conductors(test-stack)[0] == copper-3oz)
+  #EXPECT(conductors(test-stack)[1] == copper-2oz)
+  #EXPECT(conductors(test-stack)[2] == copper-1oz)
+  #EXPECT(conductors(test-stack)[3] == copper-1oz)
+  #EXPECT(conductors(test-stack)[4] == copper-2oz)
+  #EXPECT(conductors(test-stack)[5] == copper-3oz)
 
 ; Test: set-name(test-stack[0] One("cu3-new"))
 deftest(layerstack) test-set-name :
@@ -295,36 +236,27 @@ deftest(layerstack) test-set-name :
   #EXPECT(test-stack[0] == copper-3oz)
   val copper-3oz-new = Copper("cu3-new", 3.0)
   set-name(test-stack[0] One("cu3-new"))
-  #EXPECT(test-stack[0] == copper-3oz-new)
-
-defn set (spec:LayerSpec, field:Symbol, new-name:String) :
-  if field == `name :
-    set-name(spec One(new-name))
-  else :
-    throw(ValueError("No Setter for Field %_" % [field]))
-
-; Test: test-stack[0][`name] = "cu3-new"
-deftest(layerstack) test-set-name2 :
-  val copper-3oz = Copper("cu3", 3.0)
-  #EXPECT(test-stack[0] == copper-3oz)
-  val copper-3oz-new = Copper("cu3-new", 3.0)
-  test-stack[0][`name] = "cu3-new"
-   ;Verify that the layer has the new name
-  #EXPECT(test-stack[0] == copper-3oz-new)
-
-;<A>
-defn dot (spec:LayerSpec, field:Symbol, new-name:String) :
-  if field == `name :
-    set-name(spec One(new-name))
-  else :
-    throw(ValueError("No Setter for Field %_" % [field]))
-
-; Test: test-stack[0].name = "cu3-new"
-deftest(layerstack) test-set-name3 :
-  val copper-3oz = Copper("cu3", 3.0)
-  #EXPECT(test-stack[0] == copper-3oz)
-  val copper-3oz-new = Copper("cu3-new", 3.0)
-  test-stack[0].name = "cu3-new"
   ;Verify that the layer has the new name
   #EXPECT(test-stack[0] == copper-3oz-new)
-;<A>
+
+; Test: test-stack[0] = new-stack
+deftest(layerstack) test-set :
+  #EXPECT(test-stack[0] == copper-3oz)
+  test-stack[0] = copper-1oz
+  #EXPECT(test-stack[0] == copper-1oz)
+
+  #EXPECT(test-stack[1] == core-FR4-2)
+  test-stack[1] = core-FR4-1
+  #EXPECT(test-stack[1] == core-FR4-1)
+
+
+deftest(layerstack) test-thinkness-argument :
+  val copper-1oz-with-weight = Copper("cu", 1.0)
+  val thickness = thickness(copper-1oz-with-weight)
+  val copper-1oz-with-thickness = Copper("cu", thickness, is-thickness? = true)
+  #EXPECT(copper-1oz-with-weight == copper-1oz-with-thickness)
+  
+  val aluminum-1oz-with-weight = Copper("cu", 1.0, AluminumMaterial)
+  val aluminum-thickness = /thickness(aluminum-1oz-with-weight)
+  val aluminum-1oz-with-thickness = Copper("cu", aluminum-thickness, AluminumMaterial, is-thickness? = true)
+  #EXPECT(aluminum-1oz-with-weight == aluminum-1oz-with-thickness)

--- a/tests/layerstack.stanza
+++ b/tests/layerstack.stanza
@@ -82,7 +82,7 @@ deftest(layerstack) test-get-conductor:
   val stack = LayerStack(name = "6-layer")
 
   val w = 1.0
-  val copper-1oz = Copper("cu", w)
+  val copper-1oz = Copper("cu", w, weight? = true)
   val core-FR4 = FR4("core", 1.0)
   val prepreg-FR4 = FR4("prepreg", 0.5)
 
@@ -132,7 +132,7 @@ deftest(layerstack) test-with-soldermask:
   val stack = LayerStack(name = "2-layer")
 
   val w = 2.0
-  val copper-1oz = Copper("cu", w)
+  val copper-1oz = Copper("cu", w, weight? = true)
   val core-FR4 = FR4("core", 1.0)
 
   add-symmetric(copper-1oz, core-FR4, stack)
@@ -171,9 +171,9 @@ My Crazy Stack - each layer is different for testing
  10 - copper-3oz
 ;<note>
 val test-stack = LayerStack(name = "My Crazy Stack")
-val copper-1oz = Copper("cu1", 1.0)
-val copper-2oz = Copper("cu2", 2.0)
-val copper-3oz = Copper("cu3", 3.0)
+val copper-1oz = Copper("cu1", 1.0, weight? = true)
+val copper-2oz = Copper("cu2", 2.0, weight? = true)
+val copper-3oz = Copper("cu3", 3.0, weight? = true)
 val core-FR4-1 = FR4("core1", 1.0)
 val core-FR4-2 = FR4("core2", 2.0)
 val prepreg-FR4 = FR4("prepreg", 0.5)
@@ -232,9 +232,9 @@ deftest(layerstack) test-conductors :
 
 ; Test: set-name(test-stack[0] One("cu3-new"))
 deftest(layerstack) test-set-name :
-  val copper-3oz = Copper("cu3", 3.0)
+  val copper-3oz = Copper("cu3", 3.0, weight? = true)
   #EXPECT(test-stack[0] == copper-3oz)
-  val copper-3oz-new = Copper("cu3-new", 3.0)
+  val copper-3oz-new = Copper("cu3-new", 3.0, weight? = true)
   set-name(test-stack[0] One("cu3-new"))
   ;Verify that the layer has the new name
   #EXPECT(test-stack[0] == copper-3oz-new)
@@ -251,12 +251,12 @@ deftest(layerstack) test-set :
 
 
 deftest(layerstack) test-thinkness-argument :
-  val copper-1oz-with-weight = Copper("cu", 1.0)
+  val copper-1oz-with-weight = Copper("cu", 1.0, weight? = true)
   val thickness = thickness(copper-1oz-with-weight)
-  val copper-1oz-with-thickness = Copper("cu", thickness, is-thickness? = true)
+  val copper-1oz-with-thickness = Copper("cu", thickness)
   #EXPECT(copper-1oz-with-weight == copper-1oz-with-thickness)
   
-  val aluminum-1oz-with-weight = Copper("cu", 1.0, AluminumMaterial)
+  val aluminum-1oz-with-weight = Copper(1.0, AluminumMaterial, weight? = true)
   val aluminum-thickness = /thickness(aluminum-1oz-with-weight)
-  val aluminum-1oz-with-thickness = Copper("cu", aluminum-thickness, AluminumMaterial, is-thickness? = true)
+  val aluminum-1oz-with-thickness = Copper(aluminum-thickness, AluminumMaterial)
   #EXPECT(aluminum-1oz-with-weight == aluminum-1oz-with-thickness)

--- a/tests/layerstack.stanza
+++ b/tests/layerstack.stanza
@@ -184,35 +184,7 @@ add-symmetric(copper-3oz, core-FR4-2,
   )
 )
 validate!(test-stack)
-
-defmethod write (o:OutputStream, s:LayerStack) :
-  println(o, "LayerStack: %_" % [value?(name(s))])
-  println(o, "  Layers: %_ copper layers %_ total layers" % [get-conductor-count(s) length(layers(s))])
-  for [idx, l] in enumerate(layers(s)) do:
-    println(o, "    %_ : %_ | %_ | %_" %
-      [idx, value?(name(l)) get-type(material(l)) thickness(l)])
 print("%~" % [test-stack])
-
-doc:\<DOC>
-  Usage: for [idx, line] in enumerate(lines) do: 
-           println(“Line %: %_” % [idx, line])
-<DOC>
-defn enumerate<?T> (s:Seqable<?T>) -> Seq<[Int, T]> :
-  var i = 0
-  for x in s seq :
-    next where:
-      val next = [i, x]
-      i = i + 1
-
-defmethod equal? (la:LayerSpec, lb:LayerSpec) :
-  name(la) == name(lb) and
-  material(la) == material(lb) and
-  thickness(la) == thickness(lb)
-
-defmethod equal? (ma:LayerMaterial, mb:LayerMaterial) :
-  name(ma) == name(mb) and
-  type(ma) == type(mb) and
-  material-def(ma) == material-def(mb)
 
 ; Test: test-stack[0]
 deftest(layerstack) test-get :


### PR DESCRIPTION
Support access functions for Layerstack:
  - get layer by index function:  `test-stack[0]`
  - get conductor layer by index: `conductors(test-stack)[0]`
  - set-name function: `set-name(test-stack[0] One("cu3-new"))`
  - set function to change a layer by index: `test-stack[0] = new-stack`
  - allow arguments of `Copper()` functions to be either weight or thickness.
  
  I created the ticket PROD-132 for this issue, but forgot to include it in the branch name.