### PR TITLE
Add a configuration strap component array generator

### DIFF
--- a/src/circuits/ConfigStrap.stanza
+++ b/src/circuits/ConfigStrap.stanza
@@ -6,7 +6,7 @@ used to define a series of configuration straps.
 
 <DOC>
 #use-added-syntax(jitx)
-defpackage jsl/design/ConfigStrap:
+defpackage jsl/circuits/ConfigStrap:
 
   import core
   import collections

--- a/src/design/ConfigStrap.stanza
+++ b/src/design/ConfigStrap.stanza
@@ -1,0 +1,224 @@
+doc: \<DOC>
+@brief Configuration Strap Module
+
+This package contains a module generator that can be
+used to define a series of configuration straps.
+
+<DOC>
+#use-added-syntax(jitx)
+defpackage jsl/design/ConfigStrap:
+
+  import core
+  import collections
+  import jitx
+  import jitx/commands
+
+  import jsl/errors
+  import jsl/ensure
+  import jsl/design/introspection
+  import jsl/landpatterns/framework
+
+public deftype ArrayPacking
+doc: \<DOC>
+This function implements the packing algorithm for a `ArrayPacking` type.
+
+This function will look at the passed components or arrays of components and
+then structure the array according to some heuristic.
+<DOC>
+public defmulti pack-array (ap:ArrayPacking, hi-comps:JITXObject, lo-comps:JITXObject)
+
+doc: \<DOC>
+Longitudinal Packing for Configuration Component Arrays
+
+This packing type will place the components in the
+following structure:
+
+  H0  H1  H2  ...
+  L0  L1  L2
+
+This will typically place the VDD rail on one side and ground rail
+on the other for easier connecting.
+
+<DOC>
+public defstruct LongitudinalPacking <: ArrayPacking:
+  doc: \<DOC>
+  Set the extra distance between components in the packing array.
+  <DOC>
+  margin:Double with:
+    default => 0.0
+    ensure => ensure-non-negative!
+with:
+  keyword-constructor => true
+
+
+defn is-pad-L2R? (comp:Instantiable) -> True|False :
+  val lp = landpattern(comp)
+  val p1 = get-pad-by-name!(lp, "p[1]")
+  val p2 = get-pad-by-name!(lp, "p[2]")
+
+  val p1-loc = center $ pose(p1)
+  val p2-loc = center $ pose(p2)
+
+  x(p1-loc) < x(p2-loc)
+
+defn is-pad-T2B? (comp:Instantiable) -> True|False :
+  val lp = landpattern(comp)
+  val p1 = get-pad-by-name!(lp, "p[1]")
+  val p2 = get-pad-by-name!(lp, "p[2]")
+
+  val p1-loc = center $ pose(p1)
+  val p2-loc = center $ pose(p2)
+
+  y(p1-loc) > y(p2-loc)
+
+
+defmethod pack-array (ap:LongitudinalPacking, hi-comps:JITXObject, lo-comps:JITXObject):
+  inside pcb-module:
+    val h-type = get-instantiable(hi-comps)
+    val hd = get-courtyard-dims $ h-type
+    val ld = get-courtyard-dims $ get-instantiable(lo-comps)
+
+    ; We use the aspect ratio of the part to determine whether the component
+    ; grid needs to be oriented in the X direction or the Y direction.
+    val is-Y-aligned = x(hd) < y(hd)
+
+    if is-Y-aligned:
+      val is-t2b? = is-pad-T2B?(h-type)
+      val [t-comp, b-comp] = if is-pad-T2B?(h-type):
+        [hi-comps, lo-comps]
+      else:
+        [lo-comps, hi-comps]
+
+      val w = max(x(hd), x(ld))
+      val m2 = margin(ap) / 2.0
+
+      for i in 0 to length(hi-comps) do:
+        val x-p = (w + margin(ap)) * to-double(i)
+        val y-h = (y(hd) / 2.0) + m2
+        place(t-comp[i]) at loc(x-p, y-h) on Top
+        val y-l = (y(ld) / 2.0) + m2
+        place(b-comp[i]) at loc(x-p, (- y-l)) on Top
+    else:
+      ; We are X aligned
+      val [l-comp, r-comp] = if is-pad-L2R?(h-type):
+        [hi-comps, lo-comps]
+      else:
+        [lo-comps, hi-comps]
+
+      val h = max(y(hd), y(ld))
+      val m2 = margin(ap) / 2.0
+
+      for i in 0 to length(hi-comps) do:
+        val y-p = (h + margin(ap)) * to-double(i)
+        val x-h = (x(hd) / 2.0) + m2
+        place(r-comp[i]) at loc(x-h, y-p) on Top
+        val x-l = (x(ld) / 2.0) + m2
+        place(l-comp[i]) at loc((- x-l), y-p) on Top
+
+
+doc: \<DOC>
+Configuration Bus Bundle
+
+This bundle is what is used to access the
+pin assignment supports for the ConfigStrap module.
+<DOC>
+public pcb-bundle config-strap-bus (num-elems:Int) :
+  port config : pin[num-elems]
+
+doc: \<DOC>
+Construct a configuration strap sub-circuit.
+
+With complex ICs, one or more pins may be exposed as "Configuration Straps." The
+idea is that the IC will check the status of these pins are boot time and
+depending on whether those pins are pulled high or low, this will change the
+behavior of the chip.
+
+This module provides a configurable means of defining a set of config strap
+resistors using pin assignment for optimal layout.
+
+The configuration strap resistors are typically created as a high-side
+resistor in series with a low side resistor, like a voltage divider. The
+middle node is the configuration node and depending on whether the
+high-side or low side is populated, it will be pulled to one side
+or another.
+
+This module exposes the array of high side and low side components as public
+in `hi-comps` and `lo-comps` arrays.
+
+This module exposes a support for a {@link config-strap-bus} bundle of length `num-elems`
+that can be used
+
+@param num-elems Number of configuration strap channels to create. Must be greater than 0.
+@param comp Component to instantiate for the divider.
+This component is expected to follow typical 2-pin convention of providing ports `p[1]`
+and `p[2]`.
+@param lo-comp Optional component for instantiating the low-side of the divider. If `lo` is
+not provided then `comp` is used for both the high and low side of the divider.
+@param pack? Optional Component Array Packing Generator. By default, this value
+is a {@link LongitudinalPacking}. If the user passes `None()` then no `place`
+statements for the components in the array are created.
+@param name? Optional name for the configuration strap definition
+@return This function creates a `pcb-module` within a closure and then
+returns the constructed `pcb-module`.
+<DOC>
+
+public defn ConfigStrap (
+  --
+  num-elems:Int,
+  comp:Instantiable,
+  lo-comp:Instantiable = comp,
+  pack?:Maybe<ArrayPacking> = One(LongitudinalPacking()),
+  name?:String = ?
+  ) -> Instantiable :
+  pcb-module config-strap :
+    match(name?):
+      (n:One<String>):
+        name = value(n)
+      (_:None): false
+
+    port hi : pin
+    port configs : pin[num-elems]
+    port lo : pin
+
+    ; I've set these as public because I'm theorizing
+    ;  that a user could pass a custom component that isn't
+    ;  just `p[1]` and `p[2]`. It could have other ports,
+    ;  that the user might want to connect to.
+    public inst hi-comps : comp[num-elems]
+    public inst lo-comps : lo-comp[num-elems]
+
+    for i in 0 to num-elems do:
+      net (hi, hi-comps[i].p[1])
+      net (configs[i], hi-comps[i].p[2], lo-comps[i].p[1])
+      net (lo, lo-comps[i].p[2])
+
+    ; Construct an internal bundle type so that
+    ;  the user can't mess with the pin assignment
+    ;  problem from outside this module.
+    pcb-bundle int-pin :
+      port p : pin
+
+    ; Create pin assignment problem where we can use any
+    ;  of the config pins in any order.
+    for i in 0 to num-elems do :
+      supports int-pin :
+        int-pin.p => lo-comps[i].p[1]
+
+    ; User can access a `config-strap-bus` bundle to access
+    ;   the configuration straps.
+    val b = config-strap-bus(num-elems)
+    supports b:
+      for i in 0 to num-elems do:
+        require elem:int-pin
+        b.config[i] => elem.p
+
+    ; Construct the layout for the components in this component.
+    ; Typically, the resistor strap is organized together in
+    ; non-space constrained designs.
+    match(pack?):
+      (_:None): false
+      (given:One<ArrayPacking>):
+        val pack = value(given)
+        pack-array(pack, hi-comps, lo-comps)
+
+  config-strap

