### PR TITLE
Syntax Reform Updates for `layer()`

### DIFF
--- a/examples/protocols/common/example-board.stanza
+++ b/examples/protocols/common/example-board.stanza
@@ -138,28 +138,28 @@ public pcb-differential-routing-structure diff (trace-impedance:Toleranced|Doubl
     90.0 : 0.1475
     100.0 : 0.1510
   ; whatever layers are to be used for routing the differential pairs (defined by the user)
-  layer(Top) :
+  layer-constraints(Top) :
     trace-width  = tw       ; mm
     pair-spacing = tw / 1.2 ; mm
     clearance    = 0.150    ; mm
     velocity = 0.19e12      ; mm/s
     insertion-loss = 0.008  ; db/mm @ 1GHz
 
-  layer(LayerIndex(1, Top)) :
+  layer-constraints(LayerIndex(1, Top)) :
     trace-width  = tw       ; mm
     pair-spacing = 2.0 * tw ; mm
     clearance    = 0.300    ; mm
     velocity = 0.19e12      ; mm/s
     insertion-loss = 0.008  ; db/mm @ 1GHz
 
-  layer(LayerIndex(1, Bottom)) :
+  layer-constraints(LayerIndex(1, Bottom)) :
     trace-width  = tw       ; mm
     pair-spacing = 2.0 * tw ; mm
     clearance    = 0.300    ; mm
     velocity = 0.19e12      ; mm/s
     insertion-loss = 0.008  ; db/mm @ 1GHz
 
-  layer(Bottom) :
+  layer-constraints(Bottom) :
     trace-width  = tw       ; mm
     pair-spacing = tw / 1.2 ; mm
     clearance    = 0.150    ; mm
@@ -176,7 +176,7 @@ in the project code because they are dependant on the stack-up and other factors
 <DOC>
 public pcb-routing-structure se-50 :
   name = "50 Ohm single-ended"
-  layer(Top) :
+  layer-constraints(Top) :
     trace-width = 0.10    ; mm
     clearance = 0.15     ; mm
     velocity = 0.19e12   ; mm/s
@@ -186,7 +186,7 @@ public pcb-routing-structure se-50 :
       clearance = 0.1
     )
 
-  layer(Bottom) :
+  layer-constraints(Bottom) :
     trace-width = 0.10    ; mm
     clearance = 0.15         ; mm
     velocity = 0.19e12   ; mm/s

--- a/src/layerstack.stanza
+++ b/src/layerstack.stanza
@@ -256,7 +256,7 @@ public defn is-soldermask (m:LayerMaterial) -> True|False :
 ;<A>
 doc: \<DOC>
 Create a Copper layer
-  Usage: Copper(0.3) : specify thickness 
+  Usage: Copper(0.3) : specify thickness
          Copper(0.3, name = "Cu") : specify thickness and name
          Copper(0.3, CustomCuMaterial, name = "PWR") : specify thickness, material and name
 @param thickness thickness of the layer in mm
@@ -266,7 +266,7 @@ Create a Copper layer
 <DOC>
 public defn Copper (thickness:Double, material:ConductorMaterial = CopperMaterial
     -- name:String = ?, description:String = ?) -> LayerSpec :
-  #LayerSpec(name, description, material, thickness) 
+  #LayerSpec(name, description, material, thickness)
 
 doc: \<DOC>
 Create a Generic FR4 layer
@@ -280,7 +280,7 @@ Create a Generic FR4 layer
 <DOC>
 public defn FR4 (thickness:Double, material:DielectricMaterial = FR4-Material
     -- name:String = ?, description:String = ?) -> LayerSpec :
-  #LayerSpec(name, description, material, thickness) 
+  #LayerSpec(name, description, material, thickness)
 
 doc: \<DOC>
 Create a Generic Soldermask layer
@@ -291,9 +291,9 @@ Create a Generic Soldermask layer
 <DOC>
 public defn Soldermask (thickness:Double, material:DielectricMaterial = SoldermaskMaterial
     -- name:String = ?, description:String = ?) -> LayerSpec :
-  #LayerSpec(name, description, material, thickness) 
+  #LayerSpec(name, description, material, thickness)
 
