### PR TITLE
[Bugfix] Fixed delay constraint on `ctl => clk`

### DIFF
--- a/src/protocols/ethernet/MII/RGMII.stanza
+++ b/src/protocols/ethernet/MII/RGMII.stanza
@@ -149,7 +149,7 @@ public defmethod constrain (cst:RGMII-Constraint, src:JITXObject, dst:JITXObject
     max-loss(loss(cst), clk-route, bus-route, ctl-route)
 
     val data-to-clk = TimingDifferenceConstraint(clk-delay(cst))
-    timing-difference(ctl-route, clk-route) = data-to-clk
+    timing-difference(clk-route, ctl-route) = data-to-clk
 
     val se-50 = route-struct(cst)
     structure(clk-route) = se-50


### PR DESCRIPTION
I had this backwards and it was push a 2.5ns delay on `ctl` instead of on `clk`.