### PR TITLE
JSL: Revert VirtualCutout, augment artwork

### DIFF
--- a/src/landpatterns/VirtualLP.stanza
+++ b/src/landpatterns/VirtualLP.stanza
@@ -128,28 +128,6 @@ public defmethod make-landpattern (cu:VirtualCopper, pose:Pose = DEF_VLP_LOC) :
   inside pcb-landpattern:
     copper(layer-index(cu)) = pose * shape(cu)
 
-public defstruct VirtualCutout <: VirtualElement :
-  shape:Shape
-
-  ; Virtual Element
-  name?:Maybe<String> with: (as-method => true)
-  class:Vector<String> with: (as-method => true)
-with:
-  constructor => #VirtualCutout
-  printer => true
-
-public defn VirtualCutout (
-  shape:Shape
-  --
-  name?:Maybe<String> = None(),
-  class:Seqable<String>|String = []
-  ) -> VirtualCutout :
-  #VirtualCutout(shape, name?, to-class-vector(class))
-
-public defmethod make-landpattern (p:VirtualCutout, pose:Pose = DEF_VLP_LOC) :
-  inside pcb-landpattern:
-    layer(Cutout()) = pose * shape(p)
-
 public defstruct VirtualArtwork <: VirtualElement :
   layer-spec:LayerSpecifier
   shape:Shape
@@ -217,12 +195,6 @@ public defstruct VirtualLP <: VirtualElement :
   metal:Vector<VirtualCopper>
 
   doc: \<DOC>
-  Virtual `cutout` statements as placed in the virtual landpattern
-  frame of reference.
-  <DOC>
-  cutouts:Vector<VirtualCutout>
-
-  doc: \<DOC>
   Kinematic transform of this node of the virtual landpattern tree.
 
   This pose will be applied to the reference frame of this node.
