### PR TITLE
Jsl/make layer stack v2

### DIFF
--- a/src/layerstack.stanza
+++ b/src/layerstack.stanza
@@ -355,9 +355,11 @@ When used on its own, this function is useful for creating asymmetric
 pcb stackups. This function is most useful when used on a non-empty
 layer stack.
 
-@param l-set layer or set of layers to add to the top of the stack. Note
+@param l-set layer or set of layers to add to the top of the stack, ordered from inner to outer (bottom to top). Note
 that if this value is a collection, then the layers will be added to
 the stack one at a time. For example:
+
+
 
 ```
 add-top( [dielectric, copper], stack)
@@ -389,7 +391,7 @@ When used on its own, this function is useful for creating asymmetric
 pcb stackups. This function is most useful when used on a non-empty
 layer stack.
 
-@param l-set layer or set of layers to add to the top of the stack. Note
+@param l-set layer or set of layers to add to the top of the stack, ordered from inner to outer (top to bottom). Note
 that if this value is a collection, then the layers will be added to
 the stack one at a time. For example:
 
@@ -447,9 +449,9 @@ add-symmetric(copper-35um, core-FR4,
 <DOC>
 public defn add-symmetric (copper:LayerSpec, dielectric:LayerSpec, s:LayerStack) -> LayerStack:
   if length(layers(s)) > 0:
-    val ls = [dielectric, copper]
-    add-bottom(ls, s)
+    val ls = [dielectric copper]
     add-top(ls, s)
+    add-bottom(ls, s)
   else:
     ; If there are no layers yet - then we need to just create
     ;  a single dielectric layer.
@@ -555,11 +557,11 @@ doc:\<DOC>
   ```
     val copper-35um = Copper(0.035)
     val copper-17_5um = Copper(0.0175)
+    val core = FR4(1.265, FR4-Material)
     val stack = make-layer-stack("4-Layer Stack with Soldermask", outer-layers,
       soldermask = soldermask) where :
       val soldermask = Soldermask(0.019, SoldermaskMaterial)
       val prepreg = FR4(0.1, FR4-Material)
-      val core = FR4(1.265, FR4-Material)
       val outer-layers = [
         [copper-35um prepreg] 
         [copper-17_5um core]
@@ -577,48 +579,101 @@ doc:\<DOC>
        soldermask
      ]
   
-  Example 2: 4-layer with two adjacent prepreg layers
+  Example 2: 4-layer stack with three adjacent prepreg layers, such as "JLC04161H-7628B"
   ```
-    val copper-35um = Copper(0.035)
-    val prepreg = FR4(0.1, FR4-Material)
-    val copper-17_5um = Copper(0.0175)
-    val core = FR4(1.265, FR4-Material)
-    val stack = make-layer-stack("4-layer with two adjacent prepreg layers", top-layers) where :
+    make-layer-stack("4-layer stack with three adjacent prepreg layers", top-layers) where :
+      val prepreg = FR4(0.1, FR4-Material)
+      val prepreg2 = FR4(0.2, FR4-Material)
+      val prepreg3 = FR4(0.3, FR4-Material)
       val top-layers =  [
-        [copper-35um prepreg]
-        prepreg
+        [copper-35um [prepreg prepreg2 prepreg3]]
         [copper-17_5um core]
       ]
   ```
   The LayerStack created has these layers:
      [ copper-35um
-       prepreg
-       prepreg ; two adjacent prepreg layers
+       prepreg ; three adjacent prepreg layers
+       prepreg2
+       prepreg3
        copper-17_5um
        core
        copper-17_5um
-       prepreg
+       prepreg3
+       prepreg2
        prepreg
        copper-35um
      ]
 
+  Example 3: 6-layer stack with even number of layers, such as "JLC06201H-3313A"
+  ```
+    make-layer-stack("6-layer stack with even number of layers", outers, even-layers? = true) where :
+      val prepreg = FR4(0.1, FR4-Material)
+      val prepreg2 = FR4(0.2, FR4-Material)
+      val outers =
+        [
+          [copper-35um prepreg]
+          [copper-17_5um core]
+          [copper-17_5um prepreg2] ; => two layers of prepreg2 in the center
+        ]
+  ```
+  The LayerStack created has these layers:
+     [ copper-35um
+       prepreg
+       copper-17_5um
+       core
+       copper-17_5um
+       prepreg2         ; two layers of prepreg2 in the center, not one single core/prepreg layer 
+       prepreg2         ;
+       copper-17_5um
+       core
+       copper-17_5um
+       prepreg
+       copper-35um
+     ]
+
+
   @param name The name of the LayerStack
-  @param top-layers The pairs of mechanical and dielectric layers, from outer to inner layers.
-  @param description The description of the LayerStack
+  @param top-layers A tuple of pairs of the mechanical layer and one dielectric layer or 
+    of the mechanical layer and a tuple of two or more dielectric layers, from outer to inner layers.
+  @param description (optional) The description of the LayerStack
+  @param soldermask (optional) The soldermask layer to be added as the outermost layer
+  @param even-layers? (optional) Whether there are an even number of layers. The default is `false`.
 <DOC>
-public defn make-layer-stack (name:String, outers:Tuple<[LayerSpec, LayerSpec]|LayerSpec>
-      -- description:String = ?, soldermask:LayerSpec = ?) -> LayerStack :
+public defn make-layer-stack (name:String,
+  outers:Tuple<[LayerSpec LayerSpec]|[LayerSpec Tuple<LayerSpec>]>
+      -- description:String = ?, 
+         soldermask:LayerSpec = ?,
+         even-layers?:True|False = false) -> LayerStack :
   val stack = #LayerStack(One(name), description)
   ;Access pairs of outer-layers in reverse order
   for outer in in-reverse(outers) do:
