### PR TITLE
revert the last commit after Carl's approval of v1

### DIFF
--- a/src/layerstack.stanza
+++ b/src/layerstack.stanza
@@ -551,74 +551,42 @@ public defn create-pcb-stackup (stack:LayerStack) :
 doc:\<DOC>
   Construct a LayerStack with a tuple of outer layers. 
 
-  Example 1: 4-Layer Stack with Soldermask
+  Example:
   ```
     val copper-35um = Copper(0.035)
     val copper-17_5um = Copper(0.0175)
-    val stack = make-layer-stack("4-Layer Stack with Soldermask", outer-layers,
+    val jlcpcb-jlc2313 = make-layer-stack("JLCPCB 4-layer 1.6mm", outer-layers,
       soldermask = soldermask) where :
       val soldermask = Soldermask(0.019, SoldermaskMaterial)
-      val prepreg = FR4(0.1, FR4-Material)
-      val core = FR4(1.265, FR4-Material)
+      val prepreg-2313 = FR4(0.1, FR4-Material-2313)
+      val core-2313 = FR4(1.265, FR4-Material-Core)
       val outer-layers = [
-        [copper-35um prepreg] 
-        [copper-17_5um core]
+        [copper-35um prepreg-2313] 
+        [copper-17_5um core-2313]
       ]
   ```
   The LayerStack created has these layers:
      [ soldermask
        copper-35um
-       prepreg
+       prepreg-2313
        copper-17_5um
-       core
+       core-2313
        copper-17_5um
-       prepreg
+       prepreg-2313
        copper-35um
        soldermask
      ]
-  
-  Example 2: 4-layer with two adjacent prepreg layers
-  ```
-    val copper-35um = Copper(0.035)
-    val prepreg = FR4(0.1, FR4-Material)
-    val copper-17_5um = Copper(0.0175)
-    val core = FR4(1.265, FR4-Material)
-    val stack = make-layer-stack("4-layer with two adjacent prepreg layers", top-layers) where :
-      val top-layers =  [
-        [copper-35um prepreg]
-        prepreg
-        [copper-17_5um core]
-      ]
-  ```
-  The LayerStack created has these layers:
-     [ copper-35um
-       prepreg
-       prepreg ; two adjacent prepreg layers
-       copper-17_5um
-       core
-       copper-17_5um
-       prepreg
-       prepreg
-       copper-35um
-     ]
-
   @param name The name of the LayerStack
   @param top-layers The pairs of mechanical and dielectric layers, from outer to inner layers.
   @param description The description of the LayerStack
 <DOC>