@@ -262,7 +234,6 @@ defn VirtualLP (
     Vector<VirtualPad>(),
     Vector<VirtualArtwork>(),
     Vector<VirtualCopper>(),
-    Vector<VirtualCutout>(),
     pose,
     name?,
     to-class-vector(class)
@@ -283,7 +254,6 @@ public defn VirtualLP (
     Vector<VirtualPad>(),
     Vector<VirtualArtwork>(),
     Vector<VirtualCopper>(),
-    Vector<VirtualCutout>(),
     pose,
     name?,
     to-class-vector(class)
@@ -394,6 +364,33 @@ public defn add-artwork (
   append-all(vp, new-art)
 
 doc: \<DOC>
+  Add a cutout to the landpattern with a given shape.
+<DOC>
+public defn add-cutout (
+  vp:VirtualLP,
+  shape:Shape
+  --
+  name:String = ?,
+  class:Seqable<String>|String = []
+  ) -> False:
+  append(vp, VirtualArtwork(Cutout(), shape, name? = name, class = class))
+
+doc: \<DOC>
+  Add keepout regions to the landpattern with a sequence of given shapes.
+<DOC>
+public defn add-keepouts (
+  vp:VirtualLP,
+  shapes:Seqable<Shape>
+  --
+  start:LayerIndex = LayerIndex(0)
+  end:LayerIndex = LayerIndex(0)
+  name:String = ?,
+  class:Seqable<String>|String = []
+  ) -> False:
+  for s in shapes do :
+    append(vp, VirtualArtwork(ForbidCopper(start, end), s, name? = name, class = class))
+
+doc: \<DOC>
 Create a reference designator in the current virtual landpattern
 
 
@@ -495,27 +492,6 @@ public defn add-copper (
     VirtualCopper(li, sh, class = class)
   append-all(vp, new-cu)
 
-public defn add-cutout (
-  vp:VirtualLP,
-  shape:Shape
-  --
-  name:String = ?,
-  class:Seqable<String>|String = []
-  ) -> False:
-  append(vp, VirtualCutout(shape, name? = name, class = class))
-
-doc: \<DOC>
-Add a virtual `cutout` statement to virtual landpattern
-<DOC>
-public defn append (vp:VirtualLP, cu:VirtualCutout) -> False:
-  add{_, cu} $ cutouts(vp)
-
-doc: \<DOC>
-Add multiple virtual `cutout` statements to virtual landpattern
-<DOC>
-public defn append-all (vp:VirtualLP, cus:Seqable<VirtualCutout>) -> False:
-  add-all{_, cus} $ cutouts(vp)
-
 doc: \<DOC>
 Add a new child virtual landpattern node
 @param vp Self
@@ -560,7 +536,7 @@ This does not search recursively into the children, it just
 reports the elements of this node.
 <DOC>
 public defn elements (vp:VirtualLP) -> Seqable<VirtualElement> :
-  for grp in [lands(vp), artwork(vp), metal(vp), cutouts(vp)] seq-cat:
+  for grp in [lands(vp), artwork(vp), metal(vp)] seq-cat:
     for elem in grp seq:
       elem as VirtualElement
 
@@ -637,8 +613,8 @@ public defn get-first-pad (vp:VirtualLP) -> VirtualPad :
   reduce(earlier-pad, pads)
 
 ; Converters
-#for (vType in [VirtualPad, VirtualArtwork, VirtualCopper, VirtualCutout, VirtualLP]
-  funcName in [as-VirtualPad, as-VirtualArtwork, as-VirtualCopper, as-VirtualCutout ,as-VirtualLP]) :
+#for (vType in [VirtualPad, VirtualArtwork, VirtualCopper, VirtualLP]
+  funcName in [as-VirtualPad, as-VirtualArtwork, as-VirtualCopper ,as-VirtualLP]) :
   public defn funcName (e:VirtualElement) -> vType :
     e as vType
 

--- a/src/landpatterns/packages.stanza
+++ b/src/landpatterns/packages.stanza
@@ -364,35 +364,6 @@ public defmethod build-cut-out (
   false
 
 doc: \<DOC>
-Generator for creating cutout regions in the landpattern.
-
-This generator is typically called within a `pcb-landpattern`
-definition to create the `Cutout()` layer regions for this component.
-
-@param pkg IC Package for which we are creating silkscreen artwork
-@param pkg pose Offset to apply to all of the geometry generated
-by this generator function. By default, no offset is applied.
-<DOC>
-public defmulti make-cut-out (
-  pkg:Package
-  --
-  pose:Pose = ?
-  )
-
-doc: \<DOC>
-Default Generator `make-cut-out` - Constructs the cutouts only.
-<DOC>
-public defmethod make-cut-out (
-  pkg:Package
-  --
-  pose:Pose = DEF_LP_POSE
-  ):
-  inside pcb-landpattern:
-    val virt = VirtualLP(pose)
-    build-cut-out(pkg, virt)
-    make-landpattern(virt)
-
-doc: \<DOC>
 Create conformal coat mask regions in a virtual landpattern
 
 This function is used to build the landpattern's

--- a/tests/landpatterns/VirtualLP.stanza
+++ b/tests/landpatterns/VirtualLP.stanza
@@ -243,16 +243,20 @@ deftest(virtual-lp) test-find-by-class:
   val no-elems = to-tuple $ find-by-class(root, "asdfasdf")
   #EXPECT(length(no-elems) == 0)
 
-deftest(virtual-lp) test-cutout-layer :
+deftest(virtual-lp) test-artwork-layer :
   val root = VirtualLP()
 
   ; Simple single cutout layer Landpattern test
-  append(root, VirtualCutout(Circle(0.5)))
-
+  add-cutout(root, Circle(0.5))
+  add-keepouts(root, [Circle(1.0), Circle(2.0)])
+  add-keepouts(root, [Circle(3.0)], start = LayerIndex(1), end = LayerIndex(2))
   ; Generate the landpattern
   pcb-landpattern simple:
     make-landpattern(root)
 
   val layers = layers(simple)
-  #EXPECT(length(layers) == 1)
+  #EXPECT(length(layers) == 4)
   #EXPECT(specifier(layers[0]) == Cutout())
+  #EXPECT(specifier(layers[1]) == ForbidCopper(LayerIndex(0), LayerIndex(0)))
+  #EXPECT(specifier(layers[2]) == ForbidCopper(LayerIndex(0), LayerIndex(0)))
+  #EXPECT(specifier(layers[3]) == ForbidCopper(LayerIndex(1), LayerIndex(2)))


### PR DESCRIPTION
This diff reverts unnecessary addition of VirtualCutout and adds helper functions to create `Cutout()` and `ForbidCopper()` regions using `VirtualArtwork`