-    match(outer):
-      (outer:LayerSpec):
-        ; add one prepreg layer to top and bottom
-        add-top(outer, stack)
-        add-bottom(outer, stack)
-      ([metal, insul]:[LayerSpec LayerSpec]):
-        ; add [copper, prepreg] layers to top and bottom
+    ;Verify input
+    if outer[1] is Tuple<LayerSpec> and length(outer[1] as Tuple<LayerSpec>) < 2 :
+      throw(Exception("Invalid argument: Expect 2 or more layers in the tuple of dialectric layers in [LayerSpec Tuple<LayerSpec>]. Found %_" % [outer]))
+    if not even-layers? :
+      if outer[1] is LayerSpec :
+        val [metal insul] = outer as [LayerSpec LayerSpec]
         add-symmetric(metal, insul, stack)
+      else : ; outer[1] is Tuple<LayerSpec>
+        val [metal insuls] = outer as [LayerSpec Tuple<LayerSpec>]
+        ; add the innermost layers first
+        val n-insuls = length(insuls) ; insuls[n-insuls - 1] is the innermost layer
+        add-symmetric(insuls[n-insuls - 2], insuls[n-insuls - 1], stack)
+        ; then add the rest of the layers
+        val layers = to-list $ cat([metal], insuls[0 to n-insuls - 2]) ; from outer to inner layers
+        add-top(reverse(layers), stack) ; ordered from inner to outer
+        add-bottom(reverse(layers), stack)
+    else : ; even-layers? = true
+      if outer[1] is LayerSpec :
+        val [metal insul] = outer as [LayerSpec LayerSpec]
+        add-top([insul metal], stack) ; reversed order - from inner to outer layers
+        add-bottom([insul metal], stack)
+      else : ; outer[1] is Tuple<LayerSpec>
+        val [metal insuls] = outer as [LayerSpec Tuple<LayerSpec>]
+        val layers = to-list $ cat([metal], insuls) ; from outer to inner layers
+        add-top(reverse(layers), stack) ; reversed order - from inner to outer layers
+        add-bottom(reverse(layers), stack)
+        
   if value?(soldermask) is LayerSpec :
     add-soldermask(value!(soldermask), stack) 
   stack

--- a/src/layerstack.stanza
+++ b/src/layerstack.stanza
@@ -558,16 +558,17 @@ doc:\<DOC>
     val copper-35um = Copper(0.035)
     val copper-17_5um = Copper(0.0175)
     val core = FR4(1.265, FR4-Material)
+    val prepreg = FR4(0.1, FR4-Material)
     val stack = make-layer-stack("4-Layer Stack with Soldermask", outer-layers,
       soldermask = soldermask) where :
       val soldermask = Soldermask(0.019, SoldermaskMaterial)
-      val prepreg = FR4(0.1, FR4-Material)
       val outer-layers = [
         [copper-35um prepreg] 
         [copper-17_5um core]
       ]
   ```
   The LayerStack created has these layers:
+    ```
      [ soldermask
        copper-35um
        prepreg
@@ -578,20 +579,21 @@ doc:\<DOC>
        copper-35um
        soldermask
      ]
+    ```
   
   Example 2: 4-layer stack with three adjacent prepreg layers, such as "JLC04161H-7628B"
   ```
+    val prepreg2 = FR4(0.2, FR4-Material)
+    val prepreg3 = FR4(0.3, FR4-Material)
     make-layer-stack("4-layer stack with three adjacent prepreg layers", top-layers) where :
-      val prepreg = FR4(0.1, FR4-Material)
-      val prepreg2 = FR4(0.2, FR4-Material)
-      val prepreg3 = FR4(0.3, FR4-Material)
       val top-layers =  [
         [copper-35um [prepreg prepreg2 prepreg3]]
         [copper-17_5um core]
       ]
   ```
   The LayerStack created has these layers:
-     [ copper-35um
+    ```
+     [  copper-35um
        prepreg ; three adjacent prepreg layers
        prepreg2
        prepreg3
@@ -603,12 +605,11 @@ doc:\<DOC>
        prepreg
        copper-35um
      ]
+    ```
 
   Example 3: 6-layer stack with even number of layers, such as "JLC06201H-3313A"
   ```
     make-layer-stack("6-layer stack with even number of layers", outers, even-layers? = true) where :
-      val prepreg = FR4(0.1, FR4-Material)
-      val prepreg2 = FR4(0.2, FR4-Material)
       val outers =
         [
           [copper-35um prepreg]
@@ -617,6 +618,7 @@ doc:\<DOC>
         ]
   ```
   The LayerStack created has these layers:
+    ```
      [ copper-35um
        prepreg
        copper-17_5um
@@ -630,7 +632,7 @@ doc:\<DOC>
        prepreg
        copper-35um
      ]
-
+    ```
 
   @param name The name of the LayerStack
   @param top-layers A tuple of pairs of the mechanical layer and one dielectric layer or 

--- a/src/layerstack.stanza
+++ b/src/layerstack.stanza
@@ -551,74 +551,42 @@ public defn create-pcb-stackup (stack:LayerStack) :
 doc:\<DOC>
   Construct a LayerStack with a tuple of outer layers. 
 
-  Example 1: 4-Layer Stack with Soldermask
+  Example:
   ```
     val copper-35um = Copper(0.035)
     val copper-17_5um = Copper(0.0175)
