### PR TITLE
Use lane-pair for PCIe

### DIFF
--- a/examples/protocols/pcie/pcie-src.stanza
+++ b/examples/protocols/pcie/pcie-src.stanza
@@ -151,10 +151,10 @@ public pcb-module module :
   val bd-4x = pcie(4)
   supports bd-4x :
     for i in 0 to 4 do :
-      bd-4x.data.rx[i].P => sw.PRXP[i]
-      bd-4x.data.rx[i].N => sw.PRXN[i]
-      bd-4x.data.tx[i].P => sw.PTXP[i]
-      bd-4x.data.tx[i].N => sw.PTXN[i]
+      bd-4x.data.lane[i].RX.P => sw.PRXP[i]
+      bd-4x.data.lane[i].RX.N => sw.PRXN[i]
+      bd-4x.data.lane[i].TX.P => sw.PTXP[i]
+      bd-4x.data.lane[i].TX.N => sw.PTXN[i]
     bd-4x.data.refclk.P => sw.REFCLKP[0]
     bd-4x.data.refclk.N => sw.REFCLKN[0]
 
@@ -165,10 +165,10 @@ public pcb-module module :
   val bd-4x-prsnt = pcie(4, PCIe-PRSNT#)
   supports bd-4x-prsnt :
     for i in 0 to 4 do :
-      bd-4x-prsnt.data.rx[i].P => sw.PRXP[i]
-      bd-4x-prsnt.data.rx[i].N => sw.PRXN[i]
-      bd-4x-prsnt.data.tx[i].P => sw.PTXP[i]
-      bd-4x-prsnt.data.tx[i].N => sw.PTXN[i]
+      bd-4x-prsnt.data.lane[i].RX.P => sw.PRXP[i]
+      bd-4x-prsnt.data.lane[i].RX.N => sw.PRXN[i]
+      bd-4x-prsnt.data.lane[i].TX.P => sw.PTXP[i]
+      bd-4x-prsnt.data.lane[i].TX.N => sw.PTXN[i]
     bd-4x-prsnt.data.refclk.P => sw.REFCLKP[0]
     bd-4x-prsnt.data.refclk.N => sw.REFCLKN[0]
 
@@ -186,10 +186,10 @@ public pcb-module module :
     supports bd-2x:
       val ch-offset = (2 * j)
       for i in 0 to 2 do :
-        bd-2x.data.rx[i].P => sw.PRXP[i + ch-offset]
-        bd-2x.data.rx[i].N => sw.PRXN[i + ch-offset]
-        bd-2x.data.tx[i].P => sw.PTXP[i + ch-offset]
-        bd-2x.data.tx[i].N => sw.PTXN[i + ch-offset]
+        bd-2x.data.lane[i].RX.P => sw.PRXP[i + ch-offset]
+        bd-2x.data.lane[i].RX.N => sw.PRXN[i + ch-offset]
+        bd-2x.data.lane[i].TX.P => sw.PTXP[i + ch-offset]
+        bd-2x.data.lane[i].TX.N => sw.PTXN[i + ch-offset]
       bd-2x.data.refclk.P => sw.REFCLKP[ch-offset]
       bd-2x.data.refclk.N => sw.REFCLKN[ch-offset]
 
@@ -204,10 +204,10 @@ public pcb-module module :
     supports bd-2x-prsnt:
       val ch-offset = (2 * j)
       for i in 0 to 2 do :
-        bd-2x-prsnt.data.rx[i].P => sw.PRXP[i + ch-offset]
-        bd-2x-prsnt.data.rx[i].N => sw.PRXN[i + ch-offset]
-        bd-2x-prsnt.data.tx[i].P => sw.PTXP[i + ch-offset]
-        bd-2x-prsnt.data.tx[i].N => sw.PTXN[i + ch-offset]
+        bd-2x-prsnt.data.lane[i].RX.P => sw.PRXP[i + ch-offset]
+        bd-2x-prsnt.data.lane[i].RX.N => sw.PRXN[i + ch-offset]
+        bd-2x-prsnt.data.lane[i].TX.P => sw.PTXP[i + ch-offset]
+        bd-2x-prsnt.data.lane[i].TX.N => sw.PTXN[i + ch-offset]
       bd-2x-prsnt.data.refclk.P => sw.REFCLKP[ch-offset]
       bd-2x-prsnt.data.refclk.N => sw.REFCLKN[ch-offset]
 
@@ -227,10 +227,10 @@ public pcb-module module :
   ]
   for j in 0 to 4 do:
     supports bd-1x:
-      bd-1x.data.rx[0].P => sw.PRXP[j]
-      bd-1x.data.rx[0].N => sw.PRXN[j]
-      bd-1x.data.tx[0].P => sw.PTXP[j]
-      bd-1x.data.tx[0].N => sw.PTXN[j]
+      bd-1x.data.lane[0].RX.P => sw.PRXP[j]
+      bd-1x.data.lane[0].RX.N => sw.PRXN[j]
+      bd-1x.data.lane[0].TX.P => sw.PTXP[j]
+      bd-1x.data.lane[0].TX.N => sw.PTXN[j]
       bd-1x.data.refclk.P => sw.REFCLKP[j]
       bd-1x.data.refclk.N => sw.REFCLKN[j]
 
