### PR TITLE
Add the NetSymbol framework

### DIFF
--- a/examples/symbols/net-symbols.stanza
+++ b/examples/symbols/net-symbols.stanza
@@ -1,0 +1,84 @@
+#use-added-syntax(jitx)
+defpackage jsl/examples/symbols/net-symbols:
+  import core
+  import jitx
+  import jitx/commands
+
+  import jsl/design/settings
+  import jsl/landpatterns
+  import jsl/symbols
+
+  import jsl/symbols/net-symbols
+  import jsl/examples/landpatterns/board
+
+
+pcb-component R-test:
+  mpn = "XXXXX"
+  pin-properties :
+    [pin:Ref | pads:Ref ... | side:Dir | bank:Int]
+    [p[1] | p[1] | Left |  0]
+    [p[2] | p[2] | Right | 0]
+
+  val symb = ResistorSymbol()
+  assign-symbol(create-symbol(symb))
+
+  val pkg = get-chip-pkg("1206")
+
+  val lp = create-landpattern(pkg)
+  assign-landpattern(lp)
+
+pcb-component C-test:
+  mpn = "YYYYY"
+  pin-properties :
+    [pin:Ref | pads:Ref ... | side:Dir | bank:Int]
+    [p[1] | p[1] | Left |  0]
+    [p[2] | p[2] | Right | 0]
+
+  val symb = CapacitorSymbol()
+  assign-symbol(create-symbol(symb))
+
+  val pkg = get-chip-pkg("1206")
+
+  val lp = create-landpattern(pkg)
+  assign-landpattern(lp)
+
+
+
+pcb-module top-level:
+
+  inst R1 : R-test
+  inst C1 : C-test
+
+  net (R1.p[1], C1.p[1])
+
+  net GND (C1.p[2])
+
+  val gs = GroundSymbol()
+  val gs-symb = create-symbol(gs)
+
+  symbol(GND) = gs-symb
+
+  net VDD (R1.p[2])
+
+  val ps = PowerSymbol()
+  val ps-symb = create-symbol(ps)
+
+  symbol(VDD) = ps-symb
+
+
+val board-shape = RoundedRectangle(50.0, 50.0, 0.25)
+
+; Set the top level module (the module to be compile into a schematic and PCB)
+set-current-design("Ground-Symb-TEST")
+set-rules(default-rules)
+set-board(default-board(board-shape))
+
+set-main-module(top-level)
+
+; Use any helper function from helpers.stanza here. For example:
+; run-check-on-design(my-design)
+
+; View the results
+view-board()
+view-schematic()
+

--- a/src/symbols/net-symbols.stanza
+++ b/src/symbols/net-symbols.stanza
@@ -1,0 +1,8 @@
+#use-added-syntax(jitx)
+defpackage jsl/symbols/net-symbols :
+  forward jsl/symbols/net-symbols/framework
+  forward jsl/symbols/net-symbols/symbol-builder
+  forward jsl/symbols/net-symbols/ground-symbol
+  forward jsl/symbols/net-symbols/bar-ground
+  forward jsl/symbols/net-symbols/power-symbol
+  forward jsl/symbols/net-symbols/bar-power