-    val stack = make-layer-stack("4-Layer Stack with Soldermask", outer-layers,
+    val jlcpcb-jlc2313 = make-layer-stack("JLCPCB 4-layer 1.6mm", outer-layers,
       soldermask = soldermask) where :
       val soldermask = Soldermask(0.019, SoldermaskMaterial)
-      val prepreg = FR4(0.1, FR4-Material)
-      val core = FR4(1.265, FR4-Material)
+      val prepreg-2313 = FR4(0.1, FR4-Material-2313)
+      val core-2313 = FR4(1.265, FR4-Material-Core)
       val outer-layers = [
-        [copper-35um prepreg] 
-        [copper-17_5um core]
+        [copper-35um prepreg-2313] 
+        [copper-17_5um core-2313]
       ]
   ```
   The LayerStack created has these layers:
      [ soldermask
        copper-35um
-       prepreg
+       prepreg-2313
        copper-17_5um
-       core
+       core-2313
        copper-17_5um
-       prepreg
+       prepreg-2313
        copper-35um
        soldermask
      ]
-  
-  Example 2: 4-layer with two adjacent prepreg layers
-  ```
-    val copper-35um = Copper(0.035)
-    val prepreg = FR4(0.1, FR4-Material)
-    val copper-17_5um = Copper(0.0175)
-    val core = FR4(1.265, FR4-Material)
-    val stack = make-layer-stack("4-layer with two adjacent prepreg layers", top-layers) where :
-      val top-layers =  [
-        [copper-35um prepreg]
-        prepreg
-        [copper-17_5um core]
-      ]
-  ```
-  The LayerStack created has these layers:
-     [ copper-35um
-       prepreg
-       prepreg ; two adjacent prepreg layers
-       copper-17_5um
-       core
-       copper-17_5um
-       prepreg
-       prepreg
-       copper-35um
-     ]
-
   @param name The name of the LayerStack
   @param top-layers The pairs of mechanical and dielectric layers, from outer to inner layers.
   @param description The description of the LayerStack
 <DOC>
-public defn make-layer-stack (name:String, outers:Tuple<[LayerSpec, LayerSpec]|LayerSpec>
+public defn make-layer-stack (name:String, outers:Tuple<[LayerSpec, LayerSpec]>
       -- description:String = ?, soldermask:LayerSpec = ?) -> LayerStack :
   val stack = #LayerStack(One(name), description)
   ;Access pairs of outer-layers in reverse order
   for outer in in-reverse(outers) do:
-    match(outer):
-      (outer:LayerSpec):
-        ; add one prepreg layer to top and bottom
-        add-top(outer, stack)
-        add-bottom(outer, stack)
-      ([metal, insul]:[LayerSpec LayerSpec]):
-        ; add [copper, prepreg] layers to top and bottom
-        add-symmetric(metal, insul, stack)
+    val [metal, insul] = outer
+    add-symmetric(metal, insul, stack)
   if value?(soldermask) is LayerSpec :
     add-soldermask(value!(soldermask), stack) 
   stack

--- a/src/layerstack.stanza
+++ b/src/layerstack.stanza
@@ -650,8 +650,8 @@ public defn make-layer-stack (name:String,
   ;Access pairs of outer-layers in reverse order
   for outer in in-reverse(outers) do:
     ;Verify input
-    if outer[1] is Tuple<LayerSpec> and length(outer[1] as Tuple<LayerSpec>) < 2 :
-      throw(Exception("Invalid argument: Expect 2 or more layers in the tuple of dialectric layers in [LayerSpec Tuple<LayerSpec>]. Found %_" % [outer]))
+    if outer[1] is Tuple<LayerSpec> and empty?(outer[1] as Tuple<LayerSpec>) :
+      throw(Exception("Invalid argument: The tuple of dialectric layers is empty. Expect [LayerSpec Tuple<LayerSpec>]. Found %_" % [outer]))
     if not even-layers? :
       if outer[1] is LayerSpec :
         val [metal insul] = outer as [LayerSpec LayerSpec]
@@ -660,11 +660,14 @@ public defn make-layer-stack (name:String,
         val [metal insuls] = outer as [LayerSpec Tuple<LayerSpec>]
         ; add the innermost layers first
         val n-insuls = length(insuls) ; insuls[n-insuls - 1] is the innermost layer
-        add-symmetric(insuls[n-insuls - 2], insuls[n-insuls - 1], stack)
-        ; then add the rest of the layers
-        val layers = to-list $ cat([metal], insuls[0 to n-insuls - 2]) ; from outer to inner layers
-        add-top(reverse(layers), stack) ; ordered from inner to outer
-        add-bottom(reverse(layers), stack)
+        if n-insuls == 1 : ; [copper [dielectric]] => treat it as [copper dielectric]
+          add-symmetric(metal, insuls[0], stack)
+        else :
+          add-symmetric(insuls[n-insuls - 2], insuls[n-insuls - 1], stack)
+          ; then add the rest of the layers
+          val layers = to-list $ cat([metal], insuls[0 to n-insuls - 2]) ; from outer to inner layers
+          add-top(reverse(layers), stack) ; ordered from inner to outer
+          add-bottom(reverse(layers), stack)
     else : ; even-layers? = true
       if outer[1] is LayerSpec :
         val [metal insul] = outer as [LayerSpec LayerSpec]

--- a/src/layerstack.stanza
+++ b/src/layerstack.stanza
@@ -551,42 +551,74 @@ public defn create-pcb-stackup (stack:LayerStack) :
 doc:\<DOC>
   Construct a LayerStack with a tuple of outer layers. 
 
-  Example:
+  Example 1: 4-Layer Stack with Soldermask
   ```
     val copper-35um = Copper(0.035)
     val copper-17_5um = Copper(0.0175)
-    val jlcpcb-jlc2313 = make-layer-stack("JLCPCB 4-layer 1.6mm", outer-layers,
+    val stack = make-layer-stack("4-Layer Stack with Soldermask", outer-layers,
       soldermask = soldermask) where :
       val soldermask = Soldermask(0.019, SoldermaskMaterial)
-      val prepreg-2313 = FR4(0.1, FR4-Material-2313)
-      val core-2313 = FR4(1.265, FR4-Material-Core)
+      val prepreg = FR4(0.1, FR4-Material)
+      val core = FR4(1.265, FR4-Material)
       val outer-layers = [
-        [copper-35um prepreg-2313] 
-        [copper-17_5um core-2313]
+        [copper-35um prepreg] 
+        [copper-17_5um core]
       ]
   ```
   The LayerStack created has these layers:
      [ soldermask
        copper-35um
-       prepreg-2313
+       prepreg
        copper-17_5um
-       core-2313
+       core
        copper-17_5um
-       prepreg-2313
+       prepreg
        copper-35um
        soldermask
      ]
+  
+  Example 2: 4-layer with two adjacent prepreg layers
+  ```
+    val copper-35um = Copper(0.035)
+    val prepreg = FR4(0.1, FR4-Material)
+    val copper-17_5um = Copper(0.0175)
+    val core = FR4(1.265, FR4-Material)
+    val stack = make-layer-stack("4-layer with two adjacent prepreg layers", top-layers) where :
+      val top-layers =  [
+        [copper-35um prepreg]
+        prepreg
+        [copper-17_5um core]
+      ]
+  ```
+  The LayerStack created has these layers:
+     [ copper-35um
+       prepreg
+       prepreg ; two adjacent prepreg layers
+       copper-17_5um
+       core
+       copper-17_5um
+       prepreg
+       prepreg
+       copper-35um
+     ]
+
   @param name The name of the LayerStack
   @param top-layers The pairs of mechanical and dielectric layers, from outer to inner layers.
   @param description The description of the LayerStack
 <DOC>
-public defn make-layer-stack (name:String, outers:Tuple<[LayerSpec, LayerSpec]>
+public defn make-layer-stack (name:String, outers:Tuple<[LayerSpec, LayerSpec]|LayerSpec>
       -- description:String = ?, soldermask:LayerSpec = ?) -> LayerStack :
   val stack = #LayerStack(One(name), description)
   ;Access pairs of outer-layers in reverse order
   for outer in in-reverse(outers) do:
-    val [metal, insul] = outer
-    add-symmetric(metal, insul, stack)
+    match(outer):
+      (outer:LayerSpec):
+        ; add one prepreg layer to top and bottom
+        add-top(outer, stack)
+        add-bottom(outer, stack)
+      ([metal, insul]:[LayerSpec LayerSpec]):
+        ; add [copper, prepreg] layers to top and bottom
+        add-symmetric(metal, insul, stack)
   if value?(soldermask) is LayerSpec :
     add-soldermask(value!(soldermask), stack) 
   stack

--- a/tests/layerstack.stanza
+++ b/tests/layerstack.stanza
@@ -1,6 +1,7 @@
 #use-added-syntax(jitx,tests)
 defpackage jsl/tests/layerstack:
   import core
+  import collections
   import jitx
   import jitx/commands
 
@@ -140,6 +141,7 @@ My Crazy Stack - each layer is different for testing
  10 - copper-105um
 ;<note>
 val test-stack = LayerStack(name = "My Crazy Stack")
+val copper-17_5um = Copper(0.0175, name = "cu1")
 val copper-35um = Copper(0.035, name = "cu1")
 val copper-70um = Copper(0.070, name = "cu2")
 val copper-105um = Copper(0.105, name = "cu3")
@@ -208,9 +210,9 @@ doc:\<DOC>
     val top-layers = [
       soldermask
       copper-35um
-      prepreg-2313 
+      prepreg 
       copper-17_5um
-      core-2313
+      core
     ]
     verify-layers(stack, top-layers)
   ```
@@ -219,11 +221,11 @@ doc:\<DOC>
     [
       soldermask
       copper-35um
-      prepreg-2313 
+      prepreg 
       copper-17_5um
-      core-2313       ; the middle layer
+      core            ; the middle layer
       copper-17_5um
-      prepreg-2313
+      prepreg
       copper-35um
       soldermask
     ]
@@ -231,7 +233,7 @@ doc:\<DOC>
 @param stack The LayerStack to verify
 @param top-layers the top layers, from the top of the stack to the middle layer.
 <DOC>
-defn verify-layers (stack:LayerStack, top-layers:Tuple<LayerSpec>) :
+public defn verify-layers (stack:LayerStack, top-layers:Tuple<LayerSpec>) :
   #EXPECT(length(layers(stack)) == length(top-layers) * 2 - 1)
   val total-layers = length(layers(stack))
   val middle = total-layers / 2
@@ -239,49 +241,80 @@ defn verify-layers (stack:LayerStack, top-layers:Tuple<LayerSpec>) :
     #EXPECT(stack[idx] == top-layers[idx])
     #EXPECT(stack[total-layers - 1 - idx] == top-layers[idx])
 
-;Verify the layers of jlcpcb2313 
-defn verify-stack-jlcpcb-2313 (stack:LayerStack, soldermask?:True|False) :
+;Verify the 4-layers stack
+defn verify-4-layer-stack (stack:LayerStack, soldermask?:True|False) :
   val soldermask = [Soldermask(0.019, SoldermaskMaterial)]
     when soldermask? else []
-  val copper-35um = Copper(0.035)
-  val prepreg-2313 = FR4(0.1, FR4-Material)
-  val copper-17_5um = Copper(0.0175)
-  val core-2313 = FR4(1.265, FR4-Material)
+  val prepreg = FR4(0.1, FR4-Material)
+  val core = FR4(1.265, FR4-Material)
   val top-layers = to-tuple $ cat(soldermask, [
       copper-35um
-      prepreg-2313 
+      prepreg 
       copper-17_5um
-      core-2313
+      core
     ])
   verify-layers(stack, top-layers)
-  if soldermask? :
-    #EXPECT(length(conductors(stack)) == length(top-layers) - 1)
-  else :
-    #EXPECT(length(conductors(stack)) == length(top-layers))
 
 ;Use the function make-layer-stack to create a LayerStack from a tuple of LayerSpect
-deftest(layerstack) make-layer-stack-jlcpcb-2313 :
+deftest(layerstack) make-4-layer-stack :
   val soldermask = Soldermask(0.019, SoldermaskMaterial)
-  val copper-35um = Copper(0.035)
-  val prepreg-2313 = FR4(0.1, FR4-Material)
-  val copper-17_5um = Copper(0.0175)
-  val core-2313 = FR4(1.265, FR4-Material)
-  val stack = make-layer-stack("JLCPCB 4-layer 1.6mm", top-layers, soldermask = soldermask) where :
+  val prepreg = FR4(0.1, FR4-Material)
+  val core = FR4(1.265, FR4-Material)
+  val stack = make-layer-stack("4-Layer Stack without Soldermask", top-layers, soldermask = soldermask) where :
     val top-layers =  [
-      [copper-35um prepreg-2313] 
-      [copper-17_5um core-2313]
+      [copper-35um prepreg] 
+      [copper-17_5um core]
     ]
-  verify-stack-jlcpcb-2313(stack, true)
+  verify-4-layer-stack(stack, true)
 
 ;Without the soldermask layer
-deftest(layerstack) make-layer-stack-jlcpcb-2313-no-soldermask :
-  val copper-35um = Copper(0.035)
-  val prepreg-2313 = FR4(0.1, FR4-Material)
-  val copper-17_5um = Copper(0.0175)
-  val core-2313 = FR4(1.265, FR4-Material)
-  val stack = make-layer-stack("JLCPCB 4-layer 1.6mm", top-layers) where :
+deftest(layerstack) make-4-layer-layer-stack-no-soldermask :
+  val prepreg = FR4(0.1, FR4-Material)
+  val core = FR4(1.265, FR4-Material)
+  val stack = make-layer-stack("4-Layer Stack with Soldermask", top-layers) where :
     val top-layers =  [
-      [copper-35um prepreg-2313] 
-      [copper-17_5um core-2313]
+      [copper-35um prepreg] 
+      [copper-17_5um core]
     ]
-  verify-stack-jlcpcb-2313(stack, false)
+  verify-4-layer-stack(stack, false)
+
+;Verify the layers with multiple adjacent prepreg layers
+; - insert the `adjacent-prepregs` layers right below the outer [copper prepreg] layers
+defn verify-4-layer-stack-with-adjacent-prepregs (stack:LayerStack, adjacent-prepregs:Tuple<LayerSpec>) :
+  val prepreg = FR4(0.1, FR4-Material)
+  val core = FR4(1.265, FR4-Material)
+  val top-layers = Vector<LayerSpec>()
+  add-all(top-layers, [copper-35um prepreg ])
+  add-all(top-layers, adjacent-prepregs)
+  add-all(top-layers, [copper-17_5um core])
+  verify-layers(stack, to-tuple $ top-layers)
+
+; Two adjacent prepreg layers
+; Example: "JLC04161H-7628A"
+deftest(layerstack) make-layer-stack-two-adjacent-prepreg-layers :
+  val prepreg = FR4(0.1, FR4-Material)
+  val prepreg2 = FR4(0.2, FR4-Material)
+  val core = FR4(1.265, FR4-Material)
+  val stack = make-layer-stack("4-layer with two adjacent prepreg layers", top-layers) where :
+    val top-layers =  [
+      [copper-35um prepreg]
+      prepreg2
+      [copper-17_5um core]
+    ]
+  verify-4-layer-stack-with-adjacent-prepregs(stack, [prepreg2])
+
+; Two adjacent prepreg layers
+; Example: "JLC04161H-7628A"
+deftest(layerstack) make-layer-stack-three-adjacent-prepreg-layers :
+  val prepreg = FR4(0.1, FR4-Material)
+  val prepreg2 = FR4(0.2, FR4-Material)
+  val prepreg3 = FR4(0.3, FR4-Material)
+  val core = FR4(1.265, FR4-Material)
+  val stack = make-layer-stack("4-layer with two adjacent prepreg layers", top-layers) where :
+    val top-layers =  [
+      [copper-35um prepreg]
+      prepreg2
+      prepreg3
+      [copper-17_5um core]
+    ]
+  verify-4-layer-stack-with-adjacent-prepregs(stack, [prepreg2 prepreg3])

--- a/tests/layerstack.stanza
+++ b/tests/layerstack.stanza
@@ -314,7 +314,7 @@ deftest(layerstack) make-4-layer-layer-stack-no-soldermask :
     ]
   verify-4-layer-stack(stack)
 
-; Two adjacent prepreg layers
+; Two adjacent prepreg layers, right below the outer copper layer
 ; Example: "JLC04161H-7628A"
 deftest(layerstack) make-layer-stack-two-adjacent-prepreg-layers :
   val prepreg = FR4(0.1, FR4-Material)
@@ -327,7 +327,7 @@ deftest(layerstack) make-layer-stack-two-adjacent-prepreg-layers :
     ]
   verify-4-layer-stack(stack, add-prepreg-layers = [prepreg2])
 
