### PR TITLE
[Bugfix] Removed `displays.stanza` but didn't remove from forwards

### DIFF
--- a/src/bundles.stanza
+++ b/src/bundles.stanza
@@ -7,7 +7,6 @@ defpackage jsl/bundles:
   forward jsl/bundles/general
   forward jsl/bundles/debug
   forward jsl/bundles/comms
-  forward jsl/bundles/displays
   forward jsl/bundles/gates
 
 ; Utilities


### PR DESCRIPTION
Fixes bug introduced by #63 

The use of `forward` declarations unfortunately is a bit error prone when developing libraries like this. The unit tests did not detect this for some reason. I'm not sure why.