--- a/src/symbols/net-symbols/bar-ground.stanza
+++ b/src/symbols/net-symbols/bar-ground.stanza
@@ -1,0 +1,113 @@
+#use-added-syntax(jitx)
+defpackage jsl/symbols/net-symbols/bar-ground:
+  import core
+  import jitx
+  import jitx/commands
+
+  import jsl/ensure
+  import jsl/errors
+  import jsl/symbols/framework
+  import jsl/symbols/net-symbols/symbol-builder
+
+public val DEF_GND_SYMB_LINE_WIDTH = 0.05
+public val DEF_GND_SYMB_PORCH_WIDTH = 0.5
+public val DEF_BAR_GND_SYMB_SPACING = 0.2
+public val DEF_BAR_GND_SYMB_LINES = [1.0, 0.6, 0.2]
+
+doc: \<DOC>
+Bar Ground Symbol Builder
+
+This builds a typical power ground net symbol consisting
+of 3 or more horizontal lines of decreasing length, evenly
+spaced in the -Y dimension.
+
+TODO - Diagram here.
+
+All units are in schematic symbol grid units.
+<DOC>
+public defstruct BarGroundSymbol <: SymbolBuilder :
+  doc: \<DOC>
+  Set the width of the constructed lines.
+  Default value is 0.05
+  <DOC>
+  line-width:Double with: (
+    ensure => ensure-positive!
+    updater => sub-line-width
+    default => DEF_GND_SYMB_LINE_WIDTH
+  )
+  doc: \<DOC>
+  Set the porch width of the net symbol
+
+  The porch width is the distance from the symbol pin to
+  the start of the first horizontal line in the -Y direction.
+  By default, this value is 0.5.
+  <DOC>
+  porch-width:Double with: (
+    ensure => ensure-positive!,
+    updater => sub-porch-width,
+    default => DEF_GND_SYMB_PORCH_WIDTH
+  )
+  doc: \<DOC>
+  Spacing between horizontal lines of this symbol
+
+  This parameter is used for consistent spacing
+  between all of the horizontal lines.
+  The default value is 0.2.
+  <DOC>
+  spacing:Double with: (
+    ensure => ensure-positive!,
+    updater => sub-spacing,
+    default => DEF_BAR_GND_SYMB_SPACING,
+  )
+  doc: \<DOC>
+  A set of lengths for the horizontal lines to construct.
+
+  The default set is [1.0, 0.6, 0.2]. This will
+  construct 3 horizontal lines starting with the longest at
+  the highest Y, and then going further negative in the
+  Y direction by `spacing` amount for each line there after.
+  <DOC>
+  lines:Tuple<Double> with: (
+    updater => sub-lines
+    default => DEF_BAR_GND_SYMB_LINES
+  )
+with:
+  constructor => #BarGroundSymbol
+  equalable => true
+
+doc: \<DOC>
+Constructor for the BarGroundSymbol
+<DOC>
+public defn BarGroundSymbol (
+  --
+  line-width:Double = DEF_GND_SYMB_LINE_WIDTH,
+  porch-width:Double = DEF_GND_SYMB_PORCH_WIDTH,
+  spacing:Double = DEF_BAR_GND_SYMB_SPACING,
+  lines:Tuple<Double> = DEF_BAR_GND_SYMB_LINES
+) -> BarGroundSymbol :
+  if length(lines) < 1:
+    throw $ ValueError("Invalid Lines - Must be at least length 1")
+  #BarGroundSymbol(line-width, porch-width, spacing, lines)
+
+defmethod value-label (x:BarGroundSymbol) -> Pose :
+  val text-margin = 0.1
+  val y = porch-width(x) +
+    (to-double((length(lines(x)) - 1)) * spacing(x)) +
+    (line-width(x) / 2.0) +
+    text-margin
+  loc(0.0, (- y))
+
+defmethod build-symbol-glyph (x:BarGroundSymbol, node:SymbolNode) :
+  line(node, [
+    Point(0.0, 0.0),
+    Point(0.0, (- porch-width(x)))
+  ], width = line-width(x))
+  val l-set = lines(x)
+  for i in 0 to length(l-set) do:
+    val lw = l-set[i] / 2.0
+    val y = (- porch-width(x)) - (to-double(i) * spacing(x))
+    line(node, [
+      Point((- lw), y),
+      Point(lw, y),
+    ], width = line-width(x))
+