-; Three adjacent prepreg layers
+; Three adjacent prepreg layers, right below the outer copper layer
 ; Example: "JLC04161H-7628A"
 deftest(layerstack) make-layer-stack-three-adjacent-prepreg-layers :
   val prepreg = FR4(0.1, FR4-Material)
@@ -340,6 +340,25 @@ deftest(layerstack) make-layer-stack-three-adjacent-prepreg-layers :
       [copper-17_5um core]
     ]
   verify-4-layer-stack(stack, add-prepreg-layers = [prepreg2 prepreg3])
+
+; Two adjacent prepreg layers in the middle, , right below the inner copper layer
+; Example: JLC06161H-1080B"
+deftest(layerstack) make-layer-stack-three-adjacent-prepreg-layers :
+  val prepreg = FR4(0.1, FR4-Material)
+  val prepreg2 = FR4(0.2, FR4-Material)
+  val prepreg3 = FR4(0.3, FR4-Material)
+  val core = FR4(1.265, FR4-Material)
+  val stack = make-layer-stack("6-layer stack with two adjacent prepreg layers in the middle", top-layers) where :
+    val top-layers =  [
+      [copper-35um prepreg]
+      [copper-17_5um core]
+      [copper-17_5um [prepreg2 prepreg3]]
+    ]
+  verify-layers(stack, top-layers) where :
+    val top-layers = [
+      copper-35um prepreg
+      copper-17_5um core
+      copper-17_5um prepreg2 prepreg3]
 
 ; Even number of layers
 ; Example: "JLC06201H-3313A"