-public defn make-layer-statement (x:LayerSpec) :
+public defn make-stack-statement (x:LayerSpec) :
   val name? = get-name(x)
   val t = thickness(x)
   val m? = material-def $ material(x)
@@ -304,9 +304,9 @@ public defn make-layer-statement (x:LayerSpec) :
   inside pcb-stackup:
     match(name?):
       (_:None):
-        layer(t, m as Material)
+        stack(t, m as Material)
       (v:One<String>):
-        layer(t, m as Material, value(v))
+        stack(t, m as Material, value(v))
 
 public defstruct LayerStack :
   name:Maybe<String>
@@ -338,15 +338,15 @@ doc:\<DOC>
   Get a layer by index
   Usage: stack[idx]
 <DOC>
-public defn get (stack:LayerStack, idx:Int) -> LayerSpec :
-  layers(stack)[idx]
+public defn get (ls:LayerStack, idx:Int) -> LayerSpec :
+  layers(ls)[idx]
 
 doc:\<DOC>
   Get the idx-th conductor layer
   Usage: conductors(stack)[idx]
 <DOC>
-public defn conductors (stack:LayerStack) -> Tuple<LayerSpec> :
-  to-tuple $ filter({material(_) is ConductorMaterial} layers(stack))
+public defn conductors (ls:LayerStack) -> Tuple<LayerSpec> :
+  to-tuple $ filter({material(_) is ConductorMaterial}, layers(ls))
 
 doc: \<DOC>
 Add one or more layers to the top of the board stackup.
@@ -472,8 +472,8 @@ Get the total number of conductor layers in the layer stack.
 This is the number of signal and plane layers that are available
 in this stackup.
 <DOC>
-public defn get-conductor-count (stack:LayerStack) -> Int :
-  length $ to-tuple $ for l in layers(stack) filter:
+public defn get-conductor-count (ls:LayerStack) -> Int :
+  length $ to-tuple $ for l in layers(ls) filter:
     material(l) is ConductorMaterial
 
 doc: \<DOC>
@@ -487,12 +487,12 @@ layers if any.
 @param index Conductor layer to inspect. This is a zero-based index
 where the top layer is 0, the first inner layer is 1, etc.
 <DOC>
-public defn get-conductor (stack:LayerStack, index:Int) -> [Maybe<LayerSpec>, LayerSpec, Maybe<LayerSpec>] :
+public defn get-conductor (ls:LayerStack, index:Int) -> [Maybe<LayerSpec>, LayerSpec, Maybe<LayerSpec>] :
   if index < 0:
     throw $ ValueError("Invalid Copper Layer Index: %_" % [index])
   var cnt = 0
-  val ls = layers(stack)
-  val cu-index? = for l in ls index-when:
+  val l-set = layers(ls)
+  val cu-index? = for l in l-set index-when:
     if material(l) is ConductorMaterial:
       val cu-match = cnt == index
       if not cu-match:
@@ -501,21 +501,21 @@ public defn get-conductor (stack:LayerStack, index:Int) -> [Maybe<LayerSpec>, La
 
   defn get-pre-dielectric (cu-index):
     if cu-index > 0:
-      One(ls[cu-index - 1])
+      One(l-set[cu-index - 1])
     else:
       None()
 
   defn get-post-dielectric (cu-index):
-    val num = length(ls)
+    val num = length(l-set)
     if cu-index < (num - 1):
-      One(ls[cu-index + 1])
+      One(l-set[cu-index + 1])
     else:
       None()
 
   match(cu-index?):
     (_:False): throw $ ValueError("No Copper Layer with Index: %_" % [index])
     (cu-index:Int):
-      [get-pre-dielectric(cu-index), ls[cu-index], get-post-dielectric(cu-index)]
+      [get-pre-dielectric(cu-index), l-set[cu-index], get-post-dielectric(cu-index)]
 
 defn make-name (x:LayerStack) :
   ; I can't use the `name` string in the pcb-stackup definition
@@ -537,19 +537,19 @@ defn make-description (x:LayerStack) :
       (d:One<String>):
         description = value(d)
 
-public defn create-pcb-stackup (stack:LayerStack) :
+public defn create-pcb-stackup (ls:LayerStack) :
 
   pcb-stackup custom-stackup :
-    make-name(stack)
-    make-description(stack)
+    make-name(ls)
+    make-description(ls)
 
-    for l in layers(stack) do:
-      make-layer-statement(l)
+    for l in layers(ls) do:
+      make-stack-statement(l)
 
   custom-stackup
 
 doc:\<DOC>
-  Construct a LayerStack with a tuple of outer layers. 
+  Construct a LayerStack with a tuple of outer layers.
 
   Example 1: 4-Layer Stack with Soldermask
   ```
@@ -561,7 +561,7 @@ doc:\<DOC>
       val prepreg = FR4(0.1, FR4-Material)
       val core = FR4(1.265, FR4-Material)
       val outer-layers = [
-        [copper-35um prepreg] 
+        [copper-35um prepreg]
         [copper-17_5um core]
       ]
   ```
@@ -576,7 +576,7 @@ doc:\<DOC>
        copper-35um
        soldermask
      ]
