### PR TITLE
[Bugfix] Fixed regression in the BGA pad generator

### DIFF
--- a/src/landpatterns/BGA/pads.stanza
+++ b/src/landpatterns/BGA/pads.stanza
@@ -233,7 +233,7 @@ defn compute-adj (adj:Double|Percentage, copper:Shape) -> Double :
     (rel-adj:Percentage):
       val bbox = bounds(copper)
       val min-edge = min-width(bbox)
-      min-edge * rel-adj
+      (min-edge * rel-adj) / 2.0
 
 
 doc: \<DOC>


### PR DESCRIPTION
This bug was introduced in:
https://github.com/JITx-Inc/jsl/pull/61

This was a minor issue in the way that percentage modifications of the pad size were applied.

Unit tests pass when I run them locally. 