--- a/tests/layerstack.stanza
+++ b/tests/layerstack.stanza
@@ -270,18 +270,25 @@ public defn verify-layers (stack:LayerStack, top-layers:Tuple<LayerSpec>
       #EXPECT(stack[idx] == top-layers[idx])
       #EXPECT(stack[total-layers - 1 - idx] == top-layers[idx])
 
-;Verify the 4-layers stack
-defn verify-4-layer-stack (stack:LayerStack, soldermask?:True|False) :
+doc:\<DOC>
+  Verify a typical 4-layers stack used in this package
+
+  @param soldermask? When true, add the soldermask layer
+  @param add-prepreg-layers When the tuple is not empty, insert the multiple `add-prepreg-layers` right below the outer [copper prepreg] layers
+<DOC>
+defn verify-4-layer-stack (stack:LayerStack
+      -- soldermask?:True|False = false
+         add-prepreg-layers:Tuple<LayerSpec> = []) :
   val soldermask = [Soldermask(0.019, SoldermaskMaterial)]
     when soldermask? else []
   val prepreg = FR4(0.1, FR4-Material)
   val core = FR4(1.265, FR4-Material)
-  val top-layers = to-tuple $ cat(soldermask, [
-      copper-35um
-      prepreg 
-      copper-17_5um
-      core
-    ])
+  val top-layers = to-tuple $ cat-all $
+    [ soldermask
+      [copper-35um prepreg]
+      add-prepreg-layers 
+      [copper-17_5um core]
+    ]
   verify-layers(stack, top-layers)
 
 ;Use the function make-layer-stack to create a LayerStack from a tuple of LayerSpect
@@ -294,7 +301,7 @@ deftest(layerstack) make-4-layer-stack :
       [copper-35um prepreg] 
       [copper-17_5um core]
     ]