--- a/src/design/introspection.stanza
+++ b/src/design/introspection.stanza
@@ -1,0 +1,26 @@
+#use-added-syntax(jitx)
+defpackage jsl/design/introspection:
+  import core
+  import jitx
+  import jitx/commands
+
+
+doc: \<DOC>
+Retrieve the `Instantiable` that generates the instances of the passed object.
+
+NOTE: This function is recursive.
+
+@param comps This is a instantiated component or module, or an array
+ of instances (all of the same type).
+@return The originating instantiable of either the instance or the elements
+of the array.
+<DOC>
+public defn get-instantiable (comps:JITXObject|InstantiableType) -> Instantiable:
+  val hc-type = match(comps):
+    (jcomps:JITXObject): instantiable-type(jcomps)
+    (insttype:InstantiableType): insttype
+  match(hc-type):
+    (hc-arr:InstantiableArray):
+      get-instantiable(base(hc-arr))
+    (hc-inst:Instantiable):
+      hc-inst

--- a/src/landpatterns/courtyard.stanza
+++ b/src/landpatterns/courtyard.stanza
@@ -130,3 +130,23 @@ public defn get-courtyard-boundary (
   if length(content) == 0: false
   else:
     bounds $ Union(content)
+
+
+doc: \<DOC>
+Extract the courtyard dimensions for the landpattern of a component.
+
+This function introspects the given component and finds the courtyard
+layer of its landpattern. It then returns the dimensions of the landpatterns
+courtyard layer.
+
+@param comp Instantiable component (pcb-component) with assigned landpattern.
+@return X and Y dimensions of the courtyard boundary in mm
+<DOC>
+public defn get-courtyard-dims (comp:Instantiable) -> Dims:
+  val lp = landpattern(comp)
+  val topC = Courtyard(Top)
+  dims $ Union $ for lspec in layers(lp) seq?:
+    switch(specifier(lspec)):
+      Courtyard(Top):
+        One $ shape(lspec)
+      else: None()

--- a/src/landpatterns/framework.stanza
+++ b/src/landpatterns/framework.stanza
@@ -21,3 +21,4 @@ defpackage jsl/landpatterns/framework:
   forward jsl/landpatterns/helpers
   forward jsl/landpatterns/silkscreen
   forward jsl/landpatterns/courtyard
+  forward jsl/landpatterns/introspection

--- a/src/landpatterns/introspection.stanza
+++ b/src/landpatterns/introspection.stanza
@@ -1,0 +1,38 @@
+#use-added-syntax(jitx)
+defpackage jsl/landpatterns/introspection:
+  import core
+  import jitx
+  import jitx/commands
+
+  import jsl/errors
+
+doc: \<DOC>
+Retrieve a pad from a landpattern by name
+
+@param obj LandPattern object that we will interrogate
+@param name Name of the pad like `p[1]` or `A[3]`, etc
+@return If we find a pad with that name, we will require a JITXObject
+of that pad. We we don't find a pad by that name, we return `None()`
+<DOC>
+public defn get-pad-by-name (obj:LandPattern, name:String) -> Maybe<JITXObject> :
+  for p in pads(obj) first:
+    val refName = to-string("%_" % [ref(p)])
+    if suffix?(refName, name) :
+      One(p)
+    else:
+      None()
+
+doc: \<DOC>
+Retrieve a pad from a landpattern by name
+
+@param obj LandPattern object that we will interrogate
+@param name Name of the pad like `p[1]` or `A[3]`, etc
+@return A pad object by that name if one is present.
+@throws ValueError when no pad is found by the passed name
+<DOC>
+public defn get-pad-by-name! (obj:LandPattern, name:String) -> JITXObject :
+  val v? = get-pad-by-name(obj, name)
+  match(v?):
+    (_:None):
+      throw $ ValueError("No Pad by name '%_' found in LandPattern '%_'" % [name, obj])
+    (v:One<JITXObject>): value(v)

--- a/src/si/couplers.stanza
+++ b/src/si/couplers.stanza
@@ -7,18 +7,7 @@ defpackage jsl/si/couplers:
   import jsl/bundles
   import jsl/si/helpers
   import jsl/pin-assignment
-
-doc: \<DOC>
-Extract the courtyard dimensions for the landpattern of a component.
-<DOC>
-defn get-courtyard-dims (comp:Instantiable) -> Dims:
-  val lp = landpattern(comp)
-  val topC = Courtyard(Top)
-  dims $ Union $ for lspec in layers(lp) seq?:
-    switch(specifier(lspec)):
-      Courtyard(Top):
-        One $ shape(lspec)
-      else: None()
+  import jsl/landpatterns/courtyard
 
 
 doc: \<DOC>
@@ -72,8 +61,8 @@ Construct Aligned Symmetric Shunt Components
 
 This function constructs a shunt module where two 2-pin components
 are instantiated with p[1] of both components adjacent to each other.
-The far pin (p[2]) on both components is connected to a `COMMON` terminal 
-which typically could be either a ground or a power supply net but is not 
+The far pin (p[2]) on both components is connected to a `COMMON` terminal
+which typically could be either a ground or a power supply net but is not
 restricted to those nets.
 
 @param comp 2-pin component like a resistors/capacitor with `p[1]` and `p[2]`
@@ -98,4 +87,3 @@ public pcb-module symmetric-shunt (comp:Instantiable -- margin:Double = 0.0) :
 
   place(RC[0]) at loc(0.0, y-off, 180.0) on Top
   place(RC[1]) at loc(0.0, (- y-off)) on Top
-  


### PR DESCRIPTION
This adds a new module that will array a set of components for a configuration strap array.


https://github.com/JITx-Inc/jsl/assets/622392/7a92b104-c964-407b-8996-98d6068eeddc


It works for through-hole and surface mounts and handles figuring out how to best orientate the components when placing them. 

Then you can use pin assignment to generate the best connections. 

<img width="258" alt="Screenshot 2024-07-10 at 9 45 27 PM" src="https://github.com/JITx-Inc/jsl/assets/622392/e4360d63-4754-4849-a10c-d3fa3500cbc1">