--- a/src/symbols/net-symbols/bar-power.stanza
+++ b/src/symbols/net-symbols/bar-power.stanza
@@ -1,0 +1,64 @@
+#use-added-syntax(jitx)
+defpackage jsl/symbols/net-symbols/bar-power:
+  import core
+  import jitx
+  import jitx/commands
+
+  import jsl/ensure
+  import jsl/symbols/framework
+  import jsl/symbols/net-symbols/symbol-builder
+
+val DEF_PWR_SYMB_LINE_WIDTH = 0.05
+val DEF_PWR_SYMB_PORCH_WIDTH = 0.5
+val DEF_PWR_SYMB_BAR_WIDTH = 0.75
+
+public defstruct BarPowerSymbolParams <: SymbolBuilder :
+  line-width:Double with: (
+    ensure => ensure-positive!
+    updater => sub-line-width
+    default => DEF_PWR_SYMB_LINE_WIDTH
+  )
+  porch-width:Double with: (
+    ensure => ensure-positive!,
+    updater => sub-porch-width,
+    default => DEF_PWR_SYMB_PORCH_WIDTH
+  )
+  bar-width:Double with: (
+    ensure => ensure-positive!,
+    updater => sub-bar-width,
+    default => DEF_PWR_SYMB_BAR_WIDTH
+  )
+with:
+  constructor => #BarPowerSymbolParams
+  equalable => true
+
+public defn BarPowerSymbolParams (
+  --
+  line-width:Double = DEF_PWR_SYMB_LINE_WIDTH,
+  porch-width:Double = DEF_PWR_SYMB_PORCH_WIDTH,
+  bar-width:Double = DEF_PWR_SYMB_BAR_WIDTH
+  ) -> BarPowerSymbolParams :
+  #BarPowerSymbolParams(line-width, porch-width, bar-width)
+
+defmethod value-label (x:BarPowerSymbolParams) -> Pose :
+  val text-margin = 0.1
+  val y = porch-width(x) +
+    (line-width(x) / 2.0) +
+    text-margin
+  loc(0.0, y)
+
+defmethod build-symbol-glyph (x:BarPowerSymbolParams, node:SymbolNode) :
+
+  val y = porch-width(x)
+
+  line(node, [
+    Point(0.0, 0.0),
+    Point(0.0, y)
+  ], width = line-width(x))
+
+  val bw = bar-width(x)
+  line(node, [
+    Point((- bw), y),
+    Point(bw, y),
+  ], width = line-width(x))
+  false