-  verify-4-layer-stack(stack, true)
+  verify-4-layer-stack(stack, soldermask? = true)
 
 ;Without the soldermask layer
 deftest(layerstack) make-4-layer-layer-stack-no-soldermask :
@@ -305,18 +312,7 @@ deftest(layerstack) make-4-layer-layer-stack-no-soldermask :
       [copper-35um prepreg] 
       [copper-17_5um core]
     ]
-  verify-4-layer-stack(stack, false)
-
-;Verify the layers with multiple adjacent prepreg layers
-; - insert the `adjacent-prepregs` layers right below the outer [copper prepreg] layers
-defn verify-4-layer-stack-with-adjacent-prepregs (stack:LayerStack, adjacent-prepregs:Tuple<LayerSpec>) :
-  val prepreg = FR4(0.1, FR4-Material)
-  val core = FR4(1.265, FR4-Material)
-  val top-layers = Vector<LayerSpec>()
-  add-all(top-layers, [copper-35um prepreg ])
-  add-all(top-layers, adjacent-prepregs)
-  add-all(top-layers, [copper-17_5um core])
-  verify-layers(stack, to-tuple $ top-layers)
+  verify-4-layer-stack(stack)
 
 ; Two adjacent prepreg layers
 ; Example: "JLC04161H-7628A"
@@ -324,26 +320,45 @@ deftest(layerstack) make-layer-stack-two-adjacent-prepreg-layers :
   val prepreg = FR4(0.1, FR4-Material)
   val prepreg2 = FR4(0.2, FR4-Material)
   val core = FR4(1.265, FR4-Material)
-  val stack = make-layer-stack("4-layer with two adjacent prepreg layers", top-layers) where :
+  val stack = make-layer-stack("4-layer stack with two adjacent prepreg layers", top-layers) where :
     val top-layers =  [
-      [copper-35um prepreg]
-      prepreg2
+      [copper-35um [prepreg prepreg2]]
       [copper-17_5um core]
     ]
-  verify-4-layer-stack-with-adjacent-prepregs(stack, [prepreg2])
+  verify-4-layer-stack(stack, add-prepreg-layers = [prepreg2])
 
-; Two adjacent prepreg layers
+; Three adjacent prepreg layers
 ; Example: "JLC04161H-7628A"
 deftest(layerstack) make-layer-stack-three-adjacent-prepreg-layers :
   val prepreg = FR4(0.1, FR4-Material)
   val prepreg2 = FR4(0.2, FR4-Material)
   val prepreg3 = FR4(0.3, FR4-Material)
   val core = FR4(1.265, FR4-Material)
-  val stack = make-layer-stack("4-layer with two adjacent prepreg layers", top-layers) where :
+  val stack = make-layer-stack("4-layer stack with three adjacent prepreg layers", top-layers) where :
     val top-layers =  [
-      [copper-35um prepreg]
-      prepreg2
-      prepreg3
+      [copper-35um [prepreg prepreg2 prepreg3]]
       [copper-17_5um core]
     ]
