### PR TITLE
Added initial Via Structures Framework

### DIFF
--- a/examples/protocols/common/example-board.stanza
+++ b/examples/protocols/common/example-board.stanza
@@ -95,6 +95,11 @@ This variable defines a shape for a board.
 ; Define the shape/size of the board
 public val board-shape = RoundedRectangle(50.0, 30.0, 0.25)
 
+public val uTop-1 = gen-via(true,  LayerIndex(0,Top), LayerIndex(1,Top), "uTop-1") ; Gnd
+public val uTop-2 = gen-via(true,  LayerIndex(0,Top), LayerIndex(2,Top), "uTop-2") ; Signal
+public val uTop-3 = gen-via(true,  LayerIndex(0,Top), LayerIndex(3,Top) "uTop-3")  ; Gnd
+public val uTop-4 = gen-via(true,  LayerIndex(0,Top), LayerIndex(4,Top) "uTop-4")  ; Signal
+public val default-TH = gen-via(false, LayerIndex(0,Top), LayerIndex(0,Bottom) "th") ; Signal
 doc: \<DOC>
 @brief Simple board definition function
 This function call defines a board by creating a board with shape, stackup and allowable vias.
@@ -104,12 +109,7 @@ public pcb-board an-example-board (outline:Shape) :
   stackup = example-stackup
   boundary = outline
   signal-boundary = outline
-  vias = [gen-via(true,  LayerIndex(0,Top), LayerIndex(1,Top) "uTop-1") ; Gnd
-          gen-via(true,  LayerIndex(0,Top), LayerIndex(2,Top) "uTop-2") ; Signal
-          gen-via(true,  LayerIndex(0,Top), LayerIndex(3,Top) "uTop-3") ; Gnd
-          gen-via(true,  LayerIndex(0,Top), LayerIndex(4,Top) "uTop-4") ; Signal
-          gen-via(false, LayerIndex(0,Top), LayerIndex(0,Bottom) "th") ; Signal
-        ]
+  vias = [ uTop-1, uTop-2, uTop-3, uTop-4, default-TH]
 
 doc: \<DOC>
 @brief Simple board setup function

--- a/examples/via-structures/diff-via-structure.stanza
+++ b/examples/via-structures/diff-via-structure.stanza
@@ -1,0 +1,64 @@
+#use-added-syntax(jitx)
+defpackage jsl/examples/via-structures/diff-via-structures:
+  import core
+  import jitx
+  import jitx/commands
+
+  import jsl/via-structures
+  import jsl/si/helpers
+  import jsl/si/pairs
+  import jsl/si/couplers
+
+  import jsl/examples/protocols/common/example-board
+  import jsl/examples/protocols/common/example-components
+
+
+pcb-module top-level :
+  val diff-via = DifferentialViaStructure(
+    name = "DF-1",
+    via-def = uTop-2,
+    pitch = 0.4
+  )
+
+  val gc = PolarViaGroundCage(
+    via-def = default-TH,
+    count = 12,
+    radius = 0.6,
+    skips = [2, 3, 4, 8, 9, 10]
+  )
+  add-ground-cage(diff-via, gc)
+  add-anti-pad(
+    diff-via,
+    SimpleAntiPad(
+      shape = RoundedRectangle(0.8, 0.4, 0.1),
+      start = LayerIndex(0, Top),
+      end = LayerIndex(1,Top))
+  )
+  add-std-insertion-points(diff-via, 0.3)
+
+  val diff-via-struct = create-via-structure(diff-via)
+  inst vs1 : diff-via-struct
+  inst vs2 : diff-via-struct
+
+  net GND (vs1.COMMON, vs2.COMMON)
+
+  val b-cap = block-cap(100.0e-9)
+  inst tx-bcap : dp-coupler(b-cap)
+
+  topo-pair(vs1.sig-out => tx-bcap => vs2.sig-in)
+  diff-structure(diff(100.0), vs1.sig-out => vs2.sig-in)
+
+
+set-current-design("DF-ViaStructure")
+setup-board()
+; Set the schematic sheet size
+set-paper(ANSI-A)
+
+; Set the top level module (the module to be compile into a schematic and PCB)
+set-main-module(top-level)
+
+; View the results
+view-board()
+
+
+

--- a/examples/via-structures/diff-via-structure.stanza
+++ b/examples/via-structures/diff-via-structure.stanza
@@ -8,7 +8,7 @@ defpackage jsl/examples/via-structures/diff-via-structures:
   import jsl/si/helpers
   import jsl/si/pairs
   import jsl/si/couplers
-
+  import jsl/geometry/NotchedShapes
   import jsl/examples/protocols/common/example-board
   import jsl/examples/protocols/common/example-components
 
@@ -30,7 +30,8 @@ pcb-module top-level :
   add-anti-pad(
     diff-via,
     SimpleAntiPad(
-      shape = RoundedRectangle(0.8, 0.4, 0.1),
+      shape = DoubleNotchedRectangle(width = 0.8, height = 0.4, notch-width = 0.4, notch-height = 0.15)
+      ; shape = RoundedRectangle(0.8, 0.4, 0.1),
       start = LayerIndex(0, Top),
       end = LayerIndex(1,Top))
   )

--- a/examples/via-structures/se-via-structure.stanza
+++ b/examples/via-structures/se-via-structure.stanza
@@ -5,6 +5,7 @@ defpackage jsl/examples/via-structures/se-via-structures:
   import jitx/commands
 
   import jsl/via-structures
+  import jsl/geometry/NotchedShapes
   import jsl/examples/protocols/common/example-board
   import jsl/examples/protocols/common/example-components
 
@@ -25,7 +26,7 @@ pcb-module top-level :
   add-anti-pad(
     se-via,
     SimpleAntiPad(
-      shape = Circle(0.5),
+      shape = DoubleChippedCircle(radius = 0.5, edge-dist = 0.4)
       start = LayerIndex(0, Top),
       end = LayerIndex(1,Top))
   )

