### PR TITLE
PROD-250: Better error reporting for symbols with banked and unbanked

### DIFF
--- a/src/symbols/box-symbol.stanza
+++ b/src/symbols/box-symbol.stanza
@@ -342,26 +342,21 @@ defn save-pin-info (x:BoxSymbol, bank:Int|Ref|False = false) -> BoxSymbolBank :
   val decorators = HashTable<Ref,DecoratorInfo>()
 
   val sorted-pins = sort-by-row-index(pins(obj(x)))
-  val banked-pins = Vector<JITXObject>()
-  val unbanked-pins = Vector<JITXObject>()
 
-  for p in sorted-pins do :
-    match(get-property?(p, BANK_PROP)) :
-      (o:One):
-        add(banked-pins, p)
-      (n:None):
-        add(unbanked-pins, p)
+  val [banked, unbanked] = for p in sorted-pins split :
+    get-property?(p, BANK_PROP) is One
 
-  if length(banked-pins) > 0 and length(unbanked-pins) > 0 :
+  if not empty?(banked) and not empty?(unbanked) :
+    val unbanked-refs = to-tuple $ seq(ref, unbanked)
     throw $ Exception("Cannot mix pins with and without 'bank' property.\
-      Unbanked pins: %_" % [unbanked-pins])
+      Unbanked pins: %_" % [unbanked-refs])
 
   val matched-pins = to-tuple $
     match(bank):
       (b:Int|Ref) :
-        filter({get-property(_, BANK_PROP) == b}, banked-pins)
+        filter({get-property(_, BANK_PROP) == b}, banked)
       (f) :
-        unbanked-pins
+        unbanked
 
   if length(matched-pins) == 0 :
     throw $ Exception("No pins found for bank %_, box-symbol %_" % [bank, name(x)])

--- a/src/symbols/box-symbol.stanza
+++ b/src/symbols/box-symbol.stanza
@@ -342,23 +342,29 @@ defn save-pin-info (x:BoxSymbol, bank:Int|Ref|False = false) -> BoxSymbolBank :
   val decorators = HashTable<Ref,DecoratorInfo>()
 
   val sorted-pins = sort-by-row-index(pins(obj(x)))
-  val filtered-pins = Vector<JITXObject>()
-  for p in sorted-pins do :
-    match(bank, get-property?(p, BANK_PROP)) :
-      (b:Int|Ref, o:One) :
-        if value(o) == b :
-          add(filtered-pins, p)
-      (b:Int|Ref, f:None) :
-        false
-      (f:False, o:One) :
-        false
-      (f1:False, f2:None) :
-        add(filtered-pins, p)
+  val banked-pins = Vector<JITXObject>()
+  val unbanked-pins = Vector<JITXObject>()
 
-  if length(filtered-pins) == 0 :
+  for p in sorted-pins do :
+    match(get-property?(p, BANK_PROP)) :
+      (o:One):
+        add(banked-pins, p)
+      (n:None):
+        add(unbanked-pins, p)
+
+  if length(banked-pins) > 0 and length(unbanked-pins) > 0 :
+    throw $ Exception("Cannot mix pins with and without 'bank' property.\
+      Unbanked pins: %_" % [unbanked-pins])
+
+  val matched-pins = to-tuple $
+    match(bank):
+      (b:Int|Ref) :
+        filter({get-property(_, BANK_PROP) == b}, banked-pins)
+      (f) :
+        unbanked-pins
+
+  if length(matched-pins) == 0 :
     throw $ Exception("No pins found for bank %_, box-symbol %_" % [bank, name(x)])
-  if bank is False and length(sorted-pins) != length(filtered-pins) :
-    throw $ Exception("Cannot mix pins with and without 'bank' property")
 
   val bank-grid =
     match(bank) :
@@ -370,7 +376,7 @@ defn save-pin-info (x:BoxSymbol, bank:Int|Ref|False = false) -> BoxSymbolBank :
 
   val pins-by-group = HashTable<String, Vector<JITXObject>>()
   val rcs-by-pin = HashTable<Ref,RCS>()
-  for p in filtered-pins do :
+  for p in matched-pins do :
     val props = HashTable<Symbol, ?>()
     for pr in SYM_PROPS do :
       match(get-property?(p, pr)) :