@@ -242,10 +242,10 @@ public pcb-module module :
   val bd-1x-prsnt = pcie(1, PCIe-PRSNT#)
   for j in 0 to 4 do:
     supports bd-1x-prsnt:
-      bd-1x-prsnt.data.rx[0].P => sw.PRXP[j]
-      bd-1x-prsnt.data.rx[0].N => sw.PRXN[j]
-      bd-1x-prsnt.data.tx[0].P => sw.PTXP[j]
-      bd-1x-prsnt.data.tx[0].N => sw.PTXN[j]
+      bd-1x-prsnt.data.lane[0].RX.P => sw.PRXP[j]
+      bd-1x-prsnt.data.lane[0].RX.N => sw.PRXN[j]
+      bd-1x-prsnt.data.lane[0].TX.P => sw.PTXP[j]
+      bd-1x-prsnt.data.lane[0].TX.N => sw.PTXN[j]
       bd-1x-prsnt.data.refclk.P => sw.REFCLKP[j]
       bd-1x-prsnt.data.refclk.N => sw.REFCLKN[j]
 

--- a/src/protocols/displayport.stanza
+++ b/src/protocols/displayport.stanza
@@ -28,8 +28,7 @@ defpackage jsl/protocols/displayport:
 
   import jsl/bundles
   import jsl/errors
-  import jsl/si/helpers
-  import jsl/si/couplers
+  import jsl/si
   import jsl/pin-assignment
 
 

--- a/src/protocols/pcie.stanza
+++ b/src/protocols/pcie.stanza
@@ -114,8 +114,9 @@ and it also includes a refclk (100MHz) differential pair.
 public pcb-bundle pcie-data (lanes:Int) :
   name = "PCI-e Data"
   description = "PCI-e Serial Communications Link Data"
-  port rx : diff-pair[lanes]
-  port tx : diff-pair[lanes]
+  port lane : lane-pair[lanes]
+  ; port rx : diff-pair[lanes]
+  ; port tx : diff-pair[lanes]
   port refclk : diff-pair
 
 pcb-bundle pcie-control-b (pins:Collection<PCIePins>) :
@@ -153,20 +154,19 @@ arguments must both be of type `pcie` with equal lane counts.
 @param dst This is assumed to be the "Rx" side of the link. This is expected to be a port of `Bundle` type `pcie`
 @param cap Optional DC blocking capacitor to be inserted between the TX and RX pairs. Note that
 there are 2 blocking caps inserted, one on each of the P,N signals of the pair.
-
 <DOC>
 public defn connect-pcie-channel (sw:Toleranced, ml:Double, src:JITXObject, dst:JITXObject, cap:Instantiable|False) :
   inside pcb-module:
-    for i in indices(src.data.tx) do :
+    for i in indices(src.data.lane) do :
       match(cap) :
         (c:Instantiable) :
           inst bl-cap-xy : dp-coupler(c)
           require tx1 : dual-pair from bl-cap-xy
-          topo-net(src.data.tx[i], tx1.A)
-          topo-net(tx1.B, dst.data.rx[i])
+          topo-net(src.data.lane[i].TX, tx1.A)
+          topo-net(tx1.B, dst.data.lane[i].RX)
         (f:False) :
-          topo-net(src.data.tx[i], dst.data.rx[i])
-      constrain-ch(sw, ml, src.data.tx[i], dst.data.rx[i])
+          topo-net(src.data.lane[i].TX, dst.data.lane[i].RX)
+      constrain-ch(sw, ml, src.data.lane[i].TX, dst.data.lane[i].RX)
 
 doc: \<DOC>
 @brief Construct the PCIe Topology and Constraints
@@ -259,8 +259,8 @@ need to be connected to physical component pins either directly or via pin assig
 
 public defn pcie-apply-routing-structure (rs:DifferentialRoutingStructure, x:JITXObject, y:JITXObject) :
   inside pcb-module :
-    for i in indices(x.data.tx) do :
-      diff-structure(rs, x.data.tx[i] => y.data.rx[i])
-    for i in indices(y.data.tx) do :
-      diff-structure(rs, y.data.tx[i] => x.data.rx[i])
+    for i in indices(x.data.lane) do :
+      diff-structure(rs, x.data.lane[i].TX => y.data.lane[i].RX)
+    for i in indices(y.data.lane) do :
+      diff-structure(rs, y.data.lane[i].TX => x.data.lane[i].RX)
     diff-structure(rs, x.data.refclk => y.data.refclk)

--- a/src/protocols/pcie.stanza
+++ b/src/protocols/pcie.stanza
@@ -29,8 +29,7 @@ defpackage jsl/protocols/pcie:
 
   import jsl/bundles
   import jsl/errors
-  import jsl/si/helpers
-  import jsl/si/couplers
+  import jsl/si
   import jsl/pin-assignment
 
 

--- a/src/protocols/sata.stanza
+++ b/src/protocols/sata.stanza
@@ -27,9 +27,7 @@ defpackage jsl/protocols/sata:
   import jsl/errors
   import jsl/bundles
   import jsl/pin-assignment
-  import jsl/si/helpers
-  import jsl/si/pairs
-  import jsl/si/constraints
+  import jsl/si
 
 
 doc: \<DOC>


### PR DESCRIPTION
This PR is just to use of lane-pair in the PCIe code instead of explicit separate RX/TX.