--- a/src/symbols/net-symbols/framework.stanza
+++ b/src/symbols/net-symbols/framework.stanza
@@ -1,0 +1,61 @@
+#use-added-syntax(jitx)
+defpackage jsl/symbols/net-symbols/framework:
+  import core
+  import collections
+  import jitx
+  import jitx/commands
+
+  import jsl/utils
+  import jsl/symbols/framework
+
+public val NS-PINREF = Ref(`p)
+
+doc: \<DOC>
+Base Type for Net Symbols
+
+The user is expected to derive from this type and provide
+specific net symbol implementations like for Ground or
+voltage rail symbols.
+
+This implementation assumes that the net symbol connection
+location is at (0.0, 0.0). The user is expected to implement
+the graphical aspect of the symbol around that point. This
+pin is by default labeled `p[0]`
+
+This type is not intended to be instantiated on its down.
+It is more likely to be used for its interface definition
+and the base implementions of `SymbolDefn`
+
+<DOC>
+public defstruct NetSymbol <: SymbolDefn :
+  doc: \<DOC>
+  Optional Backend symbol substitution
+  The passed symbol definition can be used to replace the
+  net symbol with a backend specific definition. The
+  default is `None()`
+  <DOC>
+  backend-subs:Vector<KeyValue<String, SchematicSymbol>> with: (
+    default => Vector<KeyValue<String, SchematicSymbol>>()
+    )
+with:
+  constructor => #NetSymbol
+
+
+; This function exists so that derived types
+;  can include the base functionality.
+; Low likelihood that the derived types need to override `build-pins`
+public defn one-pin-build-pins (x:NetSymbol, node:SymbolNode) :
+  add-pin(node, NS-PINREF[0], [0.0, 0.0], name = "ns-pin-0" )
+
+public defmethod build-pins (x:NetSymbol, node:SymbolNode) :
+  one-pin-build-pins(x, node)
+
+; This function exists so that derived types
+;  can include the base functionality
+; Higher likelihood that the derived types need to override `build-params`
+;  Specifically to add the `>VALUE`
+public defn one-pin-build-params (x:NetSymbol, node:SymbolNode) :
+  add-backend-substitutions(node, backend-subs(x))
+
+public defmethod build-params (x:NetSymbol, node:SymbolNode) :
+  one-pin-build-params(x, node)

--- a/src/symbols/net-symbols/ground-symbol.stanza
+++ b/src/symbols/net-symbols/ground-symbol.stanza
@@ -1,0 +1,136 @@
+#use-added-syntax(jitx)
+defpackage jsl/symbols/net-symbols/ground-symbol:
+  import core
+  import collections
+  import jitx
+
+  import jsl/ensure
+  import jsl/symbols/framework
+  import jsl/symbols/net-symbols/framework
+  import jsl/symbols/net-symbols/symbol-builder
+  import jsl/symbols/net-symbols/bar-ground
+
+
+var DEF_GND_SYM_PARAMS = BarGroundSymbol()
+
+doc: \<DOC>
+Retrieve the default styling parameters for the ground symbol
+
+This is where the user can get the default net symbol styling
+for the `GroundSymbol()` type. By default it is a
+{@link /jsl/symbols/net-symbols/bar-ground/BarGroundSymbol}.
+
+<DOC>
+public defn get-default-gnd-symbol-builder () -> SymbolBuilder :
+  DEF_GND_SYM_PARAMS
+
+doc: \<DOC>
+Set the default styling parameters for the ground symbol
+
+This is where the user can set a new default styling for
+the `GroundSymbol()` type.
+
+@param v New {@link SymbolBuilder} that will implement the net symbol
+styling.
+<DOC>
+public defn set-default-gnd-symbol-builder (v:SymbolBuilder) -> False :
+  DEF_GND_SYM_PARAMS = v
+
+val DEF_GND_SYM_LABEL = 0.5
+val DEF_GND_SYM_NAME = "Ground-Symbol"
+
+doc: \<DOC>
+Ground Symbol Generator
+
+This type is used to define and construct net symbols
+for the ground signals.
+
+These net symbols are orientated such that their preferred
+orientation is 0 degrees. Most, if not all of the symbol lines
+will be drawn in the -Y half of the plane.
+
+The text label for the net of the net symbol is drawn with
+`N` anchor (ie, anchor centered and at the top of the text).
+
+Alternate ground symbols may be defined by constructing
+a type that implements the {@link SymbolBuilder} interface.
+This interface allows the user to define symbol construction
+using a {@link SymbolNode} scene graph and define the net label
+position.
+<DOC>
+public defstruct GroundSymbol <: NetSymbol :
+  doc: \<DOC>
+  Unique name for this ground symbol.
+  <DOC>
+  name : String with:
+    ; SymbolDefn
+    as-method  => true
+    default => DEF_GND_SYM_NAME
+  doc: \<DOC>
+  Backend Substitutions if any
+
+  See {@link NetSymbol} for more information.
+  <DOC>
+  backend-subs:Vector<KeyValue<String, SchematicSymbol>> with:
+    ; NetSymbol
+    as-method => true
+    default => Vector<KeyValue<String, SchematicSymbol>>()
+  doc: \<DOC>
+  Set the Label Size in Schematic Symbol Units
+
+  The symbol framework handles scaling this text into the right
+  physical dimensions.
+  <DOC>
+  label-size:Double with:
+    default => DEF_GND_SYM_LABEL
+    ensure => ensure-positive!
+  doc: \<DOC>
+  Set the explicit `SymbolBuilder` for rendered net symbol
+
+  This argument is optional and defaults to `None()`.
+  If `None()` - then the default symbol builder is queried from
+  {@link get-default-gnd-symbol-builder}.
+  If an explicit builder is provided, then this builder is used
+  to generate the symbol.
+  <DOC>
+  builder:Maybe<SymbolBuilder> with:
+    default => None()
+
+with:
+  constructor => #GroundSymbol
+
+defn get-builder (x:GroundSymbol) -> SymbolBuilder :
+  match(builder(x)):
+    (_:None): get-default-gnd-symbol-builder()
+    (v:One<SymbolBuilder>): value(v)
+
+doc: \<DOC>
+Constructor for a Ground Net Symbol
+<DOC>
+public defn GroundSymbol (
+  --
+  name:String = DEF_GND_SYM_NAME,
+  label-size:Double = DEF_GND_SYM_LABEL,
+  builder:SymbolBuilder = ?,
+  backend-subs:Seqable<KeyValue<String, SchematicSymbol>> = ?
+  ) -> GroundSymbol :
+
+  val b-subs = Vector<KeyValue<String, SchematicSymbol>>()
+  match(backend-subs):
+    (_:None): false
+    (v:One<Seqable<KeyValue<String, SchematicSymbol>>>):
+      add-all(b-subs, value(v))
+
+  #GroundSymbol(name, b-subs, label-size, builder)
+
+
+defmethod build-artwork (x:GroundSymbol, node:SymbolNode) :
+  val p = get-builder(x)
+  build-symbol-glyph(p, node)
+
+defmethod build-params (x:GroundSymbol, node:SymbolNode):
+  val p = get-builder(x)
+  one-pin-build-params(x, node)
+
+  add-value-label(node, value-label(p), anchor = N, unit-size = label-size(x))
+  set-preferred-orientation(node, PreferRotation([0]))

--- a/src/symbols/net-symbols/ground-symbol.stanza
+++ b/src/symbols/net-symbols/ground-symbol.stanza
@@ -134,3 +134,6 @@ defmethod build-params (x:GroundSymbol, node:SymbolNode):
 
   add-value-label(node, value-label(p), anchor = N, unit-size = label-size(x))
   set-preferred-orientation(node, PreferRotation([0]))
+
+public val GND-SYMB-GEN = GroundSymbol()
+public val GND-SYMB = create-symbol(GND-SYMB-GEN)

--- a/src/symbols/net-symbols/power-symbol.stanza
+++ b/src/symbols/net-symbols/power-symbol.stanza
@@ -1,0 +1,82 @@
+#use-added-syntax(jitx)
+defpackage jsl/symbols/net-symbols/power-symbol:
+  import core
+  import collections
+  import jitx
+  import jitx/commands
+
+  import jsl/ensure
+  import jsl/symbols/framework
+  import jsl/symbols/net-symbols/framework
+  import jsl/symbols/net-symbols/symbol-builder
+  import jsl/symbols/net-symbols/bar-power
+
+
+var DEF_PWR_SYM_PARAMS = BarPowerSymbolParams()
+public defn get-default-pwr-symbol-builder () -> SymbolBuilder :
+  DEF_PWR_SYM_PARAMS
+
+public defn set-default-pwr-symbol-builder (v:SymbolBuilder) -> False :
+  DEF_PWR_SYM_PARAMS = v
+
+val DEF_PWR_SYM_LABEL = 0.5
+val DEF_PWR_SYM_NAME = "Power-Symbol"
+
+public defstruct PowerSymbol <: NetSymbol :
+  name : String with: (
+    ; SymbolDefn
+    as-method  => true
+    default => DEF_PWR_SYM_NAME
+  )
+  backend-subs:Vector<KeyValue<String, SchematicSymbol>> with: (
+    ; NetSymbol
+    as-method => true
+    default => Vector<KeyValue<String, SchematicSymbol>>()
+    )
+  doc: \<DOC>
+  Set the Label Size in Schematic Symbol Units
+
+  The symbol framework handles scaling this text into the right
+  physical dimensions.
+  <DOC>
+  label-size:Double with:
+    default => DEF_PWR_SYM_LABEL
+    ensure => ensure-positive!
+  builder:Maybe<SymbolBuilder> with: (
+    default => None()
+  )
+with:
+  constructor => #PowerSymbol
+
+defn get-builder (x:PowerSymbol) -> SymbolBuilder :
+  match(builder(x)):
+    (_:None): get-default-pwr-symbol-builder()
+    (v:One<SymbolBuilder>): value(v)
+
+public defn PowerSymbol (
+  --
+  name:String = DEF_PWR_SYM_NAME,
+  label-size:Double = DEF_PWR_SYM_LABEL,
+  builder:SymbolBuilder = ?
+  backend-subs:Seqable<KeyValue<String, SchematicSymbol>> = ?
+  ) -> PowerSymbol :
+
+  val b-subs = Vector<KeyValue<String, SchematicSymbol>>()
+  match(backend-subs):
+    (_:None): false
+    (v:One<Seqable<KeyValue<String, SchematicSymbol>>>):
+      add-all(b-subs, value(v))
+
+  #PowerSymbol(name, b-subs, label-size, builder)
+
+
+defmethod build-artwork (x:PowerSymbol, node:SymbolNode) :
+  val p = get-builder(x)
+  build-symbol-glyph(p, node)
+
+defmethod build-params (x:PowerSymbol, node:SymbolNode):
+  val p = get-builder(x)
+  one-pin-build-params(x, node)
+
+  add-value-label(node, value-label(p), anchor = S, unit-size = label-size(x))
+  set-preferred-orientation(node, PreferRotation([0]))

--- a/src/symbols/net-symbols/power-symbol.stanza
+++ b/src/symbols/net-symbols/power-symbol.stanza
@@ -80,3 +80,6 @@ defmethod build-params (x:PowerSymbol, node:SymbolNode):
 
   add-value-label(node, value-label(p), anchor = S, unit-size = label-size(x))
   set-preferred-orientation(node, PreferRotation([0]))
+
+public val PWR-SYMB-GEN = PowerSymbol()
+public val PWR-SYMB = create-symbol(PWR-SYMB-GEN)

--- a/src/symbols/net-symbols/symbol-builder.stanza
+++ b/src/symbols/net-symbols/symbol-builder.stanza
@@ -1,0 +1,38 @@
+#use-added-syntax(jitx)
+defpackage jsl/symbols/net-symbols/symbol-builder:
+  import core
+  import jitx
+  import jitx/commands
+
+  import jsl/symbols/framework
+
+doc: \<DOC>
+Parameterized Symbol Builder
+
+This type defines the interface for the parameterized ground symbols
+to be constructed using this framework.
+<DOC>
+public deftype SymbolBuilder <: Equalable
+doc: \<DOC>
+Selects the position of the net label with respect to the symbol
+
+Typically, this will be net symbol type dependent. For example, the
+ground symbol builders all put this in the -Y half of the plane
+centered at X = 0.0. The -Y value will depend on the size of the
+created net symbol.
+@param x This `SymbolBuilder`
+<DOC>
+public defmulti value-label (x:SymbolBuilder) -> Pose
+doc: \<DOC>
+Symbol Glyphs Generator Function
+
+This is the function where the user creates the geometry
+of the rendered net symbol. The `node` object provides
+the net symbols scene graph. The user can choose to
+draw shapes and other content via the {@link SymbolNode}
+interface.
+
+@param x This `SymbolBuilder`
+@param node The scene graph object to draw content to.
+<DOC>
+public defmulti build-symbol-glyph (x:SymbolBuilder, node:SymbolNode) -> False


### PR DESCRIPTION
This implements a new framework for constructing parametrically generated net symbols.

Example:

![Screenshot 2024-07-15 at 4 38 02 PM](https://github.com/user-attachments/assets/de6ed6a2-4e01-4cfd-8006-3790c163e92d)