--- a/examples/via-structures/se-via-structure.stanza
+++ b/examples/via-structures/se-via-structure.stanza
@@ -1,0 +1,49 @@
+#use-added-syntax(jitx)
+defpackage jsl/examples/via-structures/se-via-structures:
+  import core
+  import jitx
+  import jitx/commands
+
+  import jsl/via-structures
+  import jsl/examples/protocols/common/example-board
+  import jsl/examples/protocols/common/example-components
+
+
+pcb-module top-level :
+  val se-via = SingleViaStructure(
+    name = "SE-1",
+    via-def = uTop-2
+  )
+
+  val gc = PolarViaGroundCage(
+    via-def = default-TH,
+    count = 12,
+    radius = 0.85,
+    skips = [0, 2, 3, 4, 6, 8, 9, 10]
+  )
+  add-ground-cage(se-via, gc)
+  add-anti-pad(
+    se-via,
+    SimpleAntiPad(
+      shape = Circle(0.5),
+      start = LayerIndex(0, Top),
+      end = LayerIndex(1,Top))
+  )
+  add-std-insertion-points(se-via, 0.75)
+
+  inst vs1 : create-via-structure(se-via)
+
+
+set-current-design("SE-ViaStructure")
+setup-board()
+; Set the schematic sheet size
+set-paper(ANSI-A)
+
+; Set the top level module (the module to be compile into a schematic and PCB)
+set-main-module(top-level)
+
+; View the results
+view-board()
+
+
+