-  verify-4-layer-stack-with-adjacent-prepregs(stack, [prepreg2 prepreg3])
+  verify-4-layer-stack(stack, add-prepreg-layers = [prepreg2 prepreg3])
+
+; Even number of layers
+; Example: "JLC06201H-3313A"
+deftest(layerstack) make-layer-stack-even-number-of-layers :
+  val prepreg = FR4(0.1, FR4-Material)
+  val prepreg2 = FR4(0.2, FR4-Material)
+  val core = FR4(1.265, FR4-Material)
+  val stack = make-layer-stack("6-layer stack with even number of layers", outers, even-layers? = true) where :
+    val outers =
+      [
+        [copper-35um prepreg]
+        [copper-17_5um core]
+        [copper-17_5um prepreg2] ; => two layers of prepreg2 in the center
+      ]
+
+  ;Verify the layer stack with even number of layers
+  verify-layers(stack, top-layers, even-layers? = true) where :
+    val top-layers = [
+        copper-35um prepreg
+        copper-17_5um core
+        copper-17_5um prepreg2]
+

--- a/tests/layerstack.stanza
+++ b/tests/layerstack.stanza
@@ -1,7 +1,6 @@
 #use-added-syntax(jitx,tests)
 defpackage jsl/tests/layerstack:
   import core
-  import collections
   import jitx
   import jitx/commands
 
@@ -141,7 +140,6 @@ My Crazy Stack - each layer is different for testing
  10 - copper-105um
 ;<note>
 val test-stack = LayerStack(name = "My Crazy Stack")
-val copper-17_5um = Copper(0.0175, name = "cu1")
 val copper-35um = Copper(0.035, name = "cu1")
 val copper-70um = Copper(0.070, name = "cu2")
 val copper-105um = Copper(0.105, name = "cu3")
