### PR TITLE
Added methods to support pin extraction for 2-pin devices

### DIFF
--- a/src/design/introspection.stanza
+++ b/src/design/introspection.stanza
@@ -47,11 +47,11 @@ public defn get-port-by-name (obj:JITXObject, name:String) -> Maybe<JITXObject> 
     return(None())
 
 doc: \<DOC>
-Get the Cathode / Anode Pins of a device if they exist
+Get the Cathode / Anode Ports of a device if they exist
 @param obj Two-pin component or module instance that may or
-may not be a polarized device with cathode (`c`) and anode (`a`) pins.
+may not be a polarized device with cathode (`c`) and anode (`a`) ports.
 @return If the passed object is a polarized device, then this returns
-One<Tuple> of the pins in the order `[c, a]`. If not a polarized device,
+One<Tuple> of the ports in the order `[c, a]`. If not a polarized device,
 this function returns `None()`
 <DOC>
 public defn cathode-anode? (obj:JITXObject) -> Maybe<[JITXObject, JITXObject]> :
@@ -62,26 +62,27 @@ public defn cathode-anode? (obj:JITXObject) -> Maybe<[JITXObject, JITXObject]> :
     (x,y): None()
 
 doc: \<DOC>
-Retrieve the two pins of a 2-pin device.
+Retrieve the two ports of a 2-pin element device.
 
-Two-pin devices come typically in one of two forms:
+Two-pin lumped circuit element devices (like resistors, capacitors, etc)
+come typically in one of two forms:
 
 1.  The `p[1]` and `p[2]` form for non-polatized devices.
 2.  The `c` and `a` form for the cathode / anode of polarized
 devices.
 
-This function interrogates an object and retrievs the pins
+This function interrogates an object and retrieves the ports
 in a known order for use in circuits.
 
 @param obj Two-Pin component or module instance
-@return Tuple of two pins of the component - They are returned either as:
+@return Tuple of two ports of the component - They are returned either as:
 1.  `[p[1], p[2]]`
 2.  `[c, a]`
 
 Depending on whether the passed device is polarized.
 
 <DOC>
-public defn get-pins (obj:JITXObject) -> [JITXObject, JITXObject] :
+public defn get-element-ports (obj:JITXObject) -> [JITXObject, JITXObject] :
   val mCA = cathode-anode?(obj)
   match(mCA):
     (given:One<[JITXObject, JITXObject]>): value(given)

--- a/src/design/introspection.stanza
+++ b/src/design/introspection.stanza
@@ -24,3 +24,49 @@ public defn get-instantiable (comps:JITXObject|InstantiableType) -> Instantiable
       get-instantiable(base(hc-arr))
     (hc-inst:Instantiable):
       hc-inst
+
+
+doc: \<DOC>
+Get the Cathode / Anode Pins of a device if they exist
+@param obj Two-pin component or module instance that may or
+may not be a polarized device with cathode (`c`) and anode (`a`) pins.
+@return If the passed object is a polarized device, then this returns
+One<Tuple> of the pins in the order `[c, a]`. If not a polarized device,
+this function returns `None()`
+<DOC>
+public defn get-cathode-anode (obj:JITXObject) -> Maybe<[JITXObject, JITXObject]> :
+  val mC = get-pin-by-name(obj, "c")
+  val mA = get-pin-by-name(obj, "a")
+  match(mC, mA) :
+    (oC:One<JITXObject>, oA:One<JITXObject>): One([value(oC), value(oA)])
+    (x,y): None()
+
+doc: \<DOC>
+Retrieve the two pins of a 2-pin device.
+
+Two-pin devices come typically in one of two forms:
+
+1.  The `p[1]` and `p[2]` form for non-polatized devices.
+2.  The `c` and `a` form for the cathode / anode of polarized
+devices.
+
+This function interrogates an object and retrievs the pins
+in a known order for use in circuits.
+
+@param obj Two-Pin component or module instance
+@return Tuple of two pins of the component - They are returned either as:
+1.  `[p[1], p[2]]`
+2.  `[c, a]`
+
+Depending on whether the passed device is polarized.
+
+<DOC>
+public defn get-pins (obj:JITXObject) -> [JITXObject, JITXObject] :
+  val mCA = get-cathode-anode(obj)
+  match(mCA):
+    (oCA:One<[JITXObject, JITXObject]>):
+      val ret = value(oCA)
+      ret
+    (_:None):
+      [obj.p[1], obj.p[2]]
+

--- a/src/design/introspection.stanza
+++ b/src/design/introspection.stanza
@@ -25,6 +25,26 @@ public defn get-instantiable (comps:JITXObject|InstantiableType) -> Instantiable
     (hc-inst:Instantiable):
       hc-inst
 
+doc: \<DOC>
+Retrieve a Port by its symbol name
+
+This function retrieves a port on a component but doesn't
+throw an error if that port does not exist.
+
+@param obj Component or Module to interrogate for a port
+@param name Name of port to interrogate. This name can include
+dot-notation style introspection if needed.
+@return `None()` if no port by this name exists.
+`One<JITXObject>` if a port is found by the passed name.
+<DOC>
+public defn get-port-by-name (obj:JITXObject, name:String) -> Maybe<JITXObject> :
+  label<Maybe<JITXObject>> return:
+    val pat = to-string(".%_" % [name])
+    for p in pins(obj) do:
+      val refName = to-string $ ref(p)
+      if suffix?(refName, pat) :
+        return(One(p))
+    return(None())
 
 doc: \<DOC>
 Get the Cathode / Anode Pins of a device if they exist