--- a/src/geometry/NotchedShapes.stanza
+++ b/src/geometry/NotchedShapes.stanza
@@ -1,0 +1,220 @@
+#use-added-syntax(jitx)
+defpackage jsl/geometry/NotchedShapes:
+  import core
+  import math
+  import jitx
+  import jitx/commands
+
+  import jsl/ensure
+  import jsl/errors
+
+defn compute-anchor-offset (anchor:Anchor, w2:Double, h2:Double -- w2E:Double = (- w2), h2N:Double = (- h2)) -> Pose :
+  val [vt, hr] = components(anchor)
+  val dx = match(hr) :
+    (hr:W) : w2
+    (hr:C) : 0.0
+    (hr:E) : w2E
+  val dy = match(vt) :
+    (vt:S) : h2
+    (vt:C) : 0.0
+    (vt:N) : h2N
+  loc(dx, dy)
+
+doc: \<DOC>
+Construct a Rectangle with a notch of defined shape on the long side.
+
+This function will construct a rectangle with a triangle shaped notched
+cut on the long edge in the +Y half of the plane.
+
+@param width Rectangle Width (X) in mm.
+@param height Rectangle Height (Y) in mm.
+@param notch-width Base of the triangle that will be notched from
+the width of the rectangle. This value must be less than or equal to the
+width of the triangle.
+@param notch-height Height of the triangle that will be notched. This
+value must be strictly less than the height to prevent a non-simple
+polygon or a self-intersection.
+@param anchor Origin of the resulting shape. The default is `C` or
+centered at the origin.
+<DOC>
+public defn NotchedRectangle (
+  --
+  width:Double,
+  height:Double,
+  notch-width:Double,
+  notch-height:Double,
+  anchor:Anchor = C
+  ) -> Shape:
+  ensure-positive!("width", width)
+  ensure-positive!("height", height)
+
+  if notch-width > width:
+    throw $ ValueError("Invalid Notch Width '%_' - Must be less tha or equal to Width: '%_'" % [notch-width, width])
+  if notch-height >= height:
+    throw $ ValueError("Invalid Notch Height '%_' - Must be less than Height: '%_'" % [notch-height, height])
+
+  val w2 = width / 2.0
+  val h2 = height / 2.0
+  val nw2 = notch-width / 2.0
+  val nh = notch-height
+
+  val sh = Polygon([
+    Point(w2, h2),
+    Point(w2, (- h2)),
+    Point((- w2), (- h2)),
+    Point((- w2), h2),
+    ; Start of the Notch
+    Point((- nw2), h2),
+    Point( 0.0, (h2 - nh)),
+    Point(nw2, h2)
+  ])
+  val offset = compute-anchor-offset(anchor, w2, h2)
+  offset * sh
+
+doc: \<DOC>
+Construct a Double Notched Rectangle.
+
+This function is similar to the `NotchedRectangle` but adds
+an additional notch in the -Y half plane as well.
+
+@param width Rectangle Width (X) in mm.
+@param height Rectangle Height (Y) in mm.
+@param notch-width Base of the triangle that will be notched from
+the width of the rectangle. This value must be less than or equal to the
+width of the triangle.
+@param notch-height Height of the triangle that will be notched. This
+value must be strictly less than the height to prevent a non-simple
+polygon or a self-intersection.
+@param anchor Origin of the resulting shape. The default is `C` or
+centered at the origin.
+<DOC>
+public defn DoubleNotchedRectangle (
+  --
+  width:Double,
+  height:Double,
+  notch-width:Double,
+  notch-height:Double,
+  anchor:Anchor = C
+  ) -> Shape:
+  ensure-positive!("width", width)
+  ensure-positive!("height", height)
+
+  if notch-width > width:
+    throw $ ValueError("Invalid Notch Width '%_' - Must be less tha or equal to Width: '%_'" % [notch-width, width])
+  if notch-height >= (height / 2.0):
+    throw $ ValueError("Invalid Notch Height '%_' - Must be less than Height / 2.0: '%_'" % [notch-height, height / 2.0])
+
+  val w2 = width / 2.0
+  val h2 = height / 2.0
+  val nw2 = notch-width / 2.0
+  val nh = notch-height
+
+  val sh = Polygon([
+    ; Right Side
+    Point(w2, h2),
+    Point(w2, (- h2)),
+    ; Start Bottom Notch
+    Point(nw2, (- h2)),
+    Point( 0.0, (- (h2 - nh))),
+    Point((- nw2), (- h2)),
+    ; Left Side
+    Point((- w2), (- h2)),
+    Point((- w2), h2),
+    ; Start of Top Notch
+    Point((- nw2), h2),
+    Point( 0.0, (h2 - nh)),
+    Point(nw2, h2)
+  ])
+  val offset = compute-anchor-offset(anchor, w2, h2)
+  offset * sh
+
+doc: \<DOC>
+Construct a chipped circle shape.
+
+A chipped circle is a circle with a chord drawn across one side
+and the [circular segment](https://en.wikipedia.org/wiki/Circular_segment)
+removed from the circle. The remaining circle has one straight edge and
+contains the origin.
+
+The current implementation construct a circle that has this straight
+edge aligned with the X axis and in the +Y half of the plane.
+
+@param radius Radial dimension of the originating circle in mm.
+@param edge-dist Distance from the center of the circle to the chord
+in the radial direction in mm.
+@param anchor Where the origin of this resulting shape will be.
+By default this value is `C` indicating the origin is the center
+of the circle.
+
+<DOC>
+public defn ChippedCircle (
+  --
+  radius:Double
+  edge-dist:Double,
+  anchor:Anchor = C
+  ) -> Shape:
+
+  ensure-positive!("radius", radius)
+  ensure-positive!("edge-dist", edge-dist)
+
+  if edge-dist >= radius:
+    throw $ ValueError("Invalid Edge Distance - Must be less than radius")
+
+  val start-angle = acos(edge-dist / radius)
+  val total-angle = 2.0 * PI - (2.0 * start-angle)
+  val start-y = radius * sin(start-angle)
+
+  val sh = PolygonWithArcs([
+    Arc(Point(0.0, 0.0), radius, to-degrees(start-angle), to-degrees(total-angle)),
+    Point(edge-dist, start-y)
+  ])
+
+  val offset = compute-anchor-offset(anchor, radius, radius, h2N = (- (edge-dist)))
+  offset * loc(0.0, 0.0, 90.0) * sh
+
+doc: \<DOC>
+Construct a double chipped circle shape.
+
+A chipped circle is a circle with a chord drawn across one side
+and the [circular segment](https://en.wikipedia.org/wiki/Circular_segment)
+removed from the circle. The remaining circle has one straight edge and
+contains the origin.
+
+A double chipped circle has this circular segment clipped off two edges. The
+current implementation construct a circle that has two straight
+edges aligned with the X axis and in the +Y and -Y halves of the plane.
+
+@param radius Radial dimension of the originating circle in mm.
+@param edge-dist Distance from the center of the circle to the chord
+in the radial direction in mm.
+@param anchor Where the origin of this resulting shape will be.
+By default this value is `C` indicating the origin is the center
+of the circle.
+
+<DOC>
+  public defn DoubleChippedCircle (
+    --
+    radius:Double
+    edge-dist:Double,
+    anchor:Anchor = C
+    ) -> Shape:
+
+    ensure-positive!("radius", radius)
+    ensure-positive!("edge-dist", edge-dist)
+
+    if edge-dist >= radius:
+      throw $ ValueError("Invalid Edge Distance - Must be less than radius")
+
+    val start-angle = acos(edge-dist / radius)
+    val total-angle = PI - (2.0 * start-angle)
+    val start-y = radius * sin(start-angle)
+
+    val sh = PolygonWithArcs([
+      Arc(Point(0.0, 0.0), radius, to-degrees(start-angle), to-degrees(total-angle)),
+      Point((- edge-dist), (- start-y)),
+      Arc(Point(0.0, 0.0), radius, to-degrees(PI + start-angle), to-degrees(total-angle)),
+      Point(edge-dist, start-y)
+    ])
+
+    val offset = compute-anchor-offset(anchor, radius, edge-dist)
+    offset * loc(0.0, 0.0, 90.0) * sh

--- a/src/via-structures.stanza
+++ b/src/via-structures.stanza
@@ -146,7 +146,7 @@ defmethod make-ground-cage (v:PolarViaGroundCage, n:JITXObject -- pose:Pose) -> 
     geom(n):
       for i in valid-pos do:
         val pos = pose * compute-pos(v, i)
-        via(via-def(v)) at apply(pos, Point(0.0, 0.0))
+        via(via-def(v)) at pos * Point(0.0, 0.0)
 
     if debug-mode:
       for i in 0 to count(v) do:
@@ -225,7 +225,7 @@ defmethod make-anti-pad (a:SimpleAntiPad -- pose:Pose) -> False:
   val st = start(a)
   val ed = end(a)
   val s = side(st)
-  ; The ordering can be kind of funny when user pass the layer
+  ; The ordering can be kind of funny when user passes the start/end layers
   ;  especially when we consider the `Bottom`. We use a `min/max` style
   ;  so that we cover all the layers but don't have to be too particular
   ;  about how the user specs the order.
@@ -455,7 +455,7 @@ defmethod make-via-structure (v:SingleViaStructure -- pose:Pose = DEF_VS_LOC) ->
       make-ground-cage(cv, cage, pose = pose)
 
     geom(via-net):
-      via(via-def(v)) at apply(pose, Point(0.0, 0.0))
+      via(via-def(v)) at pose * Point(0.0, 0.0)
 
     make-anti-pads(v, pose = pose)
     make-insertion-points(v, pose = pose)
@@ -589,10 +589,10 @@ defmethod make-via-structure (v:DifferentialViaStructure -- pose:Pose = DEF_VS_L
       (obj2:[Via, Via]): obj2
 
     geom(via-net-P):
-      via(vd-P) at apply(pose, Point(vp, 0.0))
+      via(vd-P) at pose * Point(vp, 0.0)
 
     geom(via-net-N):
-      via(vd-N) at apply(pose, Point((- vp), 0.0))
+      via(vd-N) at pose * Point((- vp), 0.0)
 
     make-anti-pads(v, pose = pose)
     make-insertion-points(v, pose = pose)

--- a/src/via-structures.stanza
+++ b/src/via-structures.stanza
@@ -1,0 +1,617 @@
+#use-added-syntax(jitx)
+defpackage jsl/via-structures:
+  import core
+  import math
+  import collections
+  import jitx
+  import jitx/commands
+
+  import jsl/errors
+  import jsl/ensure
+  import jsl/bundles
+  import jsl/symbols/arrows
+
+var debug-mode = false
+val debug-layer = CustomLayer("vs-debug", Top)
+
+doc: \<DOC>
+Enable or Disable debug mode for Via Structures
+@param x true = enable, false = disable
+<DOC>
+public defn set-via-structure-debug-mode (x:True|False) -> False :
+  debug-mode = x
+
+doc: \<DOC>
+Query the state of debug mode for via structures.
+<DOC>
+public defn is-via-structure-debug-mode? () -> True|False :
+  debug-mode
+
+
+doc: \<DOC>
+Via Ground Cage Interface
+
+The Via Ground Cage is the return signal path for the signal
+going through the central via. This type provides the method for
+defining different configurations of this ground cage.
+<DOC>
+public deftype ViaGroundCage
+public defmulti via-def (v:ViaGroundCage) -> Via
+doc: \<DOC>
+Generator for the Ground Cage
+
+This function must be called from within a `pcb-module` context.
+
+This function will generate the necessary vias that surround the central
+vias of the via structure.
+
+@param v This object
+@param n A `net` object for which a `geom` statement will be constructed.
+@param pose Offset in the module's coordinate frame at which to place the vias.
+Typically this is `loc(0.0, 0.0)` indicating no offset.
+<DOC>
+public defmulti make-ground-cage (v:ViaGroundCage, n:JITXObject -- pose:Pose) -> False
+
+
+doc: \<DOC>
+Polar Via Ground Cage
+
+This an implementation of the `ViaGroundCage` that places
+vias in polar space at a particular radius around the signal
+vias at the center of the via structure.
+
+TODO - Diagram Here
+
+Vias start at index 0 which is placed at (radius, 0.0). Vias 1 to `N-1` are
+then place in a counter-clock wise pattern at `radius` from the origin in increments
+of `2 * PI / count` radians.
+
+The `theta` parameter can provide an initial angle offset in degrees. A positive value
+advances the angle such that Via 0 starts at (radius, theta * PI / 180.0)
+
+The `skips` argument provides a means of depopulating particular via indices depending
+on what structure the user wants to build. This collection will contain 0 or more
+zero-based indices for via locations.
+
+<DOC>
+public defstruct PolarViaGroundCage <: ViaGroundCage :
+  doc: \<DOC>
+  Via Definition to use for all of the via placements.
+  <DOC>
+  via-def:Via with:
+    as-method => true
+  doc: \<DOC>
+  Total number of via placements. Must be positive.
+  <DOC>
+  count:Int with:
+    ensure => ensure-positive!
+  doc: \<DOC>
+  Radius in mm for the circular pattern of via placements. Must be positive.
+  <DOC>
+  radius:Double with:
+    ensure => ensure-positive!
+  doc: \<DOC>
+  Starting angle for the pattern. Value in degrees.
+  <DOC>
+  theta:Double with:
+    default => 0.0
+  doc: \<DOC>
+  Skipped indices in the via pattern. Each value in this collection
+  must be in the range `[0, count-1]`
+  <DOC>
+  skips:Collection<Int> with:
+    default => []
+with:
+  constructor => #PolarViaGroundCage
+  printer => true
+
+doc: \<DOC>
+Polar Via Ground Cage Constructor
+
+@param via-def Via to use for all via placements
+@param count Number of via placements
+@param radius Radius in mm of the via placement arc.
+@param theta-deg Initial angle in degrees. Default value is 0.0
+@param skips Collection of via placement indicies to skip. Default value is `[]`
+which implies no placements are skipped.
+<DOC>
+public defn PolarViaGroundCage (
+  --
+  via-def:Via,
+  count:Int,
+  radius:Double,
+  theta-deg:Double = 0.0,
+  skips:Collection<Int> = []
+  ) -> PolarViaGroundCage :
+  ensure-positive!("count", count)
+  ensure-positive!("radius", radius)
+
+  for (skip in skips, i in 0 to false) do:
+    if not (skip < count):
+      throw $ InvalidSkipIndexError("Skip[%_]: %_ < %_" % [i, skip, count])
+
+  #PolarViaGroundCage(via-def, count, radius, theta-deg, skips)
+
+defn compute-pos (v:PolarViaGroundCage, N:Int) -> Pose :
+  val phase = (2.0 * PI * to-double(N) / to-double(count(v))) + to-radians(theta(v))
+  val r = radius(v)
+  loc(r * cos(phase), r * sin(phase))
+
+defmethod make-ground-cage (v:PolarViaGroundCage, n:JITXObject -- pose:Pose) -> False:
+
+  val valid-pos = for i in 0 to count(v) filter:
+    not contains?(skips(v), i)
+
+  inside pcb-module:
+    geom(n):
+      for i in valid-pos do:
+        val pos = pose * compute-pos(v, i)
+        via(via-def(v)) at apply(pos, Point(0.0, 0.0))
+
+    if debug-mode:
+      for i in 0 to count(v) do:
+        val pos = pose * compute-pos(v, i)
+        layer(debug-layer) = pos * Circle(0.1)
+
+
+doc: \<DOC>
+AntiPad Definition Interface
+
+An anti-pad is a `ForbidCopper` region in the via structure to
+prevent the ground plane or other nets from interfering with the
+signal characteristics of the via structure.
+<DOC>
+public deftype AntiPad
+doc: \<DOC>
+Generator for an AntiPad Definition
+
+This function will construct the `layer()` statements for the
+forbid copper (keepout) regions of the via structure.
+@param a this AntiPad
+@param pose Offset in the module's coordinate frame. This value
+is typically `loc(0.0, 0.0)`.
+<DOC>
+public defmulti make-anti-pad (a:AntiPad -- pose:Pose) -> False
+
+
+doc: \<DOC>
+Simple Anti-Pad Definition
+
+This type implements the `AntiPad` interface and provides a
+simple shape based antipad on one or more layers.
+
+Note:
+The user is required to provide `start` and `end` that
+are specified from the same side (ie, Top or Bottom).
+
+Mixing sides is not allowed. So `start` as `LayerIndex(0, Top)` and
+`end` as `LayerIndex(0, Bottom)` would be an invalid combination will
+throw an exception.
+
+The `start` and `end` layers are inclusive - so the specified shape
+will be applied on all layers `start` through `end`. This type
+doesn't really care about order because we just apply the same shape for
+all of the layers.
+<DOC>
+public defstruct SimpleAntiPad <: AntiPad :
+  doc: \<DOC>
+  Shape of the constructed anti-pad region. This shape is applied
+  to all of the layer `start` through `end`
+  <DOC>
+  shape:Shape
+  start:LayerIndex
+  end:LayerIndex
+with:
+  constructor => #SimpleAntiPad
+  printer => true
+
+doc: \<DOC>
+Simple AntiPad Constructor
+
+@param shape Forbid Region Shape for all applicable layers
+@param start
+<DOC>
+public defn SimpleAntiPad (
+  --
+  shape:Shape,
+  start:LayerIndex,
+  end:LayerIndex
+  ) -> SimpleAntiPad:
+  if side(start) != side(end):
+    throw $ InvalidLayerIndicesError("Start and End Sides Do Not Match: start=%_ end=%_" % [side(start), side(end)])
+  #SimpleAntiPad(shape, start, end)
+
+defmethod make-anti-pad (a:SimpleAntiPad -- pose:Pose) -> False:
+  val st = start(a)
+  val ed = end(a)
+  val s = side(st)
+  ; The ordering can be kind of funny when user pass the layer
+  ;  especially when we consider the `Bottom`. We use a `min/max` style
+  ;  so that we cover all the layers but don't have to be too particular
+  ;  about how the user specs the order.
+  val st-ind = min(index(st), index(ed))
+  val ed-ind = max(index(st), index(ed))
+  inside pcb-module:
+    for i in st-ind through ed-ind do:
+      layer(ForbidCopper(LayerIndex(i, s))) = pose * shape(a)
+
+doc: \<DOC>
+Via Signal Identifier Enum
+
+This type distinguishes between single-ended and differential
+via structures.
+<DOC>
+public defenum ViaSignalType:
+  Via-Single-Ended
+  Via-Differential
+
+doc: \<DOC>
+Via Structure Definition Interface
+
+This type defines the common interfaces for defining
+a Via Structure Generator.
+<DOC>
+public deftype ViaStructureDef
+public defmulti name (v:ViaStructureDef) -> String
+public defmulti signal-type (v:ViaStructureDef) -> ViaSignalType
+
+public defmulti ground-cages (v:ViaStructureDef) -> Vector<ViaGroundCage>
+public defmulti anti-pads (v:ViaStructureDef) -> Vector<AntiPad>
+public defmulti insertion-points (v:ViaStructureDef) -> Vector<Pose>
+
+public defmulti add-ground-cage (v:ViaStructureDef, cage:ViaGroundCage) -> False
+public defmulti add-anti-pad (v:ViaStructureDef, a:AntiPad) -> False
+public defmulti add-insertion-point (v:ViaStructureDef, a:Pose) -> False
+
+public defmulti make-insertion-points (v:ViaStructureDef -- pose:Pose) -> False
+public defmulti make-anti-pads (v:ViaStructureDef -- pose:Pose) -> False
+
+doc: \<DOC>
+Create the shape placed at each insertion point.
+
+This shape will generally be placed in the custom fab layers
+as an indicator of where control points and insertion points
+are expected to be place.
+
+This function creates a shape that consists of an arrow pointing
+in the positive Y direction starting from the origin at 0,0.
+It also constructs an arc around the origin at `radius`.
+
+TODO - Diagram
+<DOC>
+public defn create-insertion-point-shape (radius:Double = 0.2) -> Shape:
+  val ap = ArrowSymbolParams()
+  val arrow = construct-arrow(ap)
+  Union([
+    Polyline(0.05, [Arc(Point(0.0, 0.0), radius, 115.0, 310.0)])
+    loc(0.0, shaft-length(ap), -90.0) * arrow
+  ])
+
+val INSERT-LAYER = Silkscreen("insert-pts", Top)
+; Custom Layers aren't showing right now in the layer stack.
+; val INSERT-LAYER = CustomLayer("insert-pts", Top)
+
+doc: \<DOC>
+Default Implementation of the Insertion Point Generator Functions
+
+This function is expected to be called from a `pcb-module` context.
+
+This function creates `layer` statements for each of the insertion points
+
+@param v This Via Structure
+@param pose Offset from the module's coordinate frame origin. Typically,
+this will be `loc(0.0, 0.0)`
+<DOC>
+defmethod make-insertion-points (v:ViaStructureDef -- pose:Pose) -> False:
+  val shape = create-insertion-point-shape()
+  inside pcb-module:
+    for pt in insertion-points(v) do:
+      layer(INSERT-LAYER) = pose * pt * shape
+
+doc: \<DOC>
+Default Implementation of the anti-pad generator functions
+
+This function is expected to be called from a `pcb-module` context.
+
+This function creates `layer` statements for each of the `AntiPad`
+instances.
+
+@param v This Via Structure
+@param pose Offset from the module's coordinate frame origin. Typically,
+this will be `loc(0.0, 0.0)`
+<DOC>
+defmethod make-anti-pads (v:ViaStructureDef -- pose:Pose) -> False:
+  inside pcb-module:
+    for ap in anti-pads(v) do:
+      make-anti-pad(ap, pose = pose)
+
+public defmulti make-via-structure (v:ViaStructureDef -- pose:Pose = ?) -> False
+public defmulti create-via-structure (v:ViaStructureDef -- pose:Pose = ?) -> Instantiable
+
+defmethod create-via-structure (v:ViaStructureDef -- pose:Pose = DEF_VS_LOC) -> Instantiable:
+  pcb-module generated-via-structure:
+    name = name(v)
+    make-via-structure(v, pose = pose)
+
+  generated-via-structure
+
+
+doc: \<DOC>
+Helper Method for all ViaStructureDef implementations
+<DOC>
+defmethod add-ground-cage (v:ViaStructureDef, cage:ViaGroundCage) -> False:
+  add(ground-cages(v), cage)
+
+doc: \<DOC>
+Helper Method for all ViaStructureDef implementations
+<DOC>
+defmethod add-anti-pad (v:ViaStructureDef, a:AntiPad) -> False:
+  add(anti-pads(v), a)
+
+doc: \<DOC>
+Helper Method for all ViaStructureDef implementations
+<DOC>
+defmethod add-insertion-point (v:ViaStructureDef, p:Pose) -> False:
+  add(insertion-points(v), p)
+
+doc: \<DOC>
+Add two insertion points, at (0.0, +R) pointed UP and (0.0, -R) pointed DOWN
+<DOC>
+public defn add-std-insertion-points (v:ViaStructureDef, radius:Double) -> False:
+  add(insertion-points(v), loc(0.0, radius))
+  add(insertion-points(v), loc(0.0, 0.0, 180.0) * loc(0.0, radius))
+
+doc: \<DOC>
+Single-Ended Via Structure Definition
+
+This type is used to create a single-ended via structure
+generator.
+<DOC>
+public defstruct SingleViaStructure <: ViaStructureDef :
+  name:String with:
+    as-method => true
+  via-def:Via
+  ground-cages:Vector<ViaGroundCage> with:
+    default => Vector<ViaGroundCage>()
+    as-method => true
+  anti-pads:Vector<AntiPad> with:
+    default => Vector<AntiPad>()
+    as-method => true
+  insertion-points:Vector<Pose> with:
+    default => Vector<Pose>()
+    as-method => true
+  signal-type:ViaSignalType with:
+    as-method => true
+    default => Via-Single-Ended
+with:
+  constructor => #SingleViaStructure
+  printer => true
+
+doc: \<DOC>
+Constructor for Single-Ended Via Structure Definitions
+
+@param name Unique name for this via structure
+@param via-def Via definition used for the signal via
+@param ground-cages Optional explicit collection of ground cages. Default is `[]`.
+User can use the {@link add-ground-cage} function to add ground cages after creation.
+@param anti-pads Optional explicit collection of anti-pads. Default is `[]`.
+User can use the {@link add-anti-pad} function to add anti-pads after creation.
+@param insertion-points Optional explicit collection of insertion-points. Default is `[]`.
+User can use the {@link add-insertion-point} function to add insertion points after creation.
+<DOC>
+public defn SingleViaStructure (
+    --
+    name:String,
+    via-def:Via,
+    ground-cages:Collection<ViaGroundCage> = [],
+    anti-pads:Collection<AntiPad> = [],
+    insertion-points:Collection<Pose> = []
+  ) -> SingleViaStructure:
+
+  #SingleViaStructure(
+    name,
+    via-def,
+    to-vector<ViaGroundCage>(ground-cages),
+    to-vector<AntiPad>(anti-pads),
+    to-vector<Pose>(insertion-points)
+  )
+
+val DEF_VS_LOC = loc(0.0, 0.0)
+
+doc: \<DOC>
+Generator to construct statements for a Single-Ended Via Structure
+
+This function will construct the ports, nets, topology segments, etc
+for a functional via structure.
+
+1.  Creates two ports, `sig-in` and `sig-out` for the explicit signal via connections.
+2.  Createa a `COMMON` pin for the ground connection of the cage vias.
+3.  Constructs a `pass-through` support for working with Pin Assignment.
+4.  Constructs the ground cage vias via the {@link make-ground-cage} method.
+5.  Constructs the signal via with a `geom` statement.
+6.  Constructs the anti-pad and insertion point artwork.
+
+@param v This Via Structure
+@param pose Optional offset from the module's coordinate frame. The default value
+is `loc(0.0, 0.0)`
+<DOC>
+defmethod make-via-structure (v:SingleViaStructure -- pose:Pose = DEF_VS_LOC) -> False:
+  inside pcb-module:
+    port sig-in : pin
+    port sig-out : pin
+
+    port COMMON : pin
+
+    net cage (COMMON)
+
+    net via-net (sig-in, sig-out)
+    topology-segment(sig-in, sig-out)
+
+    supports pass-through:
+      pass-through.A => sig-in
+      pass-through.B => sig-out
+
+    for cv in ground-cages(v) do:
+      make-ground-cage(cv, cage, pose = pose)
+
+    geom(via-net):
+      via(via-def(v)) at apply(pose, Point(0.0, 0.0))
+
+    make-anti-pads(v, pose = pose)
+    make-insertion-points(v, pose = pose)
+
+
+doc: \<DOC>
+Differential Via Structure Definition Type
+
+This type is used to encoded the necessary information and then produce
+a via structure definition in the form of a `pcb-module`.
+
+This definition utilizes the `diff-pair` bundle as the interface
+for the signals and then constructs the appropriate via definitions
+with that interface in mind. This will allow the constructed
+via structure module to work with {@link /jsl/si/pairs/topo-pairs} as well
+as other SI helper functions.
+
+TODO - Diagram Here
+
+The differential via structure is constructed by default such that the
+P/N signal vias are centered across the Y axis at `X = pitch/2` and `X = -pitch/2`.
+It is expected that the insertion points would likely be placed in the +Y or -Y
+locations centered across the X axis.
+
+<DOC>
+defstruct DifferentialViaStructure <: ViaStructureDef :
+  name:String with:
+    as-method => true
+  via-def:Via|[Via, Via]
+  pitch:Double with:
+    ensure => ensure-positive!
+  ground-cages:Vector<ViaGroundCage> with:
+    default => Vector<ViaGroundCage>()
+    as-method => true
+  anti-pads:Vector<AntiPad> with:
+    default => Vector<AntiPad>()
+    as-method => true
+  insertion-points:Vector<Pose> with:
+    default => Vector<Pose>()
+    as-method => true
+  signal-type:ViaSignalType with:
+    as-method => true
+    default => Via-Differential
+
+with:
+  constructor => #DifferentialViaStructure
+  printer => true
+
+doc: \<DOC>
+Constructor for the Differential Pair Via Structure
+
+@param name Unique name for this via structure module definition
+@param via-def Defines what vias will be used for the P/N signals.
+If this parameter is a single `Via` definition, then that definition
+will be used for both the `P` and the `N` signals. If a `[Via, Via]`
+argument is provided, then the first `Via` is for the `P` signal and
+the second `Via` is for the `N` signal.
+@param pitch Distance between the P / N signal vias.
+@param ground-cages Optional explicit collection of ground cages. Default is `[]`.
+User can use the {@link add-ground-cage} function to add ground cages after creation.
+@param anti-pads Optional explicit collection of anti-pads. Default is `[]`.
+User can use the {@link add-anti-pad} function to add anti-pads after creation.
+@param insertion-points Optional explicit collection of insertion-points. Default is `[]`.
+User can use the {@link add-insertion-point} function to add insertion points after creation.
+<DOC>
+public defn DifferentialViaStructure (
+  --
+  name:String,
+  via-def:Via|[Via, Via],
+  pitch:Double,
+  ground-cages:Collection<ViaGroundCage> = [],
+  anti-pads:Collection<AntiPad> = [],
+  insertion-points:Collection<Pose> = []
+  ) -> DifferentialViaStructure:
+
+  #DifferentialViaStructure(
+    name,
+    via-def,
+    pitch,
+    to-vector<ViaGroundCage>(ground-cages),
+    to-vector<AntiPad>(anti-pads),
+    to-vector<Pose>(insertion-points)
+  )
+
+doc: \<DOC>
+Generator for constructing the differential pair via structure.
+
+This function expects to be called from within a `pcb-module` context.
+
+This function will create the ports, nets, topology segments, etc that make
+this a usable structure in a design.
+
+This function will create:
+
+1.  The `sig-in` and `sig-out` explicit `diff-pair` ports for input and output signals
+2.  A `COMMON` pin for the ground reference of the cage vias.
+3.  Net and Topology Segments for the `sig-in` and `sig-out` ports
+4.  A `dual-pair` supports statement so that these modules can work with other SI helpers
+like {@link /jsl/si/pairs/topo-pair}
+5.  Ground Cage Vias
+6.  The signal vias for the P/N signals
+7.  AntiPad and Insertion Point artwork.
+<DOC>
+defmethod make-via-structure (v:DifferentialViaStructure -- pose:Pose = DEF_VS_LOC) -> False:
+  inside pcb-module:
+    port sig-in : diff-pair
+    port sig-out : diff-pair
+
+    port COMMON : pin
+
+    net via-net-P (sig-in.P, sig-out.P)
+    topology-segment(sig-in.P, sig-out.P)
+    net via-net-N (sig-in.N, sig-out.N)
+    topology-segment(sig-in.N, sig-out.N)
+
+    net cage (COMMON)
+
+    supports dual-pair:
+      dual-pair.A.P => sig-in.P
+      dual-pair.A.N => sig-in.N
+      dual-pair.B.P => sig-out.P
+      dual-pair.B.N => sig-out.N
+
+    for cv in ground-cages(v) do:
+      make-ground-cage(cv, cage, pose = pose)
+
+    val vp = pitch(v) / 2.0
+
+    val [vd-P, vd-N] = match(via-def(v)):
+      (obj1:Via): [obj1, obj1]
+      (obj2:[Via, Via]): obj2
+
+    geom(via-net-P):
+      via(vd-P) at apply(pose, Point(vp, 0.0))
+
+    geom(via-net-N):
+      via(vd-N) at apply(pose, Point((- vp), 0.0))
+
+    make-anti-pads(v, pose = pose)
+    make-insertion-points(v, pose = pose)
+
+
+doc: \<DOC>
+Exception for Invalid LayerIndex Configurations
+<DOC>
+public defstruct InvalidLayerIndicesError <: Exception:
+  msg:String|Printable
+
+defmethod print (o:OutputStream, e:InvalidLayerIndicesError):
+  print(o, "Invalid Layer Indexes: %_" % [to-string $ msg(e)])
+
+doc: \<DOC>
+Exception for Invalid `skips` array in ViaGroundCage
+<DOC>
+public defstruct InvalidSkipIndexError <: Exception :
+  msg:String|Printable
+
+defmethod print (o:OutputStream, e:InvalidSkipIndexError):
+  print(o, "Invalid Skip Index: %_" % [to-string $ msg(e)])

--- a/stanza.proj
+++ b/stanza.proj
@@ -26,6 +26,7 @@ build-test tests:
     jsl/tests/pin-assignment
     jsl/tests/layerstack
     jsl/tests/ensure
+    jsl/tests/via-structures
     jsl/tests/si/Microstrip
     jsl/tests/si/couplers
     jsl/tests/si/signal-ends

--- a/tests/geometry.stanza
+++ b/tests/geometry.stanza
@@ -6,6 +6,7 @@ defpackage jsl/tests/geometry:
 
   import jsl/tests/utils
   import jsl/geometry/basics
+  import jsl/geometry/NotchedShapes
 
 deftest(geometry) test-expand-dims:
   val uut = Dims(2.0, 1.0)
@@ -109,3 +110,46 @@ deftest(geometry) test-scale-shape:
         #EXPECT(almost-equal?(a*, b*))
       (a*, b*):
         #EXPECT("Unhandled Types" == "")
+
+deftest(geometry) test-notched-rect:
+
+  val a = NotchedRectangle(width = 1.0, height = 1.0, notch-width = 0.1, notch-height = 0.1)
+  #EXPECT(a is Polygon)
+
+  expect-throw({NotchedRectangle(width = -1.0, height = 1.0, notch-width = 0.1, notch-height = 0.1)})
+  expect-throw({NotchedRectangle(width = 1.0, height = -1.0, notch-width = 0.1, notch-height = 0.1)})
+  expect-throw({NotchedRectangle(width = 1.0, height = 1.0, notch-width = 0.1, notch-height = 1.5)})
+  expect-throw({NotchedRectangle(width = 1.0, height = 1.0, notch-width = 0.1, notch-height = 1.0)})
+  expect-throw({NotchedRectangle(width = 1.0, height = 1.0, notch-width = 2.0, notch-height = 0.1)})
+
+deftest(geometry) test-double-notched-rect:
+
+  val a = DoubleNotchedRectangle(width = 1.0, height = 1.0, notch-width = 0.1, notch-height = 0.1)
+  #EXPECT(a is Polygon)
+
+  expect-throw({DoubleNotchedRectangle(width = -1.0, height = 1.0, notch-width = 0.1, notch-height = 0.1)})
+  expect-throw({DoubleNotchedRectangle(width = 1.0, height = -1.0, notch-width = 0.1, notch-height = 0.1)})
+  expect-throw({DoubleNotchedRectangle(width = 1.0, height = 1.0, notch-width = 0.1, notch-height = 1.5)})
+  expect-throw({DoubleNotchedRectangle(width = 1.0, height = 1.0, notch-width = 0.1, notch-height = 0.75)})
+  expect-throw({DoubleNotchedRectangle(width = 1.0, height = 1.0, notch-width = 0.1, notch-height = 0.5)})
+  expect-throw({DoubleNotchedRectangle(width = 1.0, height = 1.0, notch-width = 2.0, notch-height = 0.1)})
+
+deftest(geometry) test-chipped-circle:
+
+  val a = ChippedCircle(radius = 1.0, edge-dist = 0.1)
+  #EXPECT(a is PolygonWithArcs)
+
+  expect-throw({ChippedCircle(radius = -1.0, edge-dist = 0.1)})
+  expect-throw({ChippedCircle(radius = 1.0, edge-dist = -0.1)})
+  expect-throw({ChippedCircle(radius = 1.0, edge-dist = 1.0)})
+  expect-throw({ChippedCircle(radius = 1.0, edge-dist = 1.5)})
+
+deftest(geometry) test-double-chipped-circle:
+
+  val a = DoubleChippedCircle(radius = 1.0, edge-dist = 0.1)
+  #EXPECT(a is PolygonWithArcs)
+
+  expect-throw({DoubleChippedCircle(radius = -1.0, edge-dist = 0.1)})
+  expect-throw({DoubleChippedCircle(radius = 1.0, edge-dist = -0.1)})
+  expect-throw({DoubleChippedCircle(radius = 1.0, edge-dist = 1.0)})
+  expect-throw({DoubleChippedCircle(radius = 1.0, edge-dist = 1.5)})

--- a/tests/via-structures.stanza
+++ b/tests/via-structures.stanza
@@ -1,0 +1,94 @@
+#use-added-syntax(jitx,tests)
+defpackage jsl/tests/via-structures:
+  import core
+  import jitx
+  import jitx/commands
+
+  import jsl/via-structures
+
+public pcb-via default-TH:
+  start = Top
+  stop = Bottom
+  diameter = 0.45
+  hole-diameter = 0.3
+  type = MechanicalDrill
+
+public pcb-via uvia-T:
+  start = LayerIndex(0, Top)
+  stop = LayerIndex(1, Top)
+  diameter = 0.35
+  hole-diameter = 0.2
+  type = LaserDrill
+
+deftest(via-structures) test-se-basic:
+
+  pcb-module top-level :
+    val se-via = SingleViaStructure(
+      name = "SE-1",
+      via-def = uvia-T
+    )
+
+    val gc = PolarViaGroundCage(
+      via-def = default-TH,
+      count = 12,
+      radius = 2.0,
+      skips = [0, 2, 3, 4, 6, 8, 9, 10]
+    )
+    add-ground-cage(se-via, gc)
+    add-anti-pad(
+      se-via,
+      SimpleAntiPad(
+        shape = Circle(1.0),
+        start = LayerIndex(0, Top),
+        end = LayerIndex(1, Top))
+    )
+    add-std-insertion-points(se-via, 1.5)
+
+    public inst vs1 : create-via-structure(se-via)
+
+  set-main-module(top-level)
+
+  val pts = ports(top-level.vs1)
+  #EXPECT(length(pts) == 3)
+
+  #EXPECT(instance-type(top-level.vs1) == SingleModule)
+
+
+deftest(via-structures) test-diff-basic:
+
+  pcb-module top-level :
+    val diff-via = DifferentialViaStructure(
+      name = "DF-1",
+      via-def = uvia-T,
+      pitch = 0.5
+    )
+
+    val gc = PolarViaGroundCage(
+      via-def = default-TH,
+      count = 12,
+      radius = 1.25,
+      skips = [2, 3, 4, 8, 9, 10]
+    )
+    add-ground-cage(diff-via, gc)
+    add-anti-pad(
+      diff-via,
+      SimpleAntiPad(
+        shape = RoundedRectangle(1.5, 0.75, 0.2),
+        start = LayerIndex(0, Top),
+        end = LayerIndex(1,Top))
+    )
+    add-std-insertion-points(diff-via, 0.5)
+
+    val diff-via-struct = create-via-structure(diff-via)
+    public inst vs1 : diff-via-struct
+
+  set-main-module(top-level)
+
+  val pts = ports(top-level.vs1)
+  #EXPECT(length(pts) == 3)
+
+  #EXPECT(port-type(top-level.vs1.sig-in) is Bundle)
+  #EXPECT(port-type(top-level.vs1.sig-out) is Bundle)
+  #EXPECT(port-type(top-level.vs1.COMMON) is SinglePin)
+
+  #EXPECT(instance-type(top-level.vs1) == SingleModule)


### PR DESCRIPTION
This PR adds a new framework for constructing via structures using `pcb-module` with `geom/via/layer` statements. 


Here are some examples: 

Single Ended Via Structure with a Double Chipped Circle Antipad and 4 ground cage vias: 
 
<img width="347" alt="Screenshot 2024-07-07 at 9 58 14 PM" src="https://github.com/JITx-Inc/jsl/assets/622392/229b9db0-afd1-4811-a0c2-39d64a5ab5c9">

Diff-Pair Via Structure with a Double Notched Rectangle Antipad and 6 ground cage vias: 
<img width="370" alt="Screenshot 2024-07-07 at 9 58 50 PM" src="https://github.com/JITx-Inc/jsl/assets/622392/d8a3ea0a-0c63-4eab-b400-ee47f5cec450">

Hard to see the double notch anti-pad - here is the keepout region turned on: 
<img width="421" alt="Screenshot 2024-07-07 at 9 58 55 PM" src="https://github.com/JITx-Inc/jsl/assets/622392/6c19fc4c-283d-4557-b1a3-7f3fa06f0da7">


# Issues:

1.  The `CustomLayer` content was not showing in the layer stack - so I put the insertion points on the silkscreen just so they would show. Probably want to revert that in the future.
2. I can't create a courtyard by introspection. There isn't really a way for me to introspect the via locations in a module. Or at least, I haven't found one. If you know of a way - let me know.
3.  The forbid copper regions seem to have an additional clearance between the shape and the copper on the internal layer.  
4.  Pin Assignment based usage (ie, with `supports` statements) is not working. I think this may be running into an ambiguous topology case because of the vias.