-public defn make-layer-stack (name:String, outers:Tuple<[LayerSpec, LayerSpec]|LayerSpec>
+public defn make-layer-stack (name:String, outers:Tuple<[LayerSpec, LayerSpec]>
       -- description:String = ?, soldermask:LayerSpec = ?) -> LayerStack :
   val stack = #LayerStack(One(name), description)
   ;Access pairs of outer-layers in reverse order
   for outer in in-reverse(outers) do:
-    match(outer):
-      (outer:LayerSpec):
-        ; add one prepreg layer to top and bottom
-        add-top(outer, stack)
-        add-bottom(outer, stack)
-      ([metal, insul]:[LayerSpec LayerSpec]):
-        ; add [copper, prepreg] layers to top and bottom
-        add-symmetric(metal, insul, stack)
+    val [metal, insul] = outer
+    add-symmetric(metal, insul, stack)
   if value?(soldermask) is LayerSpec :
     add-soldermask(value!(soldermask), stack) 
   stack

--- a/tests/layerstack.stanza
+++ b/tests/layerstack.stanza
@@ -1,7 +1,6 @@
 #use-added-syntax(jitx,tests)
 defpackage jsl/tests/layerstack:
   import core
-  import collections
   import jitx
   import jitx/commands
 
@@ -141,7 +140,6 @@ My Crazy Stack - each layer is different for testing
  10 - copper-105um
 ;<note>
 val test-stack = LayerStack(name = "My Crazy Stack")
-val copper-17_5um = Copper(0.0175, name = "cu1")
 val copper-35um = Copper(0.035, name = "cu1")
 val copper-70um = Copper(0.070, name = "cu2")
 val copper-105um = Copper(0.105, name = "cu3")
@@ -210,9 +208,9 @@ doc:\<DOC>
     val top-layers = [
       soldermask
       copper-35um
-      prepreg 
+      prepreg-2313 
       copper-17_5um
-      core
+      core-2313
     ]
     verify-layers(stack, top-layers)
   ```
@@ -221,11 +219,11 @@ doc:\<DOC>
     [
       soldermask
       copper-35um
-      prepreg 
+      prepreg-2313 
       copper-17_5um
-      core            ; the middle layer
+      core-2313       ; the middle layer
       copper-17_5um
-      prepreg
+      prepreg-2313
       copper-35um
       soldermask
     ]
@@ -233,7 +231,7 @@ doc:\<DOC>
 @param stack The LayerStack to verify
 @param top-layers the top layers, from the top of the stack to the middle layer.
 <DOC>
-public defn verify-layers (stack:LayerStack, top-layers:Tuple<LayerSpec>) :
+defn verify-layers (stack:LayerStack, top-layers:Tuple<LayerSpec>) :
   #EXPECT(length(layers(stack)) == length(top-layers) * 2 - 1)
   val total-layers = length(layers(stack))
   val middle = total-layers / 2
@@ -241,80 +239,49 @@ public defn verify-layers (stack:LayerStack, top-layers:Tuple<LayerSpec>) :
     #EXPECT(stack[idx] == top-layers[idx])
     #EXPECT(stack[total-layers - 1 - idx] == top-layers[idx])
 
-;Verify the 4-layers stack
-defn verify-4-layer-stack (stack:LayerStack, soldermask?:True|False) :
+;Verify the layers of jlcpcb2313 
+defn verify-stack-jlcpcb-2313 (stack:LayerStack, soldermask?:True|False) :
   val soldermask = [Soldermask(0.019, SoldermaskMaterial)]
     when soldermask? else []
-  val prepreg = FR4(0.1, FR4-Material)
-  val core = FR4(1.265, FR4-Material)
+  val copper-35um = Copper(0.035)
+  val prepreg-2313 = FR4(0.1, FR4-Material)
+  val copper-17_5um = Copper(0.0175)
+  val core-2313 = FR4(1.265, FR4-Material)
   val top-layers = to-tuple $ cat(soldermask, [
       copper-35um
-      prepreg 
+      prepreg-2313 
       copper-17_5um
-      core
+      core-2313
     ])
   verify-layers(stack, top-layers)
+  if soldermask? :
+    #EXPECT(length(conductors(stack)) == length(top-layers) - 1)
+  else :
+    #EXPECT(length(conductors(stack)) == length(top-layers))
 
 ;Use the function make-layer-stack to create a LayerStack from a tuple of LayerSpect
-deftest(layerstack) make-4-layer-stack :
+deftest(layerstack) make-layer-stack-jlcpcb-2313 :
   val soldermask = Soldermask(0.019, SoldermaskMaterial)
-  val prepreg = FR4(0.1, FR4-Material)
-  val core = FR4(1.265, FR4-Material)
-  val stack = make-layer-stack("4-Layer Stack without Soldermask", top-layers, soldermask = soldermask) where :
+  val copper-35um = Copper(0.035)
+  val prepreg-2313 = FR4(0.1, FR4-Material)
+  val copper-17_5um = Copper(0.0175)
+  val core-2313 = FR4(1.265, FR4-Material)
+  val stack = make-layer-stack("JLCPCB 4-layer 1.6mm", top-layers, soldermask = soldermask) where :
     val top-layers =  [
-      [copper-35um prepreg] 
-      [copper-17_5um core]
+      [copper-35um prepreg-2313] 
+      [copper-17_5um core-2313]
     ]
-  verify-4-layer-stack(stack, true)
+  verify-stack-jlcpcb-2313(stack, true)
 
 ;Without the soldermask layer
-deftest(layerstack) make-4-layer-layer-stack-no-soldermask :
-  val prepreg = FR4(0.1, FR4-Material)
-  val core = FR4(1.265, FR4-Material)
-  val stack = make-layer-stack("4-Layer Stack with Soldermask", top-layers) where :
+deftest(layerstack) make-layer-stack-jlcpcb-2313-no-soldermask :
+  val copper-35um = Copper(0.035)
+  val prepreg-2313 = FR4(0.1, FR4-Material)
+  val copper-17_5um = Copper(0.0175)
+  val core-2313 = FR4(1.265, FR4-Material)
+  val stack = make-layer-stack("JLCPCB 4-layer 1.6mm", top-layers) where :
     val top-layers =  [
-      [copper-35um prepreg] 
-      [copper-17_5um core]
+      [copper-35um prepreg-2313] 
+      [copper-17_5um core-2313]
     ]
-  verify-4-layer-stack(stack, false)
-
-;Verify the layers with multiple adjacent prepreg layers
-; - insert the `adjacent-prepregs` layers right below the outer [copper prepreg] layers
-defn verify-4-layer-stack-with-adjacent-prepregs (stack:LayerStack, adjacent-prepregs:Tuple<LayerSpec>) :
-  val prepreg = FR4(0.1, FR4-Material)
-  val core = FR4(1.265, FR4-Material)
-  val top-layers = Vector<LayerSpec>()
-  add-all(top-layers, [copper-35um prepreg ])
-  add-all(top-layers, adjacent-prepregs)
-  add-all(top-layers, [copper-17_5um core])
-  verify-layers(stack, to-tuple $ top-layers)
-
-; Two adjacent prepreg layers
-; Example: "JLC04161H-7628A"
-deftest(layerstack) make-layer-stack-two-adjacent-prepreg-layers :
-  val prepreg = FR4(0.1, FR4-Material)
-  val prepreg2 = FR4(0.2, FR4-Material)
-  val core = FR4(1.265, FR4-Material)
-  val stack = make-layer-stack("4-layer with two adjacent prepreg layers", top-layers) where :
-    val top-layers =  [
-      [copper-35um prepreg]
-      prepreg2
-      [copper-17_5um core]
-    ]
-  verify-4-layer-stack-with-adjacent-prepregs(stack, [prepreg2])
-
-; Two adjacent prepreg layers
-; Example: "JLC04161H-7628A"
-deftest(layerstack) make-layer-stack-three-adjacent-prepreg-layers :
-  val prepreg = FR4(0.1, FR4-Material)
-  val prepreg2 = FR4(0.2, FR4-Material)
-  val prepreg3 = FR4(0.3, FR4-Material)
-  val core = FR4(1.265, FR4-Material)
-  val stack = make-layer-stack("4-layer with two adjacent prepreg layers", top-layers) where :
-    val top-layers =  [
-      [copper-35um prepreg]
-      prepreg2
-      prepreg3
-      [copper-17_5um core]
-    ]
-  verify-4-layer-stack-with-adjacent-prepregs(stack, [prepreg2 prepreg3])
+  verify-stack-jlcpcb-2313(stack, false)


### PR DESCRIPTION
Revert the last commit after Carl's approval of v1.

That last commit has the following changes:
  - enhanced `make-layer-stack` to support multiple adjacent dieletric layers like `[copper [prepreg1 prepreg2]]`, which is found in many JLC-PCB stackup.
  - Specific references to JLC-PCB stackups like jlcpcb-2313 was removed so the examples are general

These changes are reverted.