-  
+
   Example 2: 4-layer with two adjacent prepreg layers
   ```
     val copper-35um = Copper(0.035)
@@ -608,18 +608,18 @@ doc:\<DOC>
 <DOC>
 public defn make-layer-stack (name:String, outers:Tuple<[LayerSpec, LayerSpec]|LayerSpec>
       -- description:String = ?, soldermask:LayerSpec = ?) -> LayerStack :
-  val stack = #LayerStack(One(name), description)
+  val ls = #LayerStack(One(name), description)
   ;Access pairs of outer-layers in reverse order
   for outer in in-reverse(outers) do:
     match(outer):
       (outer:LayerSpec):
         ; add one prepreg layer to top and bottom
-        add-top(outer, stack)
-        add-bottom(outer, stack)
+        add-top(outer, ls)
+        add-bottom(outer, ls)
       ([metal, insul]:[LayerSpec LayerSpec]):
         ; add [copper, prepreg] layers to top and bottom
-        add-symmetric(metal, insul, stack)
+        add-symmetric(metal, insul, ls)
   if value?(soldermask) is LayerSpec :
-    add-soldermask(value!(soldermask), stack) 
-  stack
+    add-soldermask(value!(soldermask), ls)
+  ls
 

--- a/src/symbols/SymbolNode.stanza
+++ b/src/symbols/SymbolNode.stanza
@@ -518,7 +518,7 @@ defn make-full-vpin (vp:VirtualPin, scale:Double, pose:Pose) :
 
     val dec-pose =  pose * loc(pt) * dec-rot()
     for dec in decorators(vp) do:
-      layer("decorators") =  dec-pose * scale-shape(art(dec), scale)
+      draw("decorators") =  dec-pose * scale-shape(art(dec), scale)
 
 
 public defn make-vpin-symbol (vp:VirtualPin, scale:Double, pose:Pose = DEF_SYMNODE_POSE) :
@@ -536,7 +536,7 @@ public defn make-vpin-symbol (vp:VirtualPin, scale:Double, pose:Pose = DEF_SYMNO
         ;  the user should provide a parameters object
         val dec-pose = pose * loc(pt)
         for dec in decorators(vp) do:
-          layer("decorators") = dec-pose * scale-shape(art(dec), scale)
+          draw("decorators") = dec-pose * scale-shape(art(dec), scale)
 
       (x:One<VirtualPinParams>):
         make-full-vpin(vp, scale, pose)
@@ -545,7 +545,7 @@ public defn make-glyph-symbol (g:Glyph, scale:Double, pose:Pose = DEF_SYMNODE_PO
   inside pcb-symbol:
     val art* = scale-shape(pose * art(g), scale)
     val lname = build-layer-name $ name?(g)
-    layer( lname ) = art*
+    draw( lname ) = art*
 
 public defn make-symbol (sn:SymbolNode, parent-pose:Pose = DEF_SYMNODE_POSE) :
   inside pcb-symbol:


### PR DESCRIPTION
This PR needs to merge in sequence with the JITX 3.14 (PI) release which will have these syntax reforms. 