### PR TITLE
Virtual LP FIxups to Support ethernet connector

### DIFF
--- a/src/landpatterns/BGA/package.stanza
+++ b/src/landpatterns/BGA/package.stanza
@@ -221,37 +221,6 @@ public defn build-outline (
   val outline = compute-outline(vp, body, density-level)
   add-artwork(vp, Silkscreen("outline", Top), outline, class = "outline")
 
-public defn build-triangle-marker (
-  vp:VirtualLP
-  --
-  pin-1-id:Int|Ref = 1,
-  side:Side = Top
-  ):
-  val o-sh = get-silkscreen-outline!(vp)
-
-  val pin-1-pad = get-pad-by-ref!(vp, pin-1-id)
-
-  ; The Outline is typically a line rectangle which creates a
-  ;  single line. We use this to determine the line width
-  ;  so that we can place the marker in the mid-line
-  val line-width = match(o-sh):
-    (x:Line): width(x)
-    ; TODO - this probably should be a setting
-    (_): 0.1
-
-  val o-box = bounds $ o-sh
-
-  val pin-1-pos = center $ pose(pin-1-pad)
-
-  val marker = compute-triangle-marker(pin-1-pos, o-box, line-width)
-
-  add-artwork(
-    vp, Silkscreen("pin-1-marker", side),
-    marker,
-    name = "pin-1-triangle",
-    class = "pin-1-marker"
-    )
-
 public defn build-pin-1-marker (
   vp:VirtualLP
   --
@@ -260,7 +229,9 @@ public defn build-pin-1-marker (
   line-width:Double = default-silk-width(),
   mask-clearance:Double = default-mask-clearance(),
   ):
-  val o-sh = get-silkscreen-outline!(vp)
+  val outline = get-silkscreen-outline!(vp)
+  val o-sh = shape(outline)
+
   val pin-1-pos = center $ pose $ get-pad-by-ref!(vp, pin-1-id)
 
   val o-box = bounds $ o-sh
@@ -291,5 +262,5 @@ public defmethod build-silkscreen (
     (_) : pad-id(get-first-pad(vp))
   build-outline(vp, package-body(pkg), density-level(pkg))
   build-pin-1-marker(vp, pin-1-id = pin-1-id)
-  build-triangle-marker(vp, pin-1-id = pin-1-id)
+  build-outline-pin-1-triangle(vp, pin-1-id = pin-1-id)
   add-reference-designator(vp)

--- a/src/landpatterns/QFN.stanza
+++ b/src/landpatterns/QFN.stanza
@@ -237,17 +237,7 @@ public defn QFN-pin-1-marker (
   add-artwork(vp, Silkscreen("pin-1-marker", side), marker-geom, name = "pin-1-dot", class = "pin1-marker")
 
   if density-level(pkg) == DensityLevelA :
-    val outline = get-silkscreen-outline!(vp)
-    val o-box = bounds(outline)
-
-    val marker = compute-triangle-marker(pad-center, o-box, line-width)
-    add-artwork(
-      vp, Silkscreen("pin-1-marker", side),
-      marker,
-      name = "pin-1-triangle",
-      class = "pin-1-marker"
-      )
-
+    build-outline-pin-1-triangle(vp)
 
 public defmethod build-silkscreen (
   pkg:QFN,

--- a/src/landpatterns/SOIC.stanza
+++ b/src/landpatterns/SOIC.stanza
@@ -40,7 +40,7 @@ defpackage jsl/landpatterns/SOIC:
   import jsl/landpatterns/numbering
   import jsl/landpatterns/packages
   import jsl/landpatterns/VirtualLP
-
+  import jsl/landpatterns/silkscreen
 
 val SOIC-DEF-PITCH = 1.27
 
@@ -288,5 +288,5 @@ public defmethod build-silkscreen (
   ) -> False :
   build-pkg-body-outline(pkg, vp)
   build-smd-pin-1(pkg, vp)
-  build-outline-pin-1(pkg, vp)
+  build-outline-pin-1-triangle(vp)
   add-reference-designator(vp)

--- a/src/landpatterns/SON.stanza
+++ b/src/landpatterns/SON.stanza
@@ -265,16 +265,7 @@ public defn SON-pin-1-marker (
   add-artwork(vp, Silkscreen("pin-1-marker", side), marker-geom, name = "pin-1-dot", class = "pin1-marker")
 
   if density-level(pkg) == DensityLevelA :
-    val outline = get-silkscreen-outline!(vp)
-    val o-box = bounds(outline)
-
-    val marker = compute-triangle-marker(pad-center, o-box, line-width)
-    add-artwork(
-      vp, Silkscreen("pin-1-marker", side),
-      marker,
-      name = "pin-1-triangle",
-      class = "pin-1-marker"
-      )
+    build-outline-pin-1-triangle(vp)
 
 
 public defmethod build-silkscreen (

--- a/src/landpatterns/VirtualLP.stanza
+++ b/src/landpatterns/VirtualLP.stanza
@@ -362,13 +362,22 @@ public defn get-copper (vp:VirtualLP, li:LayerIndex) -> Tuple<VirtualCopper> :
 public defn get-coppers (vp:VirtualLP) -> Tuple<VirtualCopper> :
   to-tuple $ metal(vp)
 
-public defn get-silkscreen-outline! (vp:VirtualLP) -> Shape :
+doc: \<DOC>
+Retrieve the silkscreen outline shape as a `VirtualArtwork` object.
+
+This function looks for a `VirtualArtwork` object with class `outline`.
+If it finds a single object meeting this description - it will be
+returned. Otherwise it throws a `ValueError`
+
+This function will search recursively through the passed `vp` node
+and all child nodes for the `outline` artwork.
+<DOC>
+public defn get-silkscreen-outline! (vp:VirtualLP) -> VirtualArtwork :
   val outlines = to-tuple $ seq{as-VirtualArtwork, _} $ find-by-class(vp, "outline")
   if length(outlines) != 1:
     throw $ ValueError("Expected only one element in class 'outline': %," % [outlines])
 
-  val outline = outlines[0]
-  shape(outline)
+  outlines[0]
 
 public defn add-artwork (
   vp:VirtualLP,

--- a/src/landpatterns/VirtualLP.stanza
+++ b/src/landpatterns/VirtualLP.stanza
@@ -36,7 +36,8 @@ Helper Struct for Constructing Virtual Landpattern definitions
 public defstruct VirtualPad <: VirtualElement :
   pad-id:Int|Ref
   pad-def:Pad
-  loc:Pose
+  loc:Pose with:
+    updater => update-loc
   side:Side
 
   ; Virtual Element
@@ -130,7 +131,8 @@ public defmethod make-landpattern (cu:VirtualCopper, pose:Pose = DEF_VLP_LOC) :
 
 public defstruct VirtualArtwork <: VirtualElement :
   layer-spec:LayerSpecifier
-  shape:Shape
+  shape:Shape with:
+    updater => update-shape
 
   ; Virtual Element
   name?:Maybe<String> with: (as-method => true)
@@ -148,8 +150,8 @@ public defn VirtualArtwork (
   ) -> VirtualArtwork :
   #VirtualArtwork(layer-spec, shape, name?, to-class-vector(class))
 
-public defn to-layer-shape (art:VirtualArtwork) -> LayerShape :
-  LayerShape(layer-spec(art), shape(art))
+public defn to-layer-shape (art:VirtualArtwork, pose:Pose = loc(0.0, 0.0)) -> LayerShape :
+  LayerShape(layer-spec(art), pose * shape(art))
 
 public defmethod make-landpattern (art:VirtualArtwork, pose:Pose = DEF_VLP_LOC) :
   inside pcb-landpattern:
@@ -288,7 +290,9 @@ public defn get-layer (vp:VirtualLP, ls:LayerSpecifier) -> Tuple<Shape> :
       None()
 
   val kid-shapes = for child in children(vp) seq-cat:
-    get-layer(child, ls)
+    val shs = get-layer(child, ls)
+    for sh in shs seq:
+      pose(child) * sh
   to-tuple $ cat(local-shapes, kid-shapes)
 
 doc: \<DOC>
@@ -300,30 +304,55 @@ public defn get-layer-all (vp:VirtualLP, ls:LayerSpecifier) -> Tuple<Shape> :
   val land-shapes = for land in lands(vp) seq-cat:
     get-layer(land, ls)
   val kid-shapes = for child in children(vp) seq-cat:
-    get-layer-all(child, ls)
+    val shs = get-layer-all(child, ls)
+    for sh in shs seq:
+      pose(child) * sh
   to-tuple $ for shList in [local-shapes, land-shapes, kid-shapes] seq-cat:
     shList
 
 doc: \<DOC>
 Attempts to mimic the `pads` function from jitx/commands
+
+This function is recursive over all of the nodes of the virtual
+land pattern scene graph.
+
+@return A Tuple of VirtualPad, 1 for each of the virtual pads in `vp`.
+For any children - the `loc:Pose` of the `VirtualPad` will be updated
+so that returned VirtualPad is correctly situated in the parent frame
+of reference. That means that the VirtualPad objects returned by this function
+are not necessarily the same as the parent definition.
 <DOC>
 public defn get-pads (vp:VirtualLP) -> Tuple<VirtualPad> :
   val kid-pads = for child in children(vp) seq-cat:
-    get-pads(child)
+    ; Here I transform the pads into the parent coordinate frame - otherwise,
+    ;   I will get unexpected results when attempting to compute total bounds
+    ;   etc.
+    for c-pad in get-pads(child) seq:
+      update-loc(c-pad, pose(child) * loc(c-pad))
+
   val lp-pads = lands(vp)
   to-tuple $ cat(lp-pads, kid-pads)
 
 doc: \<DOC>
 Attempts to mimic the `layers` function from jitx/commands
+
+This function is recursive over all of the nodes of the
+virtual landpattern scene graph.
+
+@param vp Virtual LP scene graph
+@param pose Offset position to apply to the created LayerShape objects.
+This will cause all created objects to be in the same root frame of reference
+for the VirtualLP `vp`.
+@return A Tuple of LayerShape object
 <DOC>
-public defn get-layers (vp:VirtualLP) -> Tuple<LayerShape> :
+public defn get-layers (vp:VirtualLP, offset:Pose = loc(0.0, 0.0)) -> Tuple<LayerShape> :
   ; @NOTE - to match the behavior of `layer` which doesn't seem
   ;  to act recursively on a landpattern definition - we are not
   ;  inspecting the pads in this function.
   val local-art = for va in artwork(vp) seq:
-    to-layer-shape(va)
+    to-layer-shape(va, offset)
   val kid-art = for child in children(vp) seq-cat:
-    get-layers(child)
+    get-layers(child, offset * pose(child))
   to-tuple $ cat(local-art, kid-art)
 
 public defn get-copper (vp:VirtualLP, li:LayerIndex) -> Tuple<VirtualCopper> :

--- a/src/landpatterns/VirtualLP.stanza
+++ b/src/landpatterns/VirtualLP.stanza
@@ -555,6 +555,32 @@ public defn create-child (
   ret
 
 doc: \<DOC>
+Retrieve a child node by name from the parent virtual land pattern
+
+This function is recursive. It will attempt to match to a child
+node in the `vp` scene graph by name.
+
+@param vp The parent scope to search
+@param name Child name that we will match on. Unnamed children will
+be ignored.
+@return One<VirtualLP> if we find a child with `name? = name` else `None()`
+<DOC>
+public defn get-child (vp:VirtualLP, name:String) -> Maybe<VirtualLP> :
+  val elems = to-tuple $ for elem in find-by-name(vp, name) filter:
+    elem is VirtualLP
+  if length(elems) > 1:
+    println("Found Multiple Nodes with name='%_'")
+
+  if length(elems) > 0:
+    One(elems[0] as VirtualLP)
+  else:
+    None()
+
+public defn get-child! (vp:VirtualLP, name:String) -> VirtualLP :
+  val child? = get-child(vp, name)
+  value!(child?)
+
+doc: \<DOC>
 Local Elements for this Virtual Landpattern
 
 This does not search recursively into the children, it just

--- a/src/landpatterns/dual-row.stanza
+++ b/src/landpatterns/dual-row.stanza
@@ -290,38 +290,4 @@ public defn build-smd-pin-1 (
 
   add-artwork(vp, Silkscreen("pin-1-marker", side), Circle(marker-pos, line-width), name = "pin-1-dot", class = "pin1-marker")
 
-public defn build-outline-pin-1 (
-  pkg:Dual-Package,
-  vp:VirtualLP
-  --
-  pin-1-id:Int|Ref = 1,
-  side:Side = Top
-  ):
-
-  val outline = get-silkscreen-outline!(vp)
-
-  ; Find the corner of the outline nearest to pad 1
-  val pin-1-pad = get-pad-by-ref!(vp, pin-1-id)
-
-  ; The Outline is typically a line rectangle which creates a
-  ;  single line. We use this to determine the line width
-  ;  so that we can place the marker in the mid-line
-  val line-width = match(outline):
-    (x:Line): width(x)
-    ; TODO - this probably should be a setting
-    (_): 0.1
-
-  val o-box = bounds(outline)
-
-  val pin-1-pos = center $ pose(pin-1-pad)
-
-  val marker = compute-triangle-marker(pin-1-pos, o-box, line-width)
-
-  add-artwork(
-    vp, Silkscreen("pin-1-marker", side),
-    marker,
-    name = "pin-1-triangle",
-    class = "pin-1-marker"
-    )
-
 

--- a/src/landpatterns/packages.stanza
+++ b/src/landpatterns/packages.stanza
@@ -470,7 +470,13 @@ public defmulti build-all (
   virt:VirtualLP
   ) -> False
 
-public defn package-build-all-seq (
+doc: \<DOC>
+Externally Defined Build All Order
+
+This function can be used when you want to override the
+default behavior of default `build-all` defmethod.
+<DOC>
+public defn package-build-all-order (
   pkg:Package,
   virt:VirtualLP
   ) -> False:
@@ -498,7 +504,7 @@ public defmethod build-all (
   pkg:Package,
   virt:VirtualLP
   ) -> False :
-  package-build-all-seq(pkg, virt)
+  package-build-all-order(pkg, virt)
 
 doc: \<DOC>
 Generator for applying all `Package` generators

--- a/src/landpatterns/packages.stanza
+++ b/src/landpatterns/packages.stanza
@@ -470,6 +470,17 @@ public defmulti build-all (
   virt:VirtualLP
   ) -> False
 
+public defn package-build-all-seq (
+  pkg:Package,
+  virt:VirtualLP
+  ) -> False:
+  build-pads(pkg, virt)
+  build-courtyard(pkg, virt)
+  build-silkscreen(pkg, virt)
+  build-keep-out(pkg, virt)
+  build-cut-out(pkg, virt)
+  build-conformal-mask(pkg, virt)
+
 doc: \<DOC>
 Default `build-all` implementation
 
@@ -487,13 +498,7 @@ public defmethod build-all (
   pkg:Package,
   virt:VirtualLP
   ) -> False :
-  build-pads(pkg, virt)
-  build-courtyard(pkg, virt)
-  build-silkscreen(pkg, virt)
-  build-keep-out(pkg, virt)
-  build-cut-out(pkg, virt)
-  build-conformal-mask(pkg, virt)
-
+  package-build-all-seq(pkg, virt)
 
 doc: \<DOC>
 Generator for applying all `Package` generators

--- a/src/landpatterns/silkscreen.stanza
+++ b/src/landpatterns/silkscreen.stanza
@@ -6,6 +6,7 @@ defpackage jsl/landpatterns/silkscreen:
   import jitx/commands
 
   import jsl/design/settings
+  import jsl/errors
   import jsl/geometry/box
   import jsl/geometry/LineRectangle
   import jsl/landpatterns/framework
@@ -136,6 +137,69 @@ public defn compute-triangle-marker (
   val marker-pose = loc(closest, rot)
   marker-pose * marker-shape
 
+doc: \<DOC>
+Create a triangle shaped marker in the outline on the silkscreen
+
+This function looks for the outline shape in the virtual artwork
+of this VirtualLP node and then attempts to find the corner
+of that outline closest to the `pin-1-id` pad of the land pattern.
+
+It then construct a triangle shaped marker and places it in that
+corner for a heavy indication of the pin 1 location. This corner
+marker will be placed in the silkscreen layer on the same side
+of the board as the outline is found.
+
+@param vp Land Pattern scene graph node we will search for the outline
+@param pin-1-id This argument accepts either an `Int` or a `Ref` for
+identifying the "Pin 1" of the component. If this is an `Int` it will
+map to the conventional `p[N]` ref syntax used for land patterns. The
+default value is `1`.
+@throws ValueError If we find more than one `outline` in the silkscreen,
+or if we fail to find the `pin-1-id` pad.
+
+<DOC>
+public defn build-outline-pin-1-triangle (
+  vp:VirtualLP
+  --
+  pin-1-id:Int|Ref = 1
+  ):
+
+  val outline = get-silkscreen-outline!(vp)
+  val o-side = side $ (layer-spec(outline) as Silkscreen)
+  val o-sh = shape(outline)
+
+  val pin-1-pad = get-pad-by-ref!(vp, pin-1-id)
+  ; Find the corner of the outline nearest to pad 1
+
+  ; The Outline is typically a line rectangle which creates a
+  ;  single line. We use this to determine the line width
+  ;  so that we can place the marker in the mid-line
+  val line-width = match(o-sh):
+    (x:Line): width(x)
+    (_): default-silk-width()
+
+  val o-box = bounds $ o-sh
+
+  val pin-1-pos = center $ pose(pin-1-pad)
+
+  val marker = compute-triangle-marker(pin-1-pos, o-box, line-width)
+
+  add-artwork(
+    vp, Silkscreen("pin-1-marker", o-side),
+    marker,
+    name = "pin-1-triangle",
+    class = "pin-1-marker"
+    )
+
+doc: \<DOC>
+Construct a silkscreen outline of a component based on the Package Body
+
+@param vp Virtual LP scene graph node - outline will be created here.
+@param pkg-body 3D body model for the component
+@param density-level Indicates whether we will use MMC, NMC, or LMC
+@param line-width width of the line to draw.
+@param mask-clearance clearance between soldermask openings and the outline.
+<DOC>
 public defn create-silkscreen-outline (
   vp:VirtualLP, pkg-body:PackageBody
   --
@@ -147,6 +211,9 @@ public defn create-silkscreen-outline (
   val pkg-outline = bounds $ envelope(pkg-body, density-level = density-level)
   val pkg-outline* = fatten(line-width / 2.0, pkg-outline)
   val outline-geom = LineRectangle(pkg-outline*, line-width = line-width)
+
+  ; TODO - I want to use `Difference` here will all of the soldermask openings
+  ;  defined by the pads.
 
   add-artwork(vp, Silkscreen("outline", Top), outline-geom, class = "outline")
 

--- a/src/landpatterns/silkscreen.stanza
+++ b/src/landpatterns/silkscreen.stanza
@@ -5,8 +5,10 @@ defpackage jsl/landpatterns/silkscreen:
   import jitx
   import jitx/commands
 
+  import jsl/design/settings
   import jsl/geometry/box
-  import jsl/landpatterns/helpers
+  import jsl/geometry/LineRectangle
+  import jsl/landpatterns/framework
 
 public defn default-silk-width () -> Double :
   clearance(current-rules(), MinSilkscreenWidth)
@@ -133,3 +135,19 @@ public defn compute-triangle-marker (
   ; Place the marker in the closest corner.
   val marker-pose = loc(closest, rot)
   marker-pose * marker-shape
+
+public defn create-silkscreen-outline (
+  vp:VirtualLP, pkg-body:PackageBody
+  --
+  density-level:DensityLevel = DENSITY-LEVEL
+  line-width:Double = default-silk-width(),
+  mask-clearance:Double = default-mask-clearance()
+  ) -> False :
+
+  val pkg-outline = bounds $ envelope(pkg-body, density-level = density-level)
+  val pkg-outline* = fatten(line-width / 2.0, pkg-outline)
+  val outline-geom = LineRectangle(pkg-outline*, line-width = line-width)
+
+  add-artwork(vp, Silkscreen("outline", Top), outline-geom, class = "outline")
+
+

--- a/tests/landpatterns/VirtualLP.stanza
+++ b/tests/landpatterns/VirtualLP.stanza
@@ -116,6 +116,9 @@ deftest(virtual-lp) test-lp-tree:
   ;   has a parent - this should be a fault.
   expect-throw({append(root, c1)})
 
+  val expNone = get-child(root, "SomeName")
+  #EXPECT(expNone is None)
+
   ; Null Pattern
 
   pcb-landpattern null-pattern :
@@ -218,6 +221,13 @@ deftest(virtual-lp) test-find-by-name:
 
   val no-elems = to-tuple $ find-by-name(root, "Garbage")
   #EXPECT(length(no-elems) == 0)
+
+  val expNone = get-child(root, "SomeName2")
+  #EXPECT(expNone is None)
+
+  val expCh1 = get-child(root, "Uno")
+  #EXPECT(expCh1 is-not None)
+
 
 deftest(virtual-lp) test-find-by-class:
   val root = VirtualLP()


### PR DESCRIPTION
1.  Support `build-all` overrides better
2.  Tools for easier child node lookup by name
3.  Bugfix for `get-pads` that fixes the courtyard outline for LPs with multiple child nodes
4.  Added silkscreen from package body helper routine.