@@ -410,7 +416,7 @@ defn save-pin-info (x:BoxSymbol, bank:Int|Ref|False = false) -> BoxSymbolBank :
       within group-tail-margin = got?(group-props, GROUP_TAIL_MARGIN_PROP) :
         pin-infos[ref(tail-pin)][GROUP_TAIL_MARGIN_PROP] = group-tail-margin
 
-  check-properties(filtered-pins)
+  check-properties(matched-pins)
 
   BoxSymbolBank(
     bank-grid

--- a/tests/symbols/box-symbol.stanza
+++ b/tests/symbols/box-symbol.stanza
@@ -9,19 +9,11 @@ defpackage jsl/tests/symbols/SymbolNode:
   import jsl/tests/utils
 
 deftest(box-symbol) test-props-filter:
-
   pcb-component basic-bank:
     pin-properties:
       [pin:Ref | pads:Ref ... | side:Dir]
-        [ VDD1 | p[8] | Right]
-        [ VDD2 | p[9] | Right]
-        [ DIN  | p[1] | Left]
-        [ EN | p[2] | Left]
-        [ CLK | p[3] | Left]
-        [ DOUT | p[5] | Right ]
-        [ ALERT | p[6] | Right ]
-        [ NC    | p[7] | Left ]
-        [ GND | p[4] | Left]
+        [ VDD1 | p[1] | Right]
+        [ VDD2 | p[2] | Right]
 
     val box = BoxSymbol(self)
     ; first set all banks to some default bank
@@ -32,5 +24,36 @@ deftest(box-symbol) test-props-filter:
     #EXPECT(length(vdd-pins) == 2)
     val vdd-pins-bank = find-pins-by-regex(box, "VDD.*", bank = 1)
     #EXPECT(length(vdd-pins-bank) == 1)
+    assign-symbols(
+      [
+        0 => box
+        1 => box
+      ]
+    )
+  evaluate(basic-bank)
+
+deftest(box-symbol) test-mixed-bank-unbank:
+  pcb-component basic-bank:
+    pin-properties:
+      [pin:Ref | pads:Ref ... | side:Dir]
+        [ VDD1 | p[1] | Right]
+        [ OUT  | p[3] | Right]
+
+    val box = BoxSymbol(self)
+    ; first set all banks to some default bank
+    set-bank(0, self.VDD1)
+
+    val assign-f = {
+      assign-symbols(
+        [
+          0 => box
+        ]
+      )}
+    expect-throw(assign-f)
+    expect-throw(
+      {assign-symbol $ create-symbol(box, false)}
+    )
+    set-bank(0, self.OUT)
+    assign-f()
 
   evaluate(basic-bank)

--- a/tests/symbols/box-symbol.stanza
+++ b/tests/symbols/box-symbol.stanza
@@ -32,28 +32,33 @@ deftest(box-symbol) test-props-filter:
     )
   evaluate(basic-bank)
 
-deftest(box-symbol) test-mixed-bank-unbank:
+deftest(box-symbol) test-mixed-bank-unbank-msg:
   pcb-component basic-bank:
     pin-properties:
       [pin:Ref | pads:Ref ... | side:Dir]
         [ VDD1 | p[1] | Right]
-        [ OUT  | p[3] | Right]
+        [ OUT1  | p[2] | Right]
+        [ OUT2  | p[3] | Right]
 
     val box = BoxSymbol(self)
     ; first set all banks to some default bank
     set-bank(0, self.VDD1)
 
     val assign-f = {
-      assign-symbols(
-        [
-          0 => box
-        ]
-      )}
-    expect-throw(assign-f)
+      assign-symbols([0 => box])
+    }
+
+    val unbanked-pins = map({to-string(ref(_))}, [self.OUT1, self.OUT2])
+    match(expect-throw(assign-f)) :
+      (o:One) :
+        #EXPECT(all?({substring?(value(o), _)}, unbanked-pins))
+      ; Fail if this doesn't return a message we can check
     expect-throw(
       {assign-symbol $ create-symbol(box, false)}
     )
-    set-bank(0, self.OUT)
+
+    set-bank(0, self.OUT1)
+    set-bank(0, self.OUT2)
     assign-f()
 
   evaluate(basic-bank)


### PR DESCRIPTION
Improve exception messages when there are pins with and without `bank` property