@@ -210,9 +208,9 @@ doc:\<DOC>
     val top-layers = [
       soldermask
       copper-35um
-      prepreg 
+      prepreg-2313 
       copper-17_5um
-      core
+      core-2313
     ]
     verify-layers(stack, top-layers)
   ```
@@ -221,11 +219,11 @@ doc:\<DOC>
     [
       soldermask
       copper-35um
-      prepreg 
+      prepreg-2313 
       copper-17_5um
-      core            ; the middle layer
+      core-2313       ; the middle layer
       copper-17_5um
-      prepreg
+      prepreg-2313
       copper-35um
       soldermask
     ]
@@ -233,7 +231,7 @@ doc:\<DOC>
 @param stack The LayerStack to verify
 @param top-layers the top layers, from the top of the stack to the middle layer.
 <DOC>
-public defn verify-layers (stack:LayerStack, top-layers:Tuple<LayerSpec>) :
+defn verify-layers (stack:LayerStack, top-layers:Tuple<LayerSpec>) :
   #EXPECT(length(layers(stack)) == length(top-layers) * 2 - 1)
   val total-layers = length(layers(stack))
   val middle = total-layers / 2
@@ -241,80 +239,49 @@ public defn verify-layers (stack:LayerStack, top-layers:Tuple<LayerSpec>) :
     #EXPECT(stack[idx] == top-layers[idx])
     #EXPECT(stack[total-layers - 1 - idx] == top-layers[idx])
 
-;Verify the 4-layers stack
-defn verify-4-layer-stack (stack:LayerStack, soldermask?:True|False) :
+;Verify the layers of jlcpcb2313 
+defn verify-stack-jlcpcb-2313 (stack:LayerStack, soldermask?:True|False) :
   val soldermask = [Soldermask(0.019, SoldermaskMaterial)]
     when soldermask? else []
-  val prepreg = FR4(0.1, FR4-Material)
-  val core = FR4(1.265, FR4-Material)
+  val copper-35um = Copper(0.035)
+  val prepreg-2313 = FR4(0.1, FR4-Material)
+  val copper-17_5um = Copper(0.0175)
+  val core-2313 = FR4(1.265, FR4-Material)
   val top-layers = to-tuple $ cat(soldermask, [
       copper-35um
-      prepreg 
+      prepreg-2313 
       copper-17_5um
-      core
+      core-2313
     ])
   verify-layers(stack, top-layers)
+  if soldermask? :
+    #EXPECT(length(conductors(stack)) == length(top-layers) - 1)
+  else :
+    #EXPECT(length(conductors(stack)) == length(top-layers))
 
 ;Use the function make-layer-stack to create a LayerStack from a tuple of LayerSpect
-deftest(layerstack) make-4-layer-stack :
+deftest(layerstack) make-layer-stack-jlcpcb-2313 :
   val soldermask = Soldermask(0.019, SoldermaskMaterial)
-  val prepreg = FR4(0.1, FR4-Material)
-  val core = FR4(1.265, FR4-Material)
-  val stack = make-layer-stack("4-Layer Stack without Soldermask", top-layers, soldermask = soldermask) where :
+  val copper-35um = Copper(0.035)
+  val prepreg-2313 = FR4(0.1, FR4-Material)
+  val copper-17_5um = Copper(0.0175)
+  val core-2313 = FR4(1.265, FR4-Material)
+  val stack = make-layer-stack("JLCPCB 4-layer 1.6mm", top-layers, soldermask = soldermask) where :
     val top-layers =  [
-      [copper-35um prepreg] 
-      [copper-17_5um core]
+      [copper-35um prepreg-2313] 
+      [copper-17_5um core-2313]
     ]
-  verify-4-layer-stack(stack, true)
+  verify-stack-jlcpcb-2313(stack, true)
 
 ;Without the soldermask layer
-deftest(layerstack) make-4-layer-layer-stack-no-soldermask :
-  val prepreg = FR4(0.1, FR4-Material)
-  val core = FR4(1.265, FR4-Material)
-  val stack = make-layer-stack("4-Layer Stack with Soldermask", top-layers) where :
+deftest(layerstack) make-layer-stack-jlcpcb-2313-no-soldermask :
+  val copper-35um = Copper(0.035)
+  val prepreg-2313 = FR4(0.1, FR4-Material)
+  val copper-17_5um = Copper(0.0175)
+  val core-2313 = FR4(1.265, FR4-Material)
+  val stack = make-layer-stack("JLCPCB 4-layer 1.6mm", top-layers) where :
     val top-layers =  [
-      [copper-35um prepreg] 
-      [copper-17_5um core]
+      [copper-35um prepreg-2313] 
+      [copper-17_5um core-2313]
     ]
-  verify-4-layer-stack(stack, false)
-
-;Verify the layers with multiple adjacent prepreg layers
-; - insert the `adjacent-prepregs` layers right below the outer [copper prepreg] layers
-defn verify-4-layer-stack-with-adjacent-prepregs (stack:LayerStack, adjacent-prepregs:Tuple<LayerSpec>) :
-  val prepreg = FR4(0.1, FR4-Material)
-  val core = FR4(1.265, FR4-Material)
-  val top-layers = Vector<LayerSpec>()
-  add-all(top-layers, [copper-35um prepreg ])
-  add-all(top-layers, adjacent-prepregs)
-  add-all(top-layers, [copper-17_5um core])
-  verify-layers(stack, to-tuple $ top-layers)
-
-; Two adjacent prepreg layers
-; Example: "JLC04161H-7628A"
-deftest(layerstack) make-layer-stack-two-adjacent-prepreg-layers :
-  val prepreg = FR4(0.1, FR4-Material)
-  val prepreg2 = FR4(0.2, FR4-Material)
-  val core = FR4(1.265, FR4-Material)
-  val stack = make-layer-stack("4-layer with two adjacent prepreg layers", top-layers) where :
-    val top-layers =  [
-      [copper-35um prepreg]
-      prepreg2
-      [copper-17_5um core]
-    ]
-  verify-4-layer-stack-with-adjacent-prepregs(stack, [prepreg2])
-
-; Two adjacent prepreg layers
-; Example: "JLC04161H-7628A"
-deftest(layerstack) make-layer-stack-three-adjacent-prepreg-layers :
-  val prepreg = FR4(0.1, FR4-Material)
-  val prepreg2 = FR4(0.2, FR4-Material)
-  val prepreg3 = FR4(0.3, FR4-Material)
-  val core = FR4(1.265, FR4-Material)
-  val stack = make-layer-stack("4-layer with two adjacent prepreg layers", top-layers) where :
-    val top-layers =  [
-      [copper-35um prepreg]
-      prepreg2
-      prepreg3
-      [copper-17_5um core]
-    ]
-  verify-4-layer-stack-with-adjacent-prepregs(stack, [prepreg2 prepreg3])
+  verify-stack-jlcpcb-2313(stack, false)

--- a/tests/layerstack.stanza
+++ b/tests/layerstack.stanza
@@ -205,7 +205,7 @@ doc:\<DOC>
   The middle layer, at the bottom of the `top-layers` tuple, appears only once.
   The bottom layers are symmetric to the top layers in reverse order.
 
-  Usage Example:
+  Example 1: when even-layers? = false (the middle layer is a singleton)
   ```
     val top-layers = [
       soldermask
@@ -230,16 +230,45 @@ doc:\<DOC>
       soldermask
     ]
   ```  
+
+  Example 2: When even-layers? = true, the middle layer is also duplicated.
+  ```
+    val top-layers = [
+      copper-35um
+      prepreg 
+      copper-17_5um
+      core
+    ]
+    verify-layers(stack, top-layers, even-layers? = true)
+  ```
+  The expected `layers(stack)` equals
+  ```
+    [
+      copper-35um
+      prepreg 
+      copper-17_5um
+      core            ; the middle layer at top
+      core            ; the middle layer at bottom
+      copper-17_5um
+      prepreg
+      copper-35um
+    ]
+  ```  
 @param stack The LayerStack to verify
 @param top-layers the top layers, from the top of the stack to the middle layer.
 <DOC>
-public defn verify-layers (stack:LayerStack, top-layers:Tuple<LayerSpec>) :
-  #EXPECT(length(layers(stack)) == length(top-layers) * 2 - 1)
+public defn verify-layers (stack:LayerStack, top-layers:Tuple<LayerSpec>
+      -- even-layers? = false) :
+  if even-layers? :
+    #EXPECT(length(layers(stack)) == length(top-layers) * 2)
+  else :
+    #EXPECT(length(layers(stack)) == length(top-layers) * 2 - 1)
   val total-layers = length(layers(stack))
   val middle = total-layers / 2
   for idx in 0 through middle do :
-    #EXPECT(stack[idx] == top-layers[idx])
-    #EXPECT(stack[total-layers - 1 - idx] == top-layers[idx])
+    if not even-layers? or idx < length(top-layers) :
+      #EXPECT(stack[idx] == top-layers[idx])
+      #EXPECT(stack[total-layers - 1 - idx] == top-layers[idx])
 
 ;Verify the 4-layers stack
 defn verify-4-layer-stack (stack:LayerStack, soldermask?:True|False) :


### PR DESCRIPTION
- Revert the last commit for 'Enhance make-layer-stack to handle multiple adjacent prepreg layers'
and then re-commit it for review. 
   - This commit also removes the reference to JLCPCB in the examples/tests for layer-stack so that a generic 4-layer stack is used.
- Revise `verify-layers` to handle even number of layers in a stack.

In summary, the make-layer-stack is revised to support these two examples:
```
    make-layer-stack("4-layer stack with three adjacent prepreg layers", top-layers) where :
      val top-layers =  [
        [copper-35um [prepreg prepreg2 prepreg3]]
        [copper-17_5um core]
      ]
```
and
```
    make-layer-stack("6-layer stack with even number of layers", outers, even-layers? = true) where :
      val outers =
        [
          [copper-35um prepreg]
          [copper-17_5um core]
          [copper-17_5um prepreg2] ; => two layers of prepreg2 in the center
        ]
```