### PR TITLE
Removed ref to JITX package removed in latest `jitx-client` build

### DIFF
--- a/src/symbols/box-symbol.stanza
+++ b/src/symbols/box-symbol.stanza
@@ -9,7 +9,6 @@ defpackage jsl/symbols/box-symbol:
   import jitx
   import jitx/commands
   import jitx/utils/got
-  import jitx/schematic/analysis
 
   import jsl/ensure
   import jsl/design/Classable

--- a/src/symbols/box-symbol/utils.stanza
+++ b/src/symbols/box-symbol/utils.stanza
@@ -8,7 +8,6 @@ defpackage jsl/symbols/box-symbol/utils:
   import jitx
   import jitx/commands
   import jitx/utils/got
-  import jitx/schematic/analysis
   import jsl/ensure
   import jsl/symbols/utils
   import jsl/symbols/box-symbol/errors


### PR DESCRIPTION
This package has been removed in the latest `jitx-client` on `develop`. It causes JSL to break. I'm removing it here. I've tested the BoxSymbol implementation and it does not seem to suffer (still compiles, still runs).