@@ -34,9 +54,9 @@ may not be a polarized device with cathode (`c`) and anode (`a`) pins.
 One<Tuple> of the pins in the order `[c, a]`. If not a polarized device,
 this function returns `None()`
 <DOC>
-public defn get-cathode-anode (obj:JITXObject) -> Maybe<[JITXObject, JITXObject]> :
-  val mC = get-pin-by-name(obj, "c")
-  val mA = get-pin-by-name(obj, "a")
+public defn cathode-anode? (obj:JITXObject) -> Maybe<[JITXObject, JITXObject]> :
+  val mC = get-port-by-name(obj, "c")
+  val mA = get-port-by-name(obj, "a")
   match(mC, mA) :
     (oC:One<JITXObject>, oA:One<JITXObject>): One([value(oC), value(oA)])
     (x,y): None()
@@ -62,11 +82,9 @@ Depending on whether the passed device is polarized.
 
 <DOC>
 public defn get-pins (obj:JITXObject) -> [JITXObject, JITXObject] :
-  val mCA = get-cathode-anode(obj)
+  val mCA = cathode-anode?(obj)
   match(mCA):
-    (oCA:One<[JITXObject, JITXObject]>):
-      val ret = value(oCA)
-      ret
+    (given:One<[JITXObject, JITXObject]>): value(given)
     (_:None):
       [obj.p[1], obj.p[2]]
 

--- a/stanza.proj
+++ b/stanza.proj
@@ -30,5 +30,6 @@ build-test tests:
     jsl/tests/si/Microstrip
     jsl/tests/si/couplers
     jsl/tests/si/signal-ends
+    jsl/tests/design/introspection
   pkg: "test-pkgs"
   o: "jsl-tests"

--- a/tests/design/introspection.stanza
+++ b/tests/design/introspection.stanza
@@ -1,0 +1,66 @@
+#use-added-syntax(jitx,tests)
+defpackage jsl/tests/design/introspection:
+  import core
+  import jitx
+  import jitx/commands
+
+
+  import jsl/design/introspection
+  import jsl/design/settings
+  import jsl/landpatterns
+  import jsl/symbols
+
+
+pcb-component two-pin-non-polar :
+  port p : pin[[1, 2]]
+
+  pin-properties :
+    [pin:Ref | pads:Ref ... | side:Dir | bank:Int]
+    [p[1] | p[1] | Up |  0]
+    [p[2] | p[2] | Down | 0]
+
+
+  val symb = CapacitorSymbol()
+  assign-symbol(create-symbol(symb))
+
+  val pkg = get-chip-pkg("1206")
+  val lp = create-landpattern(pkg)
+  assign-landpattern(lp)
+
+pcb-component two-pin-polar :
+  port a : pin
+  port c : pin
+
+  pin-properties :
+    [pin:Ref | pads:Ref ... | side:Dir | bank:Int]
+    [a | p[1] | Up |  0]
+    [c | p[2] | Down | 0]
+
+
+  val symb-gen = CapacitorSymbol()
+  val symb = create-symbol(symb-gen)
+
+  symbol = symb(a => symb.p[1], c => symb.p[2])
+  ; assign-symbol(create-symbol(symb))
+
+  val pkg = get-chip-pkg("1206")
+  val lp = create-landpattern(pkg)
+  assign-landpattern(lp)
+
+deftest(design_introspection) test-port-introspection :
+
+  pcb-module uut:
+    inst B : two-pin-non-polar
+    inst D : two-pin-polar
+
+    val obs = get-pins(B)
+    #EXPECT(length(obs) == 2)
+    #EXPECT(to-string(ref(obs[0])) == "B.p[1]")
+    #EXPECT(to-string(ref(obs[1])) == "B.p[2]")
+
+    val obs2 = get-pins(D)
+    #EXPECT(length(obs2) == 2)
+    #EXPECT(to-string(ref(obs2[0])) == "D.c")
+    #EXPECT(to-string(ref(obs2[1])) == "D.a")
+
+  set-main-module(uut)

--- a/tests/design/introspection.stanza
+++ b/tests/design/introspection.stanza
@@ -41,7 +41,6 @@ pcb-component two-pin-polar :
   val symb = create-symbol(symb-gen)
 
   symbol = symb(a => symb.p[1], c => symb.p[2])
-  ; assign-symbol(create-symbol(symb))
 
   val pkg = get-chip-pkg("1206")
   val lp = create-landpattern(pkg)
@@ -53,12 +52,12 @@ deftest(design_introspection) test-port-introspection :
     inst B : two-pin-non-polar
     inst D : two-pin-polar
 
-    val obs = get-pins(B)
+    val obs = get-element-ports(B)
     #EXPECT(length(obs) == 2)
     #EXPECT(to-string(ref(obs[0])) == "B.p[1]")
     #EXPECT(to-string(ref(obs[1])) == "B.p[2]")
 
-    val obs2 = get-pins(D)
+    val obs2 = get-element-ports(D)
     #EXPECT(length(obs2) == 2)
     #EXPECT(to-string(ref(obs2[0])) == "D.c")
     #EXPECT(to-string(ref(obs2[1])) == "D.a")


### PR DESCRIPTION
This adds a function for checking if a 2-pin component is the `p[1]/p[2]` version or the `c/a` version and returning the pins in a known order.