### PR TITLE
Add a new Grid management facility for landpattern generation

### DIFF
--- a/examples/landpatterns/BGA-Stagger.stanza
+++ b/examples/landpatterns/BGA-Stagger.stanza
@@ -1,0 +1,76 @@
+#use-added-syntax(jitx)
+defpackage jsl/examples/landpatterns/BGA-stagger:
+  import core
+  import jitx
+  import jitx/commands
+
+  import jsl/design/settings
+  import jsl/landpatterns
+  import jsl/symbols
+  import jsl/examples/landpatterns/board
+
+val board-shape = RoundedRectangle(50.0, 50.0, 0.25)
+
+pcb-component test-BGA:
+
+  pin-properties :
+    [pin:Ref | pads:Ref ... | side:Dir]
+    [VO- | A[2] | Right ]
+    [ASDF | A[4] | Right ]
+    [VDD | A[6] | Up ]
+    [SHUTDOWN | B[1] | Left]
+    [GND | B[3] | Down]
+    [VO+ | B[5] | Right ]
+    [BYPASS | C[2] | Left]
+    [IN+ | C[4] | Left]
+    [IN- | C[6] | Left]
+
+  val box = BoxSymbol(self)
+  assign-symbol $ create-symbol(box)
+
+  val rows = 3
+  val cols = 3
+  val grid = Grid-Numbering(rows, 2 * cols)
+  val pitch = 0.5
+
+  val planner = Staggered-Matrix-Planner(
+    rows = rows
+    columns = cols * 2
+    pitch = Dims(pitch / 2.0, pitch)
+  )
+
+  val body = PackageBody(
+    width = 2.5 +/- 0.1,
+    length = 2.0 +/- 0.1,
+    height = 0.71 +/- [0.06, 0.0]
+  )
+
+  val pkg = BGA(
+    num-leads = 9,
+    lead-diam = 0.3,
+    package-body = body,
+    lead-numbering = grid,
+    pad-planner = planner,
+    density-level = DensityLevelB
+  )
+
+  val lp = create-landpattern(pkg)
+  assign-landpattern(lp)
+
+pcb-module test-design:
+  inst c : test-BGA
+  place(c) at loc(0.0, 0.0) on Top
+
+
+; Set the top level module (the module to be compile into a schematic and PCB)
+set-current-design("BGA-STAGGER-TEST")
+set-rules(default-rules)
+set-board(default-board(board-shape))
+
+set-main-module(test-design)
+
+; Use any helper function from helpers.stanza here. For example:
+; run-check-on-design(my-design)
+
+; View the results
+view-board()

--- a/examples/landpatterns/BGA-complex.stanza
+++ b/examples/landpatterns/BGA-complex.stanza
@@ -23,13 +23,13 @@ public defn VFBGA142 () -> VFBGA142 :
     copper-D-adj = -0.05,
     mask-D-adj = 0.0,
   )
+  val rows = 12
+  val cols = 12
+  val pitch = 0.45
 
   new VFBGA142:
     defmethod num-leads (this) : 144
-    defmethod rows (this) : 12
-    defmethod columns (this) : 12
     defmethod lead-diam (this) : 0.25
-    defmethod pitch (this) : 0.45
     defmethod density-level (this) : dl
     defmethod pad-planner (this) :
       ; Create a carve out in the top-right corner
@@ -43,10 +43,13 @@ public defn VFBGA142 () -> VFBGA142 :
           to-pad-island(grid, "F[10]")
           to-pad-island(grid, "G[11]")
         ],
-        pad-config = pad-conf
+        pad-config = pad-conf,
+        rows = rows,
+        columns = cols,
+        pitch = pitch
       )
     defmethod lead-numbering (this) :
-      Grid-Numbering(rows(this), columns(this))
+      Grid-Numbering(rows, cols)
     defmethod package-body (this) :
       PackageBody(
         width = min-typ-max(6.13, 6.2, 6.27)
@@ -64,7 +67,7 @@ public defn VFBGA142 () -> VFBGA142 :
 
       val ey = 0.2075
       val ex = 0.2975
-      val l = 4.0 * pitch(this) as Double
+      val l = 4.0 * pitch
       val offset = Point(l, l) + Point(ex, ey)
       val sec = create-child(root, offset = loc(offset))
 
@@ -76,12 +79,14 @@ public defn VFBGA142 () -> VFBGA142 :
 
       val sec-pkg = BGA(
         num-leads = 16,
-        rows = sec-rows,
-        columns = sec-cols,
         lead-diam = lead-diam(this),
-        pitch = pitch(this),
         package-body = package-body(this),
-        pad-planner = Full-Matrix-Planner(pad-conf)
+        pad-planner = Full-Matrix-Planner(
+          pad-config = pad-conf
+          rows = sec-rows,
+          columns = sec-cols,
+          pitch = pitch
+          )
         lead-numbering = num-scheme,
         density-level = dl
       )

--- a/examples/landpatterns/BGA-simple.stanza
+++ b/examples/landpatterns/BGA-simple.stanza
@@ -46,6 +46,7 @@ pcb-component test-BGA:
   val rows = 3
   val cols = 3
   val grid = Grid-Numbering(rows, cols)
+  val pitch = 0.5
 
   val planner = Perimeter-Matrix-Planner(
     ; Pad A2 is not present
@@ -56,7 +57,10 @@ pcb-component test-BGA:
         density-level = DensityLevelC
         ),
       mask-D-adj = 0.0,
-    )
+    ),
+    rows = rows
+    columns = cols
+    pitch = pitch
   )
 
   val body = PackageBody(
@@ -67,10 +71,7 @@ pcb-component test-BGA:
 
   val pkg = BGA(
     num-leads = 9,
-    rows = rows,
-    columns = cols,
     lead-diam = 0.3,
-    pitch = 0.5,
     package-body = body,
     lead-numbering = grid,
     pad-planner = planner,

--- a/examples/landpatterns/BGA-simple.stanza
+++ b/examples/landpatterns/BGA-simple.stanza
@@ -5,35 +5,29 @@ defpackage jsl/examples/landpatterns/BGA-simple:
   import jitx/commands
 
   import jsl/design/settings
+  import jsl/symbols
   import jsl/landpatterns
 
   import jsl/examples/landpatterns/board
 
 val board-shape = RoundedRectangle(50.0, 50.0, 0.25)
 
-pcb-symbol test-sym:
-  val pin-names = ["VDD", "VO-", "VO+", "BYPASS", "SHUTDOWN", "GND", "IN+", "IN-"]
-  for i in 0 to length(pin-names) do :
-    pin (Ref(pin-names[i])) at Point(-2.54, (2.54 - (to-double(i) * 2.54))) with :
-      direction = Left
-      length = 2.54
-      number-size = 0.762
-      name-size = 0.762
-
 pcb-component test-BGA:
 
   pin-properties :
-    [pin:Ref | pads:Ref ... | side:Dir | bank:Int]
-    [VO- | A[1] | Right |  0]
-    [VDD | A[3] | Up |  0]
-    [SHUTDOWN | B[1] | Left | 0]
-    [GND | B[2] | Down | 0]
-    [VO+ | B[3] | Right | 0]
-    [BYPASS | C[1] | Left | 0]
-    [IN+ | C[2] | Left | 0]
-    [IN- | C[3] | Left | 0]
+    [pin:Ref | pads:Ref ... | side:Dir]
+    [VO- | A[1] | Right ]
+    [VDD | A[3] | Up ]
+    [SHUTDOWN | B[1] | Left ]
+    [GND | B[2] | Down]
+    [VO+ | B[3] | Right ]
+    [BYPASS | C[1] | Left ]
+    [IN+ | C[2] | Left ]
+    [IN- | C[3] | Left ]
 
-  assign-symbol(test-sym)
+
+  val box = BoxSymbol(self)
+  assign-symbol $ create-symbol(box)
 
  ; This test is based on the TI, TPA6203A1GQVR
   ; Datasheet:

--- a/examples/landpatterns/BGA-thermal-enhanced.stanza
+++ b/examples/landpatterns/BGA-thermal-enhanced.stanza
@@ -40,6 +40,7 @@ pcb-component test-therm-enhanded:
 
   val te-rows = 16
   val te-cols = 16
+  val te-pitch = 0.5
 
   val planner = ThermallyEnhanced-Matrix-Planner(
     inactive = PadIsland(
@@ -50,6 +51,9 @@ pcb-component test-therm-enhanded:
       8 through 9,
       8 through 9
       ),
+    rows = te-rows,
+    columns = te-cols,
+    pitch = te-pitch
   )
 
   val body = PackageBody(
@@ -60,10 +64,7 @@ pcb-component test-therm-enhanded:
 
   val pkg = BGA(
     num-leads = 224,
-    rows = te-rows,
-    columns = te-cols,
     lead-diam = 0.3,
-    pitch = 0.5,
     package-body = body,
     pad-planner = planner,
     density-level = DensityLevelB

--- a/examples/landpatterns/headers.stanza
+++ b/examples/landpatterns/headers.stanza
@@ -1,0 +1,70 @@
+#use-added-syntax(jitx)
+defpackage jsl/examples/landpatterns/headers:
+  import core
+  import jitx
+  import jitx/commands
+
+  import jsl/landpatterns
+  import jsl/symbols
+
+  import jsl/examples/landpatterns/board
+
+pcb-bundle header (w:Int):
+  port D : pin[1 through w]
+
+pcb-symbol header-sym (w:Int):
+  name = "Crappy Header Symbol"
+  val scale = 2.54
+  for i in 1 through w do:
+    pin p.D[i] at Point(0.0, scale * to-double(i))
+
+
+pcb-component header-test (num-leads:Int, num-rows:Int) :
+  port p : header(num-leads)
+
+  pin-properties:
+    [pin:Ref| pads:Ref ...]
+    for i in 1 through num-leads do:
+      [p.D[i] | p[i] ]
+
+  assign-symbol(header-sym(num-leads))
+
+  val pitch = 2.54
+  val num-cols = num-leads / num-rows
+  val body-len = to-double(num-cols) * pitch
+  val body-width = to-double(num-rows) * pitch
+
+  val pkg = Header(
+    num-leads = num-leads,
+    lead-type = TH-Lead(length = typ(2.0), width = typ(0.9)),
+    pad-diam = 1.5,
+    rows = num-rows,
+    pitch = pitch
+    package-body = PackageBody(
+      width = typ(body-width),
+      length = typ(body-len),
+      height = typ(5.0) )
+    )
+  val lp = create-landpattern(pkg)
+  assign-landpattern(lp)
+
+
+
+pcb-module test-design:
+  inst J1 : header-test(10, 2)
+  inst J2 : header-test(10, 1)
+
+val board-shape = RoundedRectangle(50.0, 50.0, 0.25)
+
+; Set the top level module (the module to be compile into a schematic and PCB)
+set-current-design("Header-TEST")
+set-rules(default-rules)
+set-board(default-board(board-shape))
+
+set-main-module(test-design)
+
+; Use any helper function from helpers.stanza here. For example:
+; run-check-on-design(my-design)
+
+; View the results
+view-board()

--- a/examples/pin-assignment/swizzle.stanza
+++ b/examples/pin-assignment/swizzle.stanza
@@ -77,17 +77,15 @@ pcb-module top-level :
 
 val stackup = LayerStack(name = "Swizzle Stack")
 
-val copper-1oz = Copper("cu", 1.0)
-val core-FR4 = FR4("core", 1.0)
-val prepreg-FR4 = FR4("prepreg", 0.5)
+val copper-1oz = Copper(1.0)
+val core-FR4 = FR4(1.0 name = "core")
+val prepreg-FR4 = FR4(0.5, name = "prepreg")
 
 add-symmetric(copper-1oz, core-FR4,
   add-symmetric(copper-1oz, prepreg-FR4,
     add-symmetric(copper-1oz, core-FR4, stackup)
   )
 )
-
-validate!(stackup)
 
 val mem-stackup = create-pcb-stackup(stackup)
 

--- a/src/landpatterns/BGA/package.stanza
+++ b/src/landpatterns/BGA/package.stanza
@@ -173,22 +173,32 @@ public defn build-vpads (
   val pad-size = Dims(lead-diam(pkg), lead-diam(pkg))
   ; Generate the grid
   val planner = get-bga-planner(pkg)
-  defn gen-pad-info () -> Seq<VirtualPad> :
-    for pos in grid(planner) seq?:
-      val [r, c] = [row(pos), column(pos)]
-      val pad-id = to-pad-id(lead-numbering(pkg), r, c)
-      val pad-gen? = pad-generator(planner, r, c)
-      match(pad-gen?):
-        (_:False): None()
-        (pad-gen):
-          val cls = [
-            "pad",
-            to-string("col-%_" % [c]),
-            to-string("row-%_" % [r])
-          ]
-          One $ VirtualPad(pad-id, pad-gen(pad-size), pose(pos), class = cls)
+  ; defn gen-pad-info () -> Seq<VirtualPad> :
+  ;   for pos in grid(planner) seq?:
+  ;     val [r, c] = [row(pos), column(pos)]
+  ;     val pad-id = to-pad-id(lead-numbering(pkg), r, c)
+  ;     val pad-gen? = pad-generator(planner, r, c)
+  ;     match(pad-gen?):
+  ;       (_:False): None()
+  ;       (pad-gen):
+  ;         val cls = [
+  ;           "pad",
+  ;           to-string("col-%_" % [c]),
+  ;           to-string("row-%_" % [r])
+  ;         ]
+  ;         One $ VirtualPad(pad-id, pad-gen(pad-size), pose(pos), class = cls)
 
-  append-all(vp, gen-pad-info())
+  ; append-all(vp, gen-pad-info())
+
+  val pad-seq = pad-grid-smt(
+    pad-size = pad-size,
+    planner = planner,
+    lead-grid = planner,
+    num-scheme = lead-numbering(pkg)
+  )
+
+  append-all(vp, pad-seq)
+
 
 public defmethod build-pads (
   pkg:BGA,

--- a/src/landpatterns/BGA/package.stanza
+++ b/src/landpatterns/BGA/package.stanza
@@ -15,6 +15,7 @@ defpackage jsl/landpatterns/BGA/package:
   import jsl/landpatterns/framework
   import jsl/landpatterns/BGA/pads
   import jsl/landpatterns/BGA/planner
+  import jsl/landpatterns/grid-planner
 
 doc: \<DOC>
 Ball Grid Array Package
@@ -31,38 +32,12 @@ public defstruct BGA <: Package :
     as-method => true
   )
   doc: \<DOC>
-  Number of Rows of leads on this package
-  <DOC>
-  rows:Int with: (
-    ensure => ensure-positive!
-  )
-  doc: \<DOC>
-  Number of Columns of leads on this package
-  <DOC>
-  columns:Int with: (
-    ensure => ensure-positive!
-  )
-  doc: \<DOC>
   BGA Ball Lead Diameter in mm
   <DOC>
   lead-diam:Double with: (
     ensure => ensure-positive!,
   )
-  doc: \<DOC>
-  BGA Ball Spacing in mm
 
-  The ball spacing can either be:
-
-  1.  Same pitch between rows and columns.
-    1.  This is indicated with a `Double` value.
-  2.  Different pitch between rows from between columns.
-    1.  This is indicated with a `Dims` value
-    2.  The width is interpretted as the column pitch
-    3.  The height is interpretted as the row pitch
-  <DOC>
-  pitch:Double|Dims with: (
-    ensure => ensure-positive!
-  )
   doc: \<DOC>
   Package Body for the BGA.
   <DOC>
@@ -71,7 +46,9 @@ public defstruct BGA <: Package :
   doc: \<DOC>
   Pad Planner for the BGA package
   The planner determines which pads will be created in the
-  grid. See {@link PadPlanner} for more info.
+  grid. See {@link PadPlanner} and {@link GridPlanner} for more info.
+  This interface will define the pitch (distance between balls) and
+  the number of rows/columns and how they are organized.
   <DOC>
   pad-planner:PadPlanner with: (as-method => true)
 
@@ -115,32 +92,58 @@ public defn BGA (
   lead-diam:Double,
   pitch:Double|Dims,
   package-body:PackageBody,
-  pad-planner:BGA-PadPlanner = Full-Matrix-Planner(),
+  pad-planner:BGA-PadPlanner = Full-Matrix-Planner(
+    rows = rows,
+    columns = columns,
+    pitch = pitch
+    ),
   lead-numbering:Numbering = Grid-Numbering(rows, columns)
   density-level:DensityLevel = DENSITY-LEVEL
 ) -> BGA :
   #BGA(
-    num-leads, rows, columns,
-    lead-diam, pitch,
+    num-leads, lead-diam,
     package-body,
     pad-planner,
     lead-numbering,
     density-level
   )
 
+public defn BGA (
+  --
+  num-leads:Int,
+  lead-diam:Double,
+  package-body:PackageBody,
+  pad-planner:BGA-PadPlanner,
+  lead-numbering:Numbering = Grid-Numbering(rows(pad-planner), columns(pad-planner))
+  density-level:DensityLevel = DENSITY-LEVEL
+) -> BGA :
+  #BGA(
+    num-leads,
+    lead-diam,
+    package-body,
+    pad-planner,
+    lead-numbering,
+    density-level
+  )
+
+public defn get-bga-planner (bga:BGA) -> BGA-PadPlanner:
+  pad-planner(bga) as BGA-PadPlanner
+
 public defmethod name (bga:BGA) -> String:
   defn to-deci (v:Double) -> String:
     val v* = to-int( v * 100.0 )
     to-string("%_" % [v*])
 
-  val pitchStr = match(pitch(bga)):
+  val grid-p = get-bga-planner(bga)
+
+  val pitchStr = match(pitch(grid-p)):
     (p:Double): to-deci(p)
     (pa:Dims):
       val px = to-deci $ x(pa)
       val py = to-deci $ y(pa)
       to-string("%_X%_" % [px, py])
 
-  val ballGrid = to-string("%_X%_" % [columns(bga), rows(bga)])
+  val ballGrid = to-string("%_X%_" % [columns(grid-p), rows(grid-p)])
 
   val b = package-body(bga)
 
@@ -169,22 +172,21 @@ public defn build-vpads (
   ;  drive the pad sizing.
   val pad-size = Dims(lead-diam(pkg), lead-diam(pkg))
   ; Generate the grid
-  val planner = pad-planner(pkg) as BGA-PadPlanner
+  val planner = get-bga-planner(pkg)
   defn gen-pad-info () -> Seq<VirtualPad> :
-    val grid = grid(planner, rows(pkg), columns(pkg), pitch(pkg))
-    for r in 0 to rows(pkg) seq-cat:
-      for (c in 0 to columns(pkg), pos in grid) seq? :
-        val pad-id = to-pad-id(lead-numbering(pkg), r, c)
-        val pad-gen? = pad-generator(planner, r, c)
-        match(pad-gen?):
-          (_:False): None()
-          (pad-gen):
-            val cls = [
-              "pad",
-              to-string("col-%_" % [c]),
-              to-string("row-%_" % [r])
-            ]
-            One $ VirtualPad(pad-id, pad-gen(pad-size), pos, class = cls)
+    for pos in grid(planner) seq?:
+      val [r, c] = [row(pos), column(pos)]
+      val pad-id = to-pad-id(lead-numbering(pkg), r, c)
+      val pad-gen? = pad-generator(planner, r, c)
+      match(pad-gen?):
+        (_:False): None()
+        (pad-gen):
+          val cls = [
+            "pad",
+            to-string("col-%_" % [c]),
+            to-string("row-%_" % [r])
+          ]
+          One $ VirtualPad(pad-id, pad-gen(pad-size), pose(pos), class = cls)
 
   append-all(vp, gen-pad-info())
 

--- a/src/landpatterns/BGA/package.stanza
+++ b/src/landpatterns/BGA/package.stanza
@@ -173,23 +173,6 @@ public defn build-vpads (
   val pad-size = Dims(lead-diam(pkg), lead-diam(pkg))
   ; Generate the grid
   val planner = get-bga-planner(pkg)
-  ; defn gen-pad-info () -> Seq<VirtualPad> :
-  ;   for pos in grid(planner) seq?:
-  ;     val [r, c] = [row(pos), column(pos)]
-  ;     val pad-id = to-pad-id(lead-numbering(pkg), r, c)
-  ;     val pad-gen? = pad-generator(planner, r, c)
-  ;     match(pad-gen?):
-  ;       (_:False): None()
-  ;       (pad-gen):
-  ;         val cls = [
-  ;           "pad",
-  ;           to-string("col-%_" % [c]),
-  ;           to-string("row-%_" % [r])
-  ;         ]
-  ;         One $ VirtualPad(pad-id, pad-gen(pad-size), pose(pos), class = cls)
-
-  ; append-all(vp, gen-pad-info())
-
   val pad-seq = pad-grid-smt(
     pad-size = pad-size,
     planner = planner,

--- a/src/landpatterns/BGA/package.stanza
+++ b/src/landpatterns/BGA/package.stanza
@@ -68,6 +68,12 @@ with:
 
 doc: \<DOC>
 BGA Package Constructor
+
+The function constructs a Full Matrix BGA by default
+using the passed arguments. For more control over
+the pads and numbering, use the other constructor
+variant.
+
 @param num-leads Total number of lead placements assuming
 all leads are present.
 @param rows Number of rows of ball leads (Y dimension)
@@ -75,14 +81,6 @@ all leads are present.
 @param lead-diam Size of the BGA ball lead.
 @param pitch Ball Spacing
 @param package-body Component body physical representation.
-@param pad-planner Pad Planner that decides which pads will
-be populated in the resultant footprints. The default is
-a {@link Full-Matrix-Planner} which populates all lead
-locations with a circular pad based on its default configs.
-@param lead-numbering Lead numbering generator that determines
-what `Ref`s are applied to each pad. By default, this function
-uses a {@link Grid-Numbering} which creates `A1`, `B7`, etc
-style references using `1-based` indexing (ie, no `C0`).
 <DOC>
 public defn BGA (
   --
@@ -92,14 +90,14 @@ public defn BGA (
   lead-diam:Double,
   pitch:Double|Dims,
   package-body:PackageBody,
-  pad-planner:BGA-PadPlanner = Full-Matrix-Planner(
+  density-level:DensityLevel = DENSITY-LEVEL
+) -> BGA :
+  val pad-planner:BGA-PadPlanner = Full-Matrix-Planner(
     rows = rows,
     columns = columns,
     pitch = pitch
     ),
-  lead-numbering:Numbering = Grid-Numbering(rows, columns)
-  density-level:DensityLevel = DENSITY-LEVEL
-) -> BGA :
+  val lead-numbering:Numbering = Grid-Numbering(rows, columns)
   #BGA(
     num-leads, lead-diam,
     package-body,

--- a/src/landpatterns/BGA/planner.stanza
+++ b/src/landpatterns/BGA/planner.stanza
@@ -1,7 +1,6 @@
 #use-added-syntax(jitx)
 defpackage jsl/landpatterns/BGA/planner:
   import core
-  import math
   import jitx
   import jitx/commands
 
@@ -10,7 +9,6 @@ defpackage jsl/landpatterns/BGA/planner:
   import jsl/landpatterns/pad-island
   import jsl/landpatterns/grid-planner
   import jsl/geometry/basics
-  import jsl/errors
   import jsl/ensure
 
 val DEF-PAD-CONFIG = PadConfig-R()
@@ -129,8 +127,7 @@ with:
 
 
 public defmethod active? (x:Staggered-Matrix-Planner, row:Int, column:Int) -> True|False:
-  val row-offset = 1 when phase(x) == Even-Phase else 0
-  ((row + row-offset) % 2) == (column % 2)
+  stagger-pattern(phase(x), row, column)
 
 doc: \<DOC>
 Equilateral Triangle Matrix - Similar to Staggered but all pads are equidistant.
@@ -175,9 +172,7 @@ with:
 
 defmethod pitch (g:EquilateralTriangle-Matrix-Planner) -> Double|Dims :
   val p = tri-pitch(g)
-  val row-span = sqrt(3.0) * 0.5 * p
-  val col-span = 0.5 * p
-  Dims(row-span, col-span)
+  equilateral-triangle-pitch(p)
 
 doc: \<DOC>
 Perimeter Matrix - Full matrix with an island of pads in-active.

--- a/src/landpatterns/BGA/planner.stanza
+++ b/src/landpatterns/BGA/planner.stanza
@@ -8,9 +8,10 @@ defpackage jsl/landpatterns/BGA/planner:
   import jsl/landpatterns/BGA/pads
   import jsl/landpatterns/pad-planner
   import jsl/landpatterns/pad-island
+  import jsl/landpatterns/grid-planner
   import jsl/geometry/basics
   import jsl/errors
-
+  import jsl/ensure
 
 val DEF-PAD-CONFIG = PadConfig-R()
 
@@ -20,35 +21,21 @@ This pad planner will create circular pads for each BGA
 ball location. The user can use the `pad-config` to
 modify the construction of each pad including the soldermask
 and pastemask openings.
+
+This type is derived from two parent implementations:
+1.  {@link PadPlanner} which manages selection of which pads to populate
+and how they should be constructed
+2.  {@link GridPlanner} which manages the placement of the created pads
+at particular grid locations.
 <DOC>
-public defstruct BGA-PadPlanner <: PadPlanner :
-  pad-config:PadConfig with: (default => DEF-PAD-CONFIG)
-
-doc: \<DOC>
-Generate the grid sequence for the BGA Pad Planner
-For the BGA pad planners, there is often a particular
-grid geometry required to generate the pads in question.
-This function can be overriden to create a pad grid that
-is customized to the planner.
-
-Grid is assumed to be in `row-major` order.
-
-@param pitch Spacing between pads. If this value is a `Double` then
-the same pitch is used for rows and columns.
-If this is a `Dims` type, then the `width` is the column pitch and
-the `height` is the row pitch.
-<DOC>
-public defmulti grid (x:BGA-PadPlanner, rows:Int, columns:Int, pitch:Double|Dims) -> Seq<Pose>
-
-doc: \<DOC>
-Default grid sequence is a standard square cell grid in row-major form
-<DOC>
-public defmethod grid (bga:BGA-PadPlanner, rows:Int, columns:Int, pitch:Double|Dims) -> Seq<Pose> :
-  to-seq $ match(pitch):
-    (p:Double):
-      grid-locs(rows, columns, p, p)
-    (pa:Dims):
-      grid-locs(rows, columns, y(pa), x(pa))
+public defstruct BGA-PadPlanner <: PadPlanner & GridPlanner:
+  doc: \<DOC>
+  Defines the features of each individual BGA pad.
+  This defines the shape and parameters for the copper,
+  soldermask opening, paste application, etc.
+  <DOC>
+  pad-config:PadConfig with:
+    default => DEF-PAD-CONFIG
 
 doc: \<DOC>
 Default Pad Shaper for BGA packages.
@@ -73,17 +60,28 @@ doc: \<DOC>
 Full Matrix - All Pads in the grid are active
 <DOC>
 public defstruct Full-Matrix-Planner <: BGA-PadPlanner :
-  pad-config:PadConfig with: (
+  pad-config:PadConfig with:
     as-method => true
     default => DEF-PAD-CONFIG
-    )
+
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;;
+  ; GridPlanner
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;;
+  rows:Int with:
+    ensure => ensure-positive!
+    as-method => true
+  columns:Int with:
+    ensure => ensure-positive!
+    as-method => true
+  pitch:Double|Dims with:
+    ensure => ensure-positive!
+    as-method => true
+with:
+  keyword-constructor => true
+  printer => true
 
 public defmethod active? (x:Full-Matrix-Planner, row:Int, column:Int) -> True|False:
   true
-
-public defenum StaggerPhase :
-  Even-Phase
-  Odd-Phase
 
 doc: \<DOC>
 Staggered Matrix - Every other pad is in-active.
@@ -97,31 +95,38 @@ as
 public defstruct Staggered-Matrix-Planner <: BGA-PadPlanner :
   doc: \<DOC>
   Phase indicates whether the first row pad 0 is empty or populated.
-  This is used to differentiate between the two pattern cases:
-
-  Pattern #1 - `Odd-Phase` :
-
-  ```
-    X | O | X  ...
-    O | X | O  ...
-    ...
-  ```
-
-  Pattern #2 - `Even-Phase` :
-
-  ```
-    O | X | O  ...
-    X | O | X  ...
-    ...
-  ```
-
   By default this function uses `Even-Phase`
   <DOC>
-  phase:StaggerPhase with: (default => Even-Phase)
-  pad-config:PadConfig with: (
+  phase:StaggerPhase with:
+    default => Even-Phase
+
+  pad-config:PadConfig with:
     as-method => true
     default => DEF-PAD-CONFIG
-    )
+
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;;
+  ; GridPlanner
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;;
+  rows:Int with:
+    ensure => ensure-positive!
+    as-method => true
+
+  doc: \<DOC>
+  Columns in the Staggered Matrix Grid.
+  Note that there are typically 2x as many columns in
+  the grid as pads that will get populated.
+  <DOC>
+  columns:Int with:
+    ensure => ensure-positive!
+    as-method => true
+
+  pitch:Double|Dims with:
+    ensure => ensure-positive!
+    as-method => true
+with:
+  keyword-constructor => true
+  printer => true
+
 
 public defmethod active? (x:Staggered-Matrix-Planner, row:Int, column:Int) -> True|False:
   val row-offset = 1 when phase(x) == Even-Phase else 0
@@ -137,23 +142,42 @@ public defstruct EquilateralTriangle-Matrix-Planner <: Staggered-Matrix-Planner 
   doc: \<DOC>
   See Staggered Matrix
   <DOC>
-  phase:StaggerPhase with: (
+  phase:StaggerPhase with:
     as-method => true,
     default => Even-Phase
-  )
-  pad-config:PadConfig with: (
+
+  pad-config:PadConfig with:
     as-method => true
     default => DEF-PAD-CONFIG
-    )
 
-public defmethod grid (x:EquilateralTriangle-Matrix-Planner, rows:Int, columns:Int, pitch:Double|Dims) -> Seq<Pose> :
-  to-seq $ match(pitch):
-    (p:Double):
-      val vertical   = sqrt(3.0) * 0.5 * p
-      val horizontal = 0.5 * p
-      grid-locs(rows, columns, horizontal, vertical)
-    (pa:Dims):
-      throw $ ValueError("Asymmetric Grid Pitch Not-Allowed for Equilateral Triangle Matrix - Try Staggered-Matrix-Planner Instead")
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;;
+  ; GridPlanner
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;;
+  rows:Int with:
+    ensure => ensure-positive!
+    as-method => true
+
+  ; Same as Stagger - must be 2x the number of pads
+  columns:Int with:
+    ensure => ensure-positive!
+    as-method => true
+
+  doc: \<DOC>
+  Equilateral Distance between triangle points
+  All pads in this planner are equidistant apart and
+  this parameter sets that distance.
+  <DOC>
+  tri-pitch:Double with:
+    ensure => ensure-positive!
+with:
+  keyword-constructor => true
+  printer => true
+
+defmethod pitch (g:EquilateralTriangle-Matrix-Planner) -> Double|Dims :
+  val p = tri-pitch(g)
+  val row-span = sqrt(3.0) * 0.5 * p
+  val col-span = 0.5 * p
+  Dims(row-span, col-span)
 
 doc: \<DOC>
 Perimeter Matrix - Full matrix with an island of pads in-active.
@@ -170,19 +194,29 @@ public defstruct Perimeter-Matrix-Planner <: BGA-PadPlanner :
   all `PadIsland`s in the tuple forms the inactive region.
   <DOC>
   inactive:PadIsland|Tuple<PadIsland>
-  pad-config:PadConfig with: (
+  pad-config:PadConfig with:
     as-method => true
     default => DEF-PAD-CONFIG
-    )
-with:
-  constructor => #Perimeter-Matrix-Planner
 
-public defn Perimeter-Matrix-Planner (
-  --
-  inactive:PadIsland|Tuple<PadIsland>,
-  pad-config:PadConfig = DEF-PAD-CONFIG
-  ) -> Perimeter-Matrix-Planner :
-  #Perimeter-Matrix-Planner(inactive, pad-config)
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;;
+  ; GridPlanner
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+  rows:Int with:
+    ensure => ensure-positive!
+    as-method => true
+
+  columns:Int with:
+    ensure => ensure-positive!
+    as-method => true
+
+  pitch:Double|Dims with:
+    ensure => ensure-positive!
+    as-method => true
+
+with:
+  keyword-constructor => true
+  printer => true
 
 defn not-inactive? (inactive:PadIsland|Tuple<PadIsland>, row:Int, column:Int) -> True|False :
   match(inactive):
@@ -210,7 +244,8 @@ public defstruct ThermallyEnhanced-Matrix-Planner <: Perimeter-Matrix-Planner :
   `Tuple<PadIsland>`. In the `Tuple` case, the union of
   all `PadIsland`s in the tuple forms the inactive region.
   <DOC>
-  inactive:PadIsland|Tuple<PadIsland> with: (as-method => true)
+  inactive:PadIsland|Tuple<PadIsland> with:
+    as-method => true
   doc: \<DOC>
   Island of Pads that will be marked active.
   This island will override the `inactive` island.
@@ -222,20 +257,29 @@ public defstruct ThermallyEnhanced-Matrix-Planner <: Perimeter-Matrix-Planner :
   all `PadIsland`s in the tuple forms the active center region.
   <DOC>
   active:PadIsland|Tuple<PadIsland>
-  pad-config:PadConfig with: (
+  pad-config:PadConfig with:
     as-method => true
     default => DEF-PAD-CONFIG
-    )
-with:
-  constructor => #ThermallyEnhanced-Matrix-Planner
 
-public defn ThermallyEnhanced-Matrix-Planner (
-  --
-  inactive:PadIsland|Tuple<PadIsland>,
-  active:PadIsland|Tuple<PadIsland>,
-  pad-config:PadConfig = DEF-PAD-CONFIG
-  ) -> ThermallyEnhanced-Matrix-Planner :
-  #ThermallyEnhanced-Matrix-Planner(inactive, active, pad-config)
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;;
+  ; GridPlanner
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+  rows:Int with:
+    ensure => ensure-positive!
+    as-method => true
+
+  columns:Int with:
+    ensure => ensure-positive!
+    as-method => true
+
+  pitch:Double|Dims with:
+    ensure => ensure-positive!
+    as-method => true
+
+with:
+  keyword-constructor => true
+  printer => true
 
 
 defn is-active? (active:PadIsland|Tuple<PadIsland>, row:Int, column:Int) -> True|False :
@@ -266,14 +310,6 @@ Example: corner-cut = 2
 <DOC>
 public defstruct Corner-Cut-Matrix-Planner <: BGA-PadPlanner :
   doc: \<DOC>
-  Number of rows in the Grid
-  <DOC>
-  rows:Int
-  doc: \<DOC>
-  Number of columns in the Grid
-  <DOC>
-  columns:Int
-  doc: \<DOC>
   Width of the triangular region in each corner that will be inactive
   <DOC>
   corner-cut:Int
@@ -281,17 +317,26 @@ public defstruct Corner-Cut-Matrix-Planner <: BGA-PadPlanner :
     as-method => true
     default => DEF-PAD-CONFIG
     )
-with:
-  constructor => #Corner-Cut-Matrix-Planner
 
-public defn Corner-Cut-Matrix-Planner (
-  --
-  rows:Int
-  columns:Int
-  corner-cut:Int
-  pad-config:PadConfig = DEF-PAD-CONFIG
-  ) -> Corner-Cut-Matrix-Planner :
-  #Corner-Cut-Matrix-Planner(rows, columns, corner-cut, pad-config)
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;;
+  ; GridPlanner
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+  rows:Int with:
+    ensure => ensure-positive!
+    as-method => true
+
+  columns:Int with:
+    ensure => ensure-positive!
+    as-method => true
+
+  pitch:Double|Dims with:
+    ensure => ensure-positive!
+    as-method => true
+
+with:
+  keyword-constructor => true
+  printer => true
 
 public defmethod active? (x:Corner-Cut-Matrix-Planner, row:Int, column:Int) -> True|False:
   val r-inv = rows(x) - row - 1

--- a/src/landpatterns/BGA/planner.stanza
+++ b/src/landpatterns/BGA/planner.stanza
@@ -44,14 +44,16 @@ public defn BGA-Pad-Shaper (s:Dims) -> Shape :
   Circle(to-radius $ x(s))
 
 public defmethod shape-generator (bga:BGA-PadPlanner, row:Int, column:Int) -> (Dims -> Shape)|False :
-  if not active?(bga, row, column): false
-  else: BGA-Pad-Shaper
+  BGA-Pad-Shaper
 
 public defmethod pad-generator (x:BGA-PadPlanner, row:Int, column:Int) -> (Dims -> Pad)|False :
   val func? = shape-generator(x, row, column)
-  match(func?):
-    (x:False): false
-    (f): build-bga-pad{f(_0), pad-config(x)}
+  match(active?(x, row, column), func?):
+    (active:False, x): false
+    (active:True, f:(Dims -> Shape)):
+      build-bga-pad{f(_0), pad-config(x)}
+    (active:True, f:False):
+      throw $ NoGeneratorForActivePadError(row, column, "shape-generator")
 
 
 doc: \<DOC>

--- a/src/landpatterns/BGA/planner.stanza
+++ b/src/landpatterns/BGA/planner.stanza
@@ -35,6 +35,11 @@ public defstruct BGA-PadPlanner <: PadPlanner & GridPlanner:
   pad-config:PadConfig with:
     default => DEF-PAD-CONFIG
 
+  ; GridPlanner Base
+  pose:Pose with:
+    as-method => true
+    default => loc(0.0, 0.0)
+
 doc: \<DOC>
 Default Pad Shaper for BGA packages.
 This accepts a `Dims` object and will convert
@@ -76,6 +81,9 @@ public defstruct Full-Matrix-Planner <: BGA-PadPlanner :
   pitch:Double|Dims with:
     ensure => ensure-positive!
     as-method => true
+  pose:Pose with:
+    as-method => true
+    default => loc(0.0, 0.0)
 with:
   keyword-constructor => true
   printer => true
@@ -119,10 +127,13 @@ public defstruct Staggered-Matrix-Planner <: BGA-PadPlanner :
   columns:Int with:
     ensure => ensure-positive!
     as-method => true
-
   pitch:Double|Dims with:
     ensure => ensure-positive!
     as-method => true
+  pose:Pose with:
+    as-method => true
+    default => loc(0.0, 0.0)
+
 with:
   keyword-constructor => true
   printer => true
@@ -160,7 +171,9 @@ public defstruct EquilateralTriangle-Matrix-Planner <: Staggered-Matrix-Planner 
   columns:Int with:
     ensure => ensure-positive!
     as-method => true
-
+  pose:Pose with:
+    as-method => true
+    default => loc(0.0, 0.0)
   doc: \<DOC>
   Equilateral Distance between triangle points
   All pads in this planner are equidistant apart and
@@ -210,6 +223,9 @@ public defstruct Perimeter-Matrix-Planner <: BGA-PadPlanner :
   pitch:Double|Dims with:
     ensure => ensure-positive!
     as-method => true
+  pose:Pose with:
+    as-method => true
+    default => loc(0.0, 0.0)
 
 with:
   keyword-constructor => true
@@ -273,6 +289,9 @@ public defstruct ThermallyEnhanced-Matrix-Planner <: Perimeter-Matrix-Planner :
   pitch:Double|Dims with:
     ensure => ensure-positive!
     as-method => true
+  pose:Pose with:
+    as-method => true
+    default => loc(0.0, 0.0)
 
 with:
   keyword-constructor => true
@@ -330,6 +349,9 @@ public defstruct Corner-Cut-Matrix-Planner <: BGA-PadPlanner :
   pitch:Double|Dims with:
     ensure => ensure-positive!
     as-method => true
+  pose:Pose with:
+    as-method => true
+    default => loc(0.0, 0.0)
 
 with:
   keyword-constructor => true

--- a/src/landpatterns/VirtualLP.stanza
+++ b/src/landpatterns/VirtualLP.stanza
@@ -60,6 +60,23 @@ public defn VirtualPad (
 
   #VirtualPad(pad-id, pad-def, loc, side, name, to-class-vector(class))
 
+doc: \<DOC>
+Construct a set of `class` strings for VirtualPad creation.
+
+This will construct the following class strings:
+
+1.  "pad"
+2.  "col-N" where `N` will be the column number
+3.  "row-M" where `M` will be the row number
+<DOC>
+public defn build-vpad-classes (r:Int, c:Int) -> Tuple<String> :
+  [
+    "pad",
+    to-string("col-%_" % [c]),
+    to-string("row-%_" % [r])
+  ]
+
+
 public defn print-pads (o:OutputStream, pds:Seqable<VirtualPad> ) :
   val pds* = to-vector<VirtualPad>(pds)
   qsort!(pad-id, pds*)

--- a/src/landpatterns/dual-row.stanza
+++ b/src/landpatterns/dual-row.stanza
@@ -22,6 +22,7 @@ defpackage jsl/landpatterns/dual-row:
   import jsl/landpatterns/IPC
   import jsl/landpatterns/VirtualLP
   import jsl/landpatterns/grid-planner
+  import jsl/landpatterns/pad-grid
 
 public val DUAL-ROW-COLS = 2
 
@@ -87,35 +88,20 @@ public defmethod build-pads (
   ) -> False :
 
   val profile = lead-profile(pkg)
-  val num-scheme = lead-numbering(pkg)
-  val pad-planner = pad-planner(pkg)
-
   val rows = num-leads(pkg) / DUAL-ROW-COLS
   val params = compute-params(profile)
 
-  defn gen-pad-info () -> Seq<VirtualPad> :
-
-    val grid-gen = DualGridPlanner(
+  val pad-seq = pad-grid-smt(
+    pad-size = pad-size(params),
+    planner = pad-planner(pkg),
+    lead-grid = DualGridPlanner(
       lead-params = params
       rows = rows,
-      )
-    val pad-size = pad-size(params)
+    ),
+    num-scheme = lead-numbering(pkg) ;  num-scheme,
+  )
 
-    for pos in grid(grid-gen) seq? :
-      val [r, c] = [row(pos), column(pos)]
-      val pad-id = to-pad-id(num-scheme, r, c)
-      val pad-gen? = pad-generator(pad-planner, r, c)
-      match(pad-gen?):
-        (_:False): None()
-        (pad-gen):
-          val cls = [
-            "pad",
-            to-string("col-%_" % [c]),
-            to-string("row-%_" % [r])
-          ]
-          One $ VirtualPad(pad-id, pad-gen(pad-size), pose(pos), class = cls)
-
-  append-all(vp, gen-pad-info())
+  append-all(vp, pad-seq)
 
   match(thermal-lead?(pkg)):
     (lead-shape:Shape):

--- a/src/landpatterns/dual-row.stanza
+++ b/src/landpatterns/dual-row.stanza
@@ -21,6 +21,7 @@ defpackage jsl/landpatterns/dual-row:
   import jsl/landpatterns/leads
   import jsl/landpatterns/IPC
   import jsl/landpatterns/VirtualLP
+  import jsl/landpatterns/grid-planner
 
 public val DUAL-ROW-COLS = 2
 
@@ -93,31 +94,26 @@ public defmethod build-pads (
   val params = compute-params(profile)
 
   defn gen-pad-info () -> Seq<VirtualPad> :
-    for c in 0 to DUAL-ROW-COLS seq-cat :
-      ; Each Column consists of  N / 2 rows.
-      ; Each column is constructed as a 1-D grid that
-      ;   is translated and then rotated into place.
-      ; This allows:
-      ;  1. All of the pads have the -X axis pointing out
-      ;     from the package body.
-      ;  2. The numbering via Column-Major can satisfy the
-      ;     standard IC numbering strategy (ie, U shaped pattern)
-      val [pad-size, delta, pitch] = to-tuple(params)
-      val rot = to-double(180 * c)
-      val offset = loc(0.0, 0.0, rot) * loc((- delta) / 2.0, 0.0)
-      val grid = grid-locs(rows, 1, 1.0, pitch)
-      for (r in 0 to rows, pos in grid) seq? :
-        val pad-id = to-pad-id(num-scheme, r, c)
-        val pad-gen? = pad-generator(pad-planner, r, c)
-        match(pad-gen?):
-          (_:False): None()
-          (pad-gen):
-            val cls = [
-              "pad",
-              to-string("col-%_" % [c]),
-              to-string("row-%_" % [r])
-            ]
-            One $ VirtualPad(pad-id, pad-gen(pad-size), offset * pos, class = cls)
+
+    val grid-gen = DualGridPlanner(
+      lead-params = params
+      rows = rows,
+      )
+    val pad-size = pad-size(params)
+
+    for pos in grid(grid-gen) seq? :
+      val [r, c] = [row(pos), column(pos)]
+      val pad-id = to-pad-id(num-scheme, r, c)
+      val pad-gen? = pad-generator(pad-planner, r, c)
+      match(pad-gen?):
+        (_:False): None()
+        (pad-gen):
+          val cls = [
+            "pad",
+            to-string("col-%_" % [c]),
+            to-string("row-%_" % [r])
+          ]
+          One $ VirtualPad(pad-id, pad-gen(pad-size), pose(pos), class = cls)
 
   append-all(vp, gen-pad-info())
 
@@ -291,3 +287,95 @@ public defn build-smd-pin-1 (
   add-artwork(vp, Silkscreen("pin-1-marker", side), Circle(marker-pos, line-width), name = "pin-1-dot", class = "pin1-marker")
 
 
+doc: \<DOC>
+Dual-Row Grid Planner
+
+This grid planner supports Dual Row components like SOIC,
+SON, SOT, etc.
+
+The idea is that this constructs a 2-Column grid where:
+1.  Column 0 is in `-X` half plane and orders ascending for +Y to -Y
+2.  Column 1 is in the `+X` half-plane and is rotated 180 degrees such
+that the locations are ordered ascending from -Y to +Y.
+
+This creates the typical numbering scheme for ICs:
+
+```
+Left-Row    Col 0   Col 1   Right-Row
+   0          1       8         3
+   1          2       7         2
+   2          3       6         1
+   3          4       5         0
+
+```
+
+Notice that the row indices are flipped on the left and right side.
+<DOC>
+public defstruct DualGridPlanner <: GridPlanner :
+  doc: \<DOC>
+  Lead Profile Parameters
+  This object defines aspects of the lead profile such
+  as the row center-to-center span and the pitch between
+  pads in a column.
+
+  In this implementation, the pitch is assumed constant in
+  both columns.
+  <DOC>
+  lead-params:Lead-Profile-Params
+
+  doc: \<DOC>
+  Number of Rows in each Column of the grid.
+  <DOC>
+  rows:Int with:
+    ensure => ensure-positive!
+    as-method => true
+  doc: \<DOC>
+  Number of Columns in the Grid
+  By default the dual row is pegged to 2 columns.
+  <DOC>
+  columns:Int with:
+    ensure => ensure-positive!
+    as-method => true
+    default => DEF_DUAL_GRID_COLS
+
+with:
+  constructor => #DualGridPlanner
+  printer => true
+
+val DEF_DUAL_GRID_COLS = 2
+
+doc: \<DOC>
+Constructor for the DualGridPlanner
+
+This grid planner has a fixed 2 column grid.
+
+@param lead-params Sets the lead span information including pitch and
+pad center to center distance
+@param rows Number of rows in the grid.
+<DOC>
+public defn DualGridPlanner (
+  --
+  lead-params:Lead-Profile-Params
+  rows:Int,
+  ) -> DualGridPlanner :
+  #DualGridPlanner(lead-params, rows, DEF_DUAL_GRID_COLS)
+
+defmethod pitch (g:DualGridPlanner) -> Double|Dims :
+  pitch $ lead-params(g)
+
+defmethod grid (g:DualGridPlanner) -> Seq<GridPosition> :
+  if columns(g) != DEF_DUAL_GRID_COLS:
+    throw $ ValueError("Unexpected 'columns=%_' - Expected '%_'" % [columns(g), DEF_DUAL_GRID_COLS])
+
+  val [_, row-C-to-C, row-pitch] = to-tuple $ lead-params(g)
+
+  for c in 0 to columns(g) seq-cat:
+    val rot = to-double(180 * c)
+    val offset = loc(0.0, 0.0, rot) * loc((- row-C-to-C) / 2.0, 0.0)
+
+    val row-set = grid-locs(rows(g), 1, 1.0, row-pitch)
+    val raw-grid-locs = for row-loc in row-set seq:
+      offset * row-loc
+
+    for (raw-grid-loc in raw-grid-locs, r in 0 to false) seq:
+      GridPosition(r, c, raw-grid-loc)

--- a/src/landpatterns/framework.stanza
+++ b/src/landpatterns/framework.stanza
@@ -13,6 +13,7 @@ defpackage jsl/landpatterns/framework:
   forward jsl/landpatterns/numbering
   forward jsl/landpatterns/VirtualLP
   forward jsl/landpatterns/pad-planner
+  forward jsl/landpatterns/grid-planner
   forward jsl/landpatterns/pad-island
   forward jsl/landpatterns/leads
   forward jsl/landpatterns/pads

--- a/src/landpatterns/framework.stanza
+++ b/src/landpatterns/framework.stanza
@@ -23,3 +23,4 @@ defpackage jsl/landpatterns/framework:
   forward jsl/landpatterns/silkscreen
   forward jsl/landpatterns/courtyard
   forward jsl/landpatterns/introspection
+  forward jsl/landpatterns/pad-grid

--- a/src/landpatterns/grid-planner.stanza
+++ b/src/landpatterns/grid-planner.stanza
@@ -85,6 +85,40 @@ with:
   printer => true
 
 doc: \<DOC>
+Construct GridPlanner with Anchor
+<DOC>
+public defn GridPlanner (
+  --
+  pitch:Double|Dims
+  columns:Int
+  rows:Int
+  anchor:Anchor
+  ) -> GridPlanner:
+
+  val r = to-double(rows - 1)
+  val c = to-double(columns - 1)
+  val [w, h] = match(pitch):
+    (sp:Double): [c * sp, r * sp]
+    (dp:Dims): [c * x(dp), r * y(dp)]
+
+  val [vt, hr] = components(anchor)
+  val dx = match(hr) :
+    (hr:W) : w / 2.0
+    (hr:C) : 0.0
+    (hr:E) : w / -2.0
+  val dy = match(vt) :
+    (vt:S) : h / 2.0
+    (vt:C) : 0.0
+    (vt:N) : h / -2.0
+
+  GridPlanner(
+    pitch = pitch,
+    columns = columns,
+    rows = rows,
+    pose = loc(dx, dy)
+    )
+
+doc: \<DOC>
 Number of Rows in the Grid
 
 This value is expected to be a positive integer

--- a/src/landpatterns/grid-planner.stanza
+++ b/src/landpatterns/grid-planner.stanza
@@ -1,6 +1,7 @@
 #use-added-syntax(jitx)
 defpackage jsl/landpatterns/grid-planner:
   import core
+  import math
   import jitx
   import jitx/commands
 
@@ -145,3 +146,38 @@ is populated.
 public defenum StaggerPhase :
   Even-Phase
   Odd-Phase
+
+doc: \<DOC>
+Stagger Pattern for Marking Active Pads
+
+This function is a re-usable pattern generator for the
+staggered phase grid approach.
+
+@param phase This indicates the ordering of when a location is populated or not.
+@param row Row index (zero-based)
+@param column Column index (zero-based)
+<DOC>
+public defn stagger-pattern (phase:StaggerPhase, row:Int, column:Int) -> True|False :
+  val row-offset = 1 when phase == Even-Phase else 0
+  ((row + row-offset) % 2) == (column % 2)
+
+
+doc: \<DOC>
+Construct the asymmetric pitch for an equilateral triangle grid.
+
+This function assumes that you will use the {@link stagger-pattern} for
+constructing the active pads.
+
+This constructs a pad pattern in the form of a grid where every 3 pads
+creates a equilateral triangle.
+
+@param p Side length of the equilateral triangle.
+@return A two dimensional pitch where the row pitch is the height
+of an equilateral triangle and the col span is `p / 2.0`. Every
+skipped pad in a `stagger-pattern` creates a full length side of
+the equilateral triangle.
+<DOC>
+public defn equilateral-triangle-pitch (p:Double) -> Dims :
+  val row-span = sqrt(3.0) * 0.5 * p
+  val col-span = 0.5 * p
+  Dims(row-span, col-span)

--- a/src/landpatterns/grid-planner.stanza
+++ b/src/landpatterns/grid-planner.stanza
@@ -35,34 +35,54 @@ reusable way so that we don't have to copy and paste the same implementations
 over and over.
 
 <DOC>
-public deftype GridPlanner
+public defstruct GridPlanner:
+  doc: \<DOC>
+  Compute the Pitch (inter-pad distance) for the grid.
 
-doc: \<DOC>
-Compute the Pitch (inter-pad distance) for the grid.
+  The interpretation of the `pitch` is up to the `GridPlanner` implementation.
+  For example a `Equilateral Triangle` grid generator may interpret the
+  pitch as being non-orthonormal and instead be the equidistant distance between
+  pads.
 
-The interpretation of the `pitch` is up to the `GridPlanner` implementation.
-For example a `Equilateral Triangle` grid generator may interpret the
-pitch as being non-orthonormal and instead be the equidistant distance between
-pads.
+  By default this is a field but could be implemented as a defmethod
+  if needed.
 
-@return The value return can be either:
-1.  A `Double` where the X and Y pitches are the same creating a regular grid
-2.  A `Dims` where the X and Y pitches are different creating an irregular grid.
+  @return The value return can be either:
+  1.  A `Double` where the X and Y pitches are the same creating a regular grid
+  2.  A `Dims` where the X and Y pitches are different creating an irregular grid.
 
-The values of this grid are expected to be positive values only.
-<DOC>
-public defmulti pitch (g:GridPlanner) -> Double|Dims
+  The values of this grid are expected to be positive values only.
+  <DOC>
+  pitch:Double|Dims
+  doc: \<DOC>
+  Number of Columns in the Grid
 
+  This value is expected to be a positive integer
+  The columns traverse the X dimension.
+  <DOC>
+  columns:Int
+  doc: \<DOC>
+  Number of Rows in the Grid
 
-doc: \<DOC>
-Number of Columns in the Grid
+  This value is expected to be a positive integer
+  The rows traverse the Y dimension.
 
-This value is expected to be a positive integer
-The rows traverse the X dimension.
-<DOC>
-public defmulti columns (g:GridPlanner) -> Int
+  This value should be used when there is no uneven-ness
+  in the grid.
+  <DOC>
+  rows:Int
 
-public defmulti rows (g:GridPlanner) -> Int
+  doc: \<DOC>
+  Optional Pose Rotation for the Grid
+
+  This can be useful when we want to orientate the
+  grid differently from how we construct it.
+  <DOC>
+  pose:Pose with:
+    default => loc(0.0, 0.0)
+with:
+  keyword-constructor => true
+  printer => true
 
 doc: \<DOC>
 Number of Rows in the Grid
@@ -115,7 +135,7 @@ public defmethod grid (g:GridPlanner) -> Seq<GridPosition> :
   for r in 0 to rs seq-cat:
     for c in 0 to cs seq:
       val raw-pos = next(raw-grid)
-      GridPosition(r, c, raw-pos)
+      GridPosition(r, c, pose(g) * raw-pos)
 
 doc: \<DOC>
 Stagger Phase Definition

--- a/src/landpatterns/grid-planner.stanza
+++ b/src/landpatterns/grid-planner.stanza
@@ -116,3 +116,32 @@ public defmethod grid (g:GridPlanner) -> Seq<GridPosition> :
       val raw-pos = next(raw-grid)
       GridPosition(r, c, raw-pos)
 
+doc: \<DOC>
+Stagger Phase Definition
+
+This type is used to construct Staggered Grid implementations.
+The phase indicates whether the first row pad 0 is empty or populated.
+
+In the following examples, the `X` indicates a location where the
+pad is not populated. An `O` indicates a location where the pad
+is populated.
+
+## Pattern #1 - `Odd-Phase` :
+
+  ```
+    X | O | X  ...
+    O | X | O  ...
+    ...
+  ```
+
+## Pattern #2 - `Even-Phase` :
+
+  ```
+    O | X | O  ...
+    X | O | X  ...
+    ...
+  ```
+<DOC>
+public defenum StaggerPhase :
+  Even-Phase
+  Odd-Phase

--- a/src/landpatterns/grid-planner.stanza
+++ b/src/landpatterns/grid-planner.stanza
@@ -164,7 +164,7 @@ public defmethod grid (g:GridPlanner) -> Seq<GridPosition> :
     (p:Double):
       grid-locs(rs, cs, p, p)
     (pa:Dims):
-      grid-locs(rs, cs, y(pa), x(pa))
+      grid-locs(rs, cs, x(pa), y(pa))
 
   for r in 0 to rs seq-cat:
     for c in 0 to cs seq:
@@ -234,4 +234,4 @@ the equilateral triangle.
 public defn equilateral-triangle-pitch (p:Double) -> Dims :
   val row-span = sqrt(3.0) * 0.5 * p
   val col-span = 0.5 * p
-  Dims(row-span, col-span)
+  Dims(col-span, row-span)

--- a/src/landpatterns/grid-planner.stanza
+++ b/src/landpatterns/grid-planner.stanza
@@ -1,0 +1,118 @@
+#use-added-syntax(jitx)
+defpackage jsl/landpatterns/grid-planner:
+  import core
+  import jitx
+  import jitx/commands
+
+  import jsl/ensure
+  import jsl/errors
+
+public defstruct GridPosition :
+  row:Int with:
+    ensure => ensure-non-negative!
+  column:Int with:
+    ensure => ensure-non-negative!
+  pose:Pose
+with:
+  printer => true
+
+doc: \<DOC>
+Pad Grid Pose Planner
+
+This type defines the interface for the grid creation of a land pattern.
+The most obvious package with a grid is a Ball Grid Array (BGA) which is
+typically 2D orthonormal. But there is a wide diversity of different land
+pattern grids even within BGAs.
+
+In JSL, the land pattern framework assumes that all land patterns have a
+grid. Some of those grids may be quite trivial - ie a single row or column
+with N pins. Others can be quite complex with Uneven sides, unpopulated grid
+locations, among other idiosyncracies.
+
+The Grid Planner type allows us to define typical grid patterns in a common
+reusable way so that we don't have to copy and paste the same implementations
+over and over.
+
+<DOC>
+public deftype GridPlanner
+
+doc: \<DOC>
+Compute the Pitch (inter-pad distance) for the grid.
+
+The interpretation of the `pitch` is up to the `GridPlanner` implementation.
+For example a `Equilateral Triangle` grid generator may interpret the
+pitch as being non-orthonormal and instead be the equidistant distance between
+pads.
+
+@return The value return can be either:
+1.  A `Double` where the X and Y pitches are the same creating a regular grid
+2.  A `Dims` where the X and Y pitches are different creating an irregular grid.
+
+The values of this grid are expected to be positive values only.
+<DOC>
+public defmulti pitch (g:GridPlanner) -> Double|Dims
+
+
+doc: \<DOC>
+Number of Columns in the Grid
+
+This value is expected to be a positive integer
+The rows traverse the X dimension.
+<DOC>
+public defmulti columns (g:GridPlanner) -> Int
+
+public defmulti rows (g:GridPlanner) -> Int
+
+doc: \<DOC>
+Number of Rows in the Grid
+
+This value is expected to be a positive integer
+The rows traverse the Y dimension.
+@param c In some grids, the number of rows is variable. This
+means that from column to column the row count might change.
+The optional `c` argument identifies the column which may or
+may not be used.
+<DOC>
+public defmulti rows (g:GridPlanner, c:Int) -> Int
+
+public defmethod rows (g:GridPlanner, c:Int) -> Int :
+  rows(g)
+
+doc: \<DOC>
+Grid Generator
+
+This method constructs a sequence of `Pose` locations for the desired grid.
+
+This method must be implemented by the derived grid type to generate
+this sequence.
+
+@param g This Grid Planner
+@param rows Number of rows for the grid (Y)
+@param columns Number of columns for the grid (X)
+@return The generated grid consists of `GridPosition` objects which provide
+the row index, column index, and a `Pose` object for identifying the location
+of that grid position.
+
+<DOC>
+public defmulti grid (g:GridPlanner) -> Seq<GridPosition>
+
+doc: \<DOC>
+Default Grid Generator
+
+This default implementation creates either a regular or irregular grid
+leveraging the `grid-locs` function.
+<DOC>
+public defmethod grid (g:GridPlanner) -> Seq<GridPosition> :
+  val rs:Int = rows(g)
+  val cs:Int = columns(g)
+  val raw-grid = to-seq $ match(pitch(g)):
+    (p:Double):
+      grid-locs(rs, cs, p, p)
+    (pa:Dims):
+      grid-locs(rs, cs, y(pa), x(pa))
+
+  for r in 0 to rs seq-cat:
+    for c in 0 to cs seq:
+      val raw-pos = next(raw-grid)
+      GridPosition(r, c, raw-pos)
+

--- a/src/landpatterns/headers.stanza
+++ b/src/landpatterns/headers.stanza
@@ -10,12 +10,7 @@ defpackage jsl/landpatterns/headers:
   import jsl/geometry/box
   import jsl/geometry/LineRectangle
 
-  import jsl/landpatterns/packages
-  import jsl/landpatterns/VirtualLP
-  import jsl/landpatterns/numbering
-  import jsl/landpatterns/pad-planner
-  import jsl/landpatterns/leads
-  import jsl/landpatterns/silkscreen
+  import jsl/landpatterns/framework
 
 doc: \<DOC>
 Landpattern Generator for Headers
@@ -29,10 +24,10 @@ planner and numbering objects would likely fill the gap.
 <DOC>
 public defstruct Header <: Package :
 
-  num-leads:Int with: (
+  num-leads:Int with:
     ensure => ensure-positive!,
     as-method => true
-  )
+
   doc: \<DOC>
   Lead Type indicates TH vs SMT leads and their parameters.
   <DOC>
@@ -40,41 +35,45 @@ public defstruct Header <: Package :
   doc: \<DOC>
   Set the size of the pad diameter for through-hole and width for SMT.
   <DOC>
-  pad-diam:Double with: (
+  pad-diam:Double with:
     ensure => ensure-positive!
-  )
+
   doc: \<DOC>
   Number of Rows of leads on this package
   <DOC>
-  rows:Int with: (
+  rows:Int with:
     ensure => ensure-positive!
-  )
 
-  pitch:Double|Dims with: (
+  pitch:Double|Dims with:
     ensure => ensure-positive!
-  )
 
   doc: \<DOC>
   Package Body for the Header.
   <DOC>
-  package-body:PackageBody with: (as-method => true)
+  package-body:PackageBody with:
+    as-method => true
 
   doc: \<DOC>
   Pad Planner for the Header
   The planner determines which pads will be created in the
   grid. See {@link PadPlanner} for more info.
+  This planner will also determine whether through-hole or
+  surface-mount pads are created for this land pattern.
   <DOC>
-  pad-planner:PadPlanner with: (as-method => true)
+  pad-planner:PadPlanner with:
+    as-method => true
 
   doc: \<DOC>
   Lead Numbering Scheme for the Header
   <DOC>
-  lead-numbering:Numbering with: (as-method => true)
+  lead-numbering:Numbering with:
+    as-method => true
 
   doc: \<DOC>
   Density Level for the Generated Package
   <DOC>
-  density-level:DensityLevel with: (as-method => true)
+  density-level:DensityLevel with:
+    as-method => true
 
 with:
   hashable => true
@@ -85,7 +84,10 @@ defn default-pad-planner (lead-type:Lead) -> PadPlanner :
   PthPadPlanner(capsule-shaper)
 
 defn default-numbering (num-leads:Int, rows:Int) -> Numbering:
-  Row-Major-Numbering(num-leads, num-leads / rows)
+  ; This is a bit strange - but the typical numbering
+  ;  for a dual-row header is usually column wise
+  ;  not row wise.
+  Column-Major-Numbering(num-leads, num-leads / rows)
 
 public defn Header (
   --
@@ -99,13 +101,45 @@ public defn Header (
   lead-numbering:Numbering = default-numbering(num-leads, rows),
   density-level:DensityLevel = DENSITY-LEVEL
   ) -> Header :
+  if (num-leads % rows) != 0 :
+    throw $ ValueError("Number of Leads is not easily divisible by 'rows': num-leads=%_ rows=%_"  % [num-leads, rows])
   #Header(num-leads, lead-type, pad-diam, rows, pitch, package-body, pad-planner, lead-numbering, density-level)
 
-public defmethod name (bga:Header) -> String:
+public defmethod name (pkg:Header) -> String:
   "Header"
 
 public defmethod courtyard-excess (pkg:Header) -> Double :
-  0.0
+  0.2
+
+defn build-smt-pads (
+  pkg:Header,
+  lt:SMT-Lead,
+  pgrid:GridPlanner,
+  ) -> Seq<VirtualPad> :
+
+  ; FIX ME - we should pull from the lead data.
+  val pad-size = Dims(pad-diam(pkg), pad-diam(pkg))
+  pad-grid-smt(
+    pad-size = pad-size
+    planner = pad-planner(pkg)
+    lead-grid = pgrid
+    num-scheme = lead-numbering(pkg),
+  )
+
+defn build-th-pads (
+  pkg:Header,
+  lt:TH-Lead,
+  pgrid:GridPlanner,
+  ) -> Seq<VirtualPad> :
+
+  pad-grid-th(
+    lead-type = lt
+    planner = pad-planner(pkg),
+    lead-grid = pgrid
+    num-scheme = lead-numbering(pkg),
+    density-level = density-level(pkg),
+  )
+
 
 public defn build-vpads (
   pkg:Header,
@@ -113,46 +147,26 @@ public defn build-vpads (
   ):
   val lt = lead-type(pkg)
 
-  ; We call them rows for convenience in the definition
-  ;  but for our grid construction - the rows are actually columns
+  val rows = rows(pkg)
+  val cols = num-leads(pkg) / rows
+  val pgrid = GridPlanner(
+    pitch = pitch(pkg),
+    rows = rows,
+    columns = cols,
+    ; The grid gets constructed horizontally because of the "row"
+    ;  nomenclature but we want the resultant header to be shown vertically.
+    ;  The FlipY puts the pad ordering in the right direction.
+    pose = loc(0.0, 0.0, -90.0, FlipY)
+    )
 
-  val cols = rows(pkg)
-  val rows = num-leads(pkg) / cols
-  val pad-size = Dims(pad-diam(pkg), pad-diam(pkg))
-  val hole-size = Dims(typ $ width(lt), typ $ width(lt))
-  ; Generate the grid
-  val planner = pad-planner(pkg)
-  defn gen-pad-info () -> Seq<VirtualPad> :
-    val [xp, yp] = match(pitch(pkg)):
-      (p1:Double):
-        [p1, p1]
-      (p2:Dims):
-        [x(p2), y(p2)]
+  val pad-set = match(lt):
+    (smt:SMT-Lead):
+      build-smt-pads(pkg, smt, pgrid)
+    (th:TH-Lead):
+      build-th-pads(pkg, th, pgrid)
 
-    val grid = to-seq $ grid-locs(rows, cols, xp, yp)
-    for (c in 0 to cols) seq-cat :
-      for (r in 0 to rows) seq?:
-        val pos = next(grid)
-        val pad-id = to-pad-id(lead-numbering(pkg), r, c)
-        val pad-gen? = match(lt):
-          (smt:SMT-Lead):
-            pad-generator(planner, r, c)
-          (th:TH-Lead):
-            val g = th-pad-generator(planner, r, c)
-            match(g):
-              (_:False): false
-              (func): {func(hole-size, _0)}
-        match(pad-gen?):
-          (_:False): None()
-          (pad-gen):
-            val cls = [
-              "pad",
-              to-string("col-%_" % [c]),
-              to-string("row-%_" % [r])
-            ]
-            One $ VirtualPad(pad-id, pad-gen(pad-size), pos, class = cls)
+  append-all(vp, pad-set)
 
-  append-all(vp, gen-pad-info())
 
 public defmethod build-pads (
   pkg:Header,

--- a/src/landpatterns/numbering.stanza
+++ b/src/landpatterns/numbering.stanza
@@ -21,7 +21,7 @@ row and column setup.
 -  For Quad style components (QFP, QFN, etc), there are typically
   4 columns and `N / 4` rows (where `N` is the number of pins).
 -  For BGA style components, there are typically N pins and X columns by Y rows
-  where X * Y = N (for a Full Matrix). This is only example to demonstrate the
+  where X * Y = N (for a Full Matrix). This is only an example to demonstrate the
   typical row and column configurations. More complex arrangements are possible.
 
 Note that this numbering scheme does not consider the exposed thermal lead/pad
@@ -186,7 +186,23 @@ numbering scheme. For example - a `col-offset = 1` would construct:
 @param col-skip Value to divide the raw column value by. This parameter
 is useful when working with staggered grids where a pad is active every
 other column. When this value is greater than 1 - then the numbering scheme
-will accept twice as many columns as normal.
+will accept twice as many columns as normal. The default value for this
+parameter is 1.
+
+Consider the following example where `X` is the pad location and
+`O` is a skipped location and `col-skip = 2`
+
+```
+   0     1     2     3     4   ...    Raw Columns
+   0     0     1     1     2   ...    Assigned Column
+   X  |  O  |  X  |  O  |  X          Pad Row 0
+   O  |  X  |  O  |  X  |  O          Pad Row 1
+   ...
+```
+
+In this case, the stagger pattern results in 5 columns, but for
+many numbering conditions, that isn't what we want. This `skip`
+parameter allows us to reduce the total number of columns.
 
 @param row-skip Value to divide the raw row value by. This parameter
 is useful when working with a staggered grid where a pad is active every

--- a/src/landpatterns/numbering.stanza
+++ b/src/landpatterns/numbering.stanza
@@ -183,6 +183,16 @@ numbering scheme. For example - a `col-offset = 1` would construct:
     8   12
   ```
 
+@param col-skip Value to divide the raw column value by. This parameter
+is useful when working with staggered grids where a pad is active every
+other column. When this value is greater than 1 - then the numbering scheme
+will accept twice as many columns as normal.
+
+@param row-skip Value to divide the raw row value by. This parameter
+is useful when working with a staggered grid where a pad is active every
+other row. When this value is greater than 1 - then the numbering scheme
+will accept twice as many rows as normal.
+
 @throws ValueError If num-pads is not divisible by num-columns.
 <DOC>
 public defstruct Column-Major-Numbering <: Numbering :
@@ -196,6 +206,12 @@ public defstruct Column-Major-Numbering <: Numbering :
   col-offset:Int with:
     ensure => ensure-non-negative!
     default => 0
+  col-skip:Int with:
+    ensure => ensure-positive!
+    default => 1
+  row-skip:Int with:
+    ensure => ensure-positive!
+    default => 1
 with:
   constructor => #Column-Major-Numbering
 
@@ -204,9 +220,11 @@ public defn Column-Major-Numbering (
   --
   row-offset:Int = 0
   col-offset:Int = 0
+  col-skip:Int = 1
+  row-skip:Int = 1
   ) -> Column-Major-Numbering :
   ensure-divisible!(num-pads, num-columns, "Column-Major-Numbering")
-  #Column-Major-Numbering(num-pads, num-columns, row-offset, col-offset)
+  #Column-Major-Numbering(num-pads, num-columns, row-offset, col-offset, col-skip, row-skip)
 
 public defmethod to-pad-id (x:Column-Major-Numbering, row:Int, column:Int) -> Int|Ref :
   val cols = num-columns(x)
@@ -215,13 +233,13 @@ public defmethod to-pad-id (x:Column-Major-Numbering, row:Int, column:Int) -> In
   if (row < 0 or column < 0):
     throw $ ValueError("Expecting Non-negative Indices: r=%_ c=%_" % [row,column])
 
-  if not (row < rows):
+  if not (row < (rows * row-skip(x))):
     throw $ ValueError("Invalid Row Offset: %_ < %_" % [row, rows])
 
-  if not (column < cols):
+  if not (column < (cols * col-skip(x))):
     throw $ ValueError("Invalid Column Offset: %_ < %_" % [column, cols])
 
-  ((column + col-offset(x)) * rows) + (row + 1 + row-offset(x))
+  (((column / col-skip(x)) + col-offset(x)) * rows) + ((row / row-skip(x)) + 1 + row-offset(x))
 
 doc: \<DOC>
 Uneven (Asymmetric) Column Major Numbering

--- a/src/landpatterns/pad-grid.stanza
+++ b/src/landpatterns/pad-grid.stanza
@@ -64,6 +64,7 @@ public defn pad-grid-th (
   if not is-through-hole?(planner):
     throw $ ValueError("Mismatch Lead Type and Planner - Planner doesn't support Through-Holes")
 
+
   val lead-diam = width(lead-type)
   val hole-diam = compute-hole-diam(lead-diam, density-level)
   val pad-diam = compute-pad-diam(hole-diam, density-level)
@@ -77,7 +78,9 @@ public defn pad-grid-th (
     match(pad-gen?):
       (_:False): None()
       (func):
-        val pad-gen = {func(hole-size, pad-size)}
+        val pad-gen = match(override(lead-type)):
+          (_:None): {func(hole-size, pad-size)}
+          (given:One<Pad>): {value(given)}
         val cls = build-vpad-classes(r, c)
         One $ VirtualPad(pad-id, pad-gen(), pose(pos), class = cls)
 

--- a/src/landpatterns/pad-grid.stanza
+++ b/src/landpatterns/pad-grid.stanza
@@ -31,13 +31,13 @@ public defn pad-grid-smt (
 
   for pos in grid(lead-grid) seq?:
     val [r, c] = [row(pos), column(pos)]
-      val pad-id = to-pad-id(num-scheme, r, c)
-      val pad-gen? = pad-generator(planner, r, c)
-      match(pad-gen?):
-        (_:False): None()
-        (pad-gen):
-          val cls = build-vpad-classes(r, c)
-          One $ VirtualPad(pad-id, pad-gen(pad-size), pose(pos), class = cls)
+    val pad-id = to-pad-id(num-scheme, r, c)
+    val pad-gen? = pad-generator(planner, r, c)
+    match(pad-gen?):
+      (_:False): None()
+      (pad-gen):
+        val cls = build-vpad-classes(r, c)
+        One $ VirtualPad(pad-id, pad-gen(pad-size), pose(pos), class = cls)
 
 doc: \<DOC>
 Construct a Through-Hole Pad Grid using a `GridPlanner`
@@ -73,7 +73,6 @@ public defn pad-grid-th (
   for pos in grid(lead-grid) seq?:
     val [r, c] = [row(pos), column(pos)]
     val pad-id = to-pad-id(num-scheme, r, c)
-
     val pad-gen? = th-pad-generator(planner, r, c)
     match(pad-gen?):
       (_:False): None()

--- a/src/landpatterns/pad-grid.stanza
+++ b/src/landpatterns/pad-grid.stanza
@@ -1,0 +1,84 @@
+#use-added-syntax(jitx)
+defpackage jsl/landpatterns/pad-grid:
+  import core
+  import jitx
+
+  import jsl/design/settings
+  import jsl/errors
+  import jsl/landpatterns/framework
+  import jsl/landpatterns/two-pin/utils
+
+
+doc: \<DOC>
+Construct an SMT Pad Grid using a `GridPlanner`
+
+This is a common helper routine for constructing a grid
+of pads.
+
+@param pad-size Dimensions of the pad to construct
+@param planner Pad Planner that determines shaping and population
+@param lead-grid Grid construction in the form of pad positions
+@param num-scheme Pad numbering scheme depending on location.
+@return Sequence of pads for applying to a `VirtualLP` node.
+<DOC>
+public defn pad-grid-smt (
+  --
+  pad-size:Dims,
+  planner:PadPlanner,
+  lead-grid:GridPlanner,
+  num-scheme:Numbering,
+  ) -> Seq<VirtualPad>:
+
+  for pos in grid(lead-grid) seq?:
+    val [r, c] = [row(pos), column(pos)]
+      val pad-id = to-pad-id(num-scheme, r, c)
+      val pad-gen? = pad-generator(planner, r, c)
+      match(pad-gen?):
+        (_:False): None()
+        (pad-gen):
+          val cls = build-vpad-classes(r, c)
+          One $ VirtualPad(pad-id, pad-gen(pad-size), pose(pos), class = cls)
+
+doc: \<DOC>
+Construct a Through-Hole Pad Grid using a `GridPlanner`
+@param lead-type Through-Hole Lead parameterization
+@param planner Pad Planner providing shapes and population
+@param lead-grid Construct a grid of positions for the pads
+@param num-scheme Lead numbering of the grid.
+@param density-level IPC density level. The default value
+is based on {@link DENSITY-LEVEL} from `jsl/design/settings`
+@return Sequence of pads for applying to a `VirtualLP` node.
+@throws ValueError If the `planner` doesn't support through-hole generators.
+To support through-hole, the `planner` needs to implement the `hole-generator`
+defmethod and have it return a function instead of `false`.
+<DOC>
+public defn pad-grid-th (
+  --
+  lead-type:TH-Lead
+  planner:PadPlanner,
+  lead-grid:GridPlanner,
+  num-scheme:Numbering,
+  density-level:DensityLevel = DENSITY-LEVEL
+  ) -> Seq<VirtualPad>:
+
+  if not is-through-hole?(planner):
+    throw $ ValueError("Mismatch Lead Type and Planner - Planner doesn't support Through-Holes")
+
+  val lead-diam = width(lead-type)
+  val hole-diam = compute-hole-diam(lead-diam, density-level)
+  val pad-diam = compute-pad-diam(hole-diam, density-level)
+  val pad-size = Dims(pad-diam, pad-diam)
+  val hole-size = Dims(hole-diam, hole-diam)
+
+  for pos in grid(lead-grid) seq?:
+    val [r, c] = [row(pos), column(pos)]
+    val pad-id = to-pad-id(num-scheme, r, c)
+
+    val pad-gen? = th-pad-generator(planner, r, c)
+    match(pad-gen?):
+      (_:False): None()
+      (func):
+        val pad-gen = {func(hole-size, pad-size)}
+        val cls = build-vpad-classes(r, c)
+        One $ VirtualPad(pad-id, pad-gen(), pose(pos), class = cls)
+

--- a/src/landpatterns/pad-planner.stanza
+++ b/src/landpatterns/pad-planner.stanza
@@ -235,13 +235,6 @@ hole should be created. If this function returns `false` at an
 functions will raise an exception.
 
 <DOC>
-
-; TODO - Should we make this return `Circle|Capsule` instead of `Shape` ?
-;   Holes in the board generally speaking are very expensive to make in
-;   other shapes but I don't necessarily want to limit things here.
-;   Perhaps with make non-Circle/Capsule shaped holes a check that is
-;   disable-able so that the user can override.
-
 public defmulti hole-generator (x:PadPlanner, row:Int, column:Int) -> (Dims -> Shape)|False
 
 doc: \<DOC>

--- a/src/landpatterns/pad-planner.stanza
+++ b/src/landpatterns/pad-planner.stanza
@@ -56,6 +56,8 @@ defpackage jsl/landpatterns/pad-planner:
   import jsl/geometry/basics
   import jsl/errors
 
+  import jsl/landpatterns/grid-planner
+
 doc: \<DOC>
 Pad Planner Base Type
 
@@ -354,7 +356,9 @@ public defstruct PthPadPlanner <: ShapePadPlanner:
   Both top and bottom copper for the PTH will
   have the same shape.
   <DOC>
-  shaper:(Dims -> Shape) with: (as-method => true)
+  shaper:(Dims -> Shape) with:
+    as-method => true
+    default => to-CircleOrCapsule
 
 doc: \<DOC>
 Shape generator for Circle/Capsule
@@ -374,8 +378,30 @@ public defn to-CircleOrCapsule (d:Dims) -> Shape :
 public defmethod hole-generator (x:PthPadPlanner, row:Int, column:Int) -> (Dims -> Shape)|False:
   to-CircleOrCapsule
 
-public defn PthPadPlanner () -> PthPadPlanner :
-  PthPadPlanner(to-CircleOrCapsule)
+
+public defstruct StaggerPthPlanner <: PthPadPlanner :
+  doc: \<DOC>
+  Copper pad shape
+  Both top and bottom copper for the PTH will
+  have the same shape.
+  <DOC>
+  shaper:(Dims -> Shape) with:
+    as-method => true
+    default => to-CircleOrCapsule
+
+  doc: \<DOC>
+  Set the stagger phase for the planner
+  <DOC>
+  phase:StaggerPhase with:
+    default => Even-Phase
+with:
+  keyword-constructor => true
+  printer => true
+
+public defmethod active? (x:StaggerPthPlanner, row:Int, column:Int) -> True|False:
+  stagger-pattern(phase(x), row, column)
+
+
 
 doc: \<DOC>
 Error for MisMatched Active & Generators

--- a/src/landpatterns/pad-planner.stanza
+++ b/src/landpatterns/pad-planner.stanza
@@ -54,6 +54,7 @@ defpackage jsl/landpatterns/pad-planner:
     prefix(Rectangle) => jitx-
   import jsl/landpatterns/pads
   import jsl/geometry/basics
+  import jsl/errors
 
 doc: \<DOC>
 Pad Planner Base Type
@@ -77,6 +78,25 @@ placed at this location.
 @return Pad Grid location is Active.
 <DOC>
 public defmulti active? (x:PadPlanner, row:Int, column:Int) -> True|False
+
+doc: \<DOC>
+Is this PadPlanner configured to generate through-hole pads ?
+
+This is a flag that indicates whether this planner is intended
+for through-hole or surface mount pad generation. This is a
+helper function to make it easier to determine whether the
+`pad-generator` or `th-pad-generator` functions should be
+called in a particular application
+<DOC>
+public defmulti is-through-hole? (x:PadPlanner) -> True|False
+
+doc: \<DOC>
+Default Implementation
+
+This just checks if `hole-generator` returns False or not.
+<DOC>
+public defmethod is-through-hole? (x:PadPlanner) -> True|False :
+  hole-generator(x, 0, 0) is-not False
 
 doc: \<DOC>
 Retrieve the Shape Generator for this grid position
@@ -158,7 +178,6 @@ public defmethod th-pad-generator (x:PadPlanner, row:Int, column:Int) -> ( (Dims
   val shape-gen = shape-generator(x, row, column)
   val hole-gen = hole-generator(x, row, column)
 
-
   match(active?(x, row, column), shape-gen, hole-gen):
     (a:False, f, h): false
     (a:True, f:(Dims -> Shape), h:(Dims -> Shape)):
@@ -168,14 +187,20 @@ public defmethod th-pad-generator (x:PadPlanner, row:Int, column:Int) -> ( (Dims
         npth-pad(h(hole))
       npth-gen
     (a:True, f, h):
-      ; TODO - Log Warning Here ?
-      ; this is a exceptional case but I'm not sure it is an error
-      false
+      throw $ ValueError("Grid Location [row=%_, col=%_] Marked Active - But no shaper functions provided" % [row, column])
 
 doc: \<DOC>
 Hole Shape for Pad
 This function provides the user with the ability to create a
 plated through-hole pad instead of an SMT pad.
+
+The typical use case is to only return `False` if the land pattern
+contains zero through-hole pads. If you need to create a land pattern
+with a mix of through-hole and surface mount pads - it is better to construct
+this land pattern through composition.
+
+If you intend to violate this convention - you must provide a reformed
+version of {@link is-through-hole?} in your derived implementation.
 
 @param x Pad Planner (self)
 @param row Zero-based Index into the grid of a package's pad positions.
@@ -186,12 +211,14 @@ Otherwise, if a the function returns a shape, then holes of that
 shape will be created. Note - that you can pass any shape here but
 your fabricator may have limitations on what shapes it can create.
 
-TODO - Should we make this return `Circle|Capsule` instead of `Shape` ?
-  Holes in the board generally speaking are very expensive to make in
-  other shapes but I don't necessarily want to limit things here.
-  Perhaps with make non-Circle/Capsule shaped holes a check that is
-  disable-able so that the user can override.
 <DOC>
+
+; TODO - Should we make this return `Circle|Capsule` instead of `Shape` ?
+;   Holes in the board generally speaking are very expensive to make in
+;   other shapes but I don't necessarily want to limit things here.
+;   Perhaps with make non-Circle/Capsule shaped holes a check that is
+;   disable-able so that the user can override.
+
 public defmulti hole-generator (x:PadPlanner, row:Int, column:Int) -> (Dims -> Shape)|False
 
 doc: \<DOC>

--- a/src/landpatterns/pad-planner.stanza
+++ b/src/landpatterns/pad-planner.stanza
@@ -101,6 +101,10 @@ public defmethod is-through-hole? (x:PadPlanner) -> True|False :
 doc: \<DOC>
 Retrieve the Shape Generator for this grid position
 
+In general, this function should not query `active?` unless
+it needs to. The `active?` flag will be queried in the `pad-generator`
+functions when selecting whether to generate pad shapes.
+
 @param x Pad Planner (self)
 @param row Zero-based Index into the grid of a package's pad positions.
 @param column Zero-based Index into the grid of a package's pad positions.
@@ -139,11 +143,13 @@ for creating the pad definition. The default soldermask and
 pastemask settings will be used.
 <DOC>
 public defmethod pad-generator (x:PadPlanner, row:Int, column:Int) -> (Dims -> Pad)|False:
-  val func = shape-generator(x, row, column)
-  match(func):
-    (x:False): false
-    (f): smd-pad{f(_0)}
-
+  val func? = shape-generator(x, row, column)
+  match(active?(x, row, column), func?):
+    (active:False, x): false
+    (active:True, f:(Dims -> Shape)):
+      smd-pad{f(_0)}
+    (active:True, x:False):
+      throw $ NoGeneratorForActivePadError(row, column, "shape-generator")
 
 doc: \<DOC>
 Through-hole Pad Generator
@@ -172,13 +178,16 @@ depending on whether the `shape-generator` returns true or false.
 For non-plated holes - the `copper:Dims` argument will be ignored.
 
 If the user tries to use `th-pad-generator` when `hole-generator`
-returns false - then no pad is created.
+returns false - then this function will raise an error.
+
+@throws NoGeneratorForActivePadError When an improper configuration
+of hole and shape generator functions are provided to an active grid location.
 <DOC>
 public defmethod th-pad-generator (x:PadPlanner, row:Int, column:Int) -> ( (Dims, Dims) -> Pad )|False :
-  val shape-gen = shape-generator(x, row, column)
-  val hole-gen = hole-generator(x, row, column)
+  val shape-gen? = shape-generator(x, row, column)
+  val hole-gen? = hole-generator(x, row, column)
 
-  match(active?(x, row, column), shape-gen, hole-gen):
+  match(active?(x, row, column), shape-gen?, hole-gen?):
     (a:False, f, h): false
     (a:True, f:(Dims -> Shape), h:(Dims -> Shape)):
       pth-pad{h(_0), f(_1)}
@@ -187,12 +196,16 @@ public defmethod th-pad-generator (x:PadPlanner, row:Int, column:Int) -> ( (Dims
         npth-pad(h(hole))
       npth-gen
     (a:True, f, h):
-      throw $ ValueError("Grid Location [row=%_, col=%_] Marked Active - But no shaper functions provided" % [row, column])
+      throw $ NoGeneratorForActivePadError(row, column, "shape- or hole-")
 
 doc: \<DOC>
 Hole Shape for Pad
 This function provides the user with the ability to create a
 plated through-hole pad instead of an SMT pad.
+
+In general, this function should not query `active?` unless
+it needs to. The `active?` flag will be queried in the `pad-generator`
+functions when selecting whether to generate pad shapes.
 
 The typical use case is to only return `False` if the land pattern
 contains zero through-hole pads. If you need to create a land pattern
@@ -206,10 +219,18 @@ version of {@link is-through-hole?} in your derived implementation.
 @param row Zero-based Index into the grid of a package's pad positions.
 @param column Zero-based Index into the grid of a package's pad positions.
 
-@return If this function returns `false` then no hole is created.
-Otherwise, if a the function returns a shape, then holes of that
-shape will be created. Note - that you can pass any shape here but
-your fabricator may have limitations on what shapes it can create.
+@return This function should return a function that will convert
+a `Dims` object into a `Shape`. That function will need to have the
+following signature:
+
+```stanza
+Dims -> Shape
+```
+
+This function can return `false` for location in the grid where no
+hole should be created. If this function returns `false` at an
+`active? = true` grid location - then the related pad generation
+functions will raise an exception.
 
 <DOC>
 
@@ -245,8 +266,7 @@ public defmethod active? (x:ShapePadPlanner, row:Int, column:Int) -> True|False 
   true
 
 public defmethod shape-generator (x:ShapePadPlanner, row:Int, column:Int) -> (Dims -> Shape)|False:
-  if active?(x, row, column): shaper(x)
-  else: false
+  shaper(x)
 
 public val rect-shaper:(Dims -> Shape) = Rectangle ;  {Rectangle(_0)}
 public val RectanglePadPlanner = ShapePadPlanner(rect-shaper)
@@ -274,10 +294,8 @@ public defmethod active? (x:Pin1-PadPlanner, row:Int, column:Int) -> True|False 
   true
 
 public defmethod shape-generator (x:Pin1-PadPlanner, row:Int, column:Int) -> (Dims -> Shape)|False:
-  if active?(x, row, column):
-    if column == 0 and row == 0: pin1-shaper(x)
-    else: shaper(x)
-  else: false
+  if column == 0 and row == 0: pin1-shaper(x)
+  else: shaper(x)
 
 doc: \<DOC>
 Chamfered Corner Shaper
@@ -312,20 +330,17 @@ public defmethod active? (x:Corner-PadPlanner, row:Int, column:Int) -> True|Fals
     (_): true
 
 public defmethod shape-generator (x:Corner-PadPlanner, row:Int, column:Int) -> (Dims -> Shape)|False:
-  if active?(x, row, column):
+  val rows = match(rows(x)):
+    (r-set:Tuple<Int>): r-set[column]
+    (row-max:Int): row-max
 
-    val rows = match(rows(x)):
-      (r-set:Tuple<Int>): r-set[column]
-      (row-max:Int): row-max
-
-    if row == 0:
-      corner-shaper(x)
-    else if row == (rows - 1):
-      val flip-Y = loc(Point(0.0, 0.0), FlipY)
-      {flip-Y * corner-shaper(x)(_0)}
-    else:
-      shaper(x)
-  else: false
+  if row == 0:
+    corner-shaper(x)
+  else if row == (rows - 1):
+    val flip-Y = loc(Point(0.0, 0.0), FlipY)
+    {flip-Y * corner-shaper(x)(_0)}
+  else:
+    shaper(x)
 
 doc: \<DOC>
 Plated Through-Hole Pad Planner
@@ -361,3 +376,17 @@ public defmethod hole-generator (x:PthPadPlanner, row:Int, column:Int) -> (Dims 
 
 public defn PthPadPlanner () -> PthPadPlanner :
   PthPadPlanner(to-CircleOrCapsule)
+
+doc: \<DOC>
+Error for MisMatched Active & Generators
+
+If the generator functions return `False` for an active
+pad grid location - then this exception will be thrown.
+<DOC>
+public defstruct NoGeneratorForActivePadError <: Exception:
+  row:Int
+  column:Int
+  gen-func:String
+
+defmethod print (o:OutputStream, e:NoGeneratorForActivePadError):
+  print(o, "No '%_' generator for Active Pad [r=%_, c=%_]" % [gen-func(e), row(e), column(e)])

--- a/src/landpatterns/quad.stanza
+++ b/src/landpatterns/quad.stanza
@@ -30,6 +30,7 @@ defpackage jsl/landpatterns/quad:
   import jsl/landpatterns/VirtualLP
   import jsl/landpatterns/numbering
   import jsl/landpatterns/pad-planner
+  import jsl/landpatterns/grid-planner
 
 public val QUAD-NUM-COLUMNS = 4
 
@@ -288,29 +289,29 @@ public defmethod build-pads (
   val y-params = compute-params(y-leads(profile))
 
   defn gen-pad-info () -> Seq<VirtualPad> :
-    for c in 0 to QUAD-NUM-COLUMNS seq-cat :
-      ; Get the number of rows in this column
-      val rows = row-sets[c]
-      ; Each column of the grid is structured as a sequence of
-      ;  N or M pads. We then translate and then rotate that grid
-      ;  to place it in the 4 edge locations.
-      val params = x-params when c % 2 == 0 else y-params
-      val [pad-size, delta, pitch] = to-tuple(params)
-      val rot = to-double(90 * c)
-      val offset = loc(0.0, 0.0, rot) * loc((- delta) / 2.0, 0.0)
-      val grid = grid-locs(rows, 1, 1.0, pitch)
-      for (r in 0 to rows, pos in grid) seq? :
-        val pad-id = to-pad-id(num-scheme, r, c)
-        val pad-gen? = pad-generator(pad-planner, r, c)
-        match(pad-gen?):
-          (_:False): None()
-          (pad-gen):
-            val cls = [
-              "pad",
-              to-string("col-%_" % [c]),
-              to-string("row-%_" % [r])
-            ]
-            One $ VirtualPad(pad-id, pad-gen(pad-size), offset * pos, class = cls)
+
+    val grid-gen = QuadGridPlanner(
+      param-sets = [x-params, y-params],
+      row-sets = row-sets
+    )
+
+    for pos in grid(grid-gen) seq? :
+      val [r, c] = [row(pos), column(pos)]
+
+      val params = get-params(grid-gen, c)
+      val pad-size = pad-size(params)
+
+      val pad-id = to-pad-id(num-scheme, r, c)
+      val pad-gen? = pad-generator(pad-planner, r, c)
+      match(pad-gen?):
+        (_:False): None()
+        (pad-gen):
+          val cls = [
+            "pad",
+            to-string("col-%_" % [c]),
+            to-string("row-%_" % [r])
+          ]
+          One $ VirtualPad(pad-id, pad-gen(pad-size), pose(pos), class = cls)
 
   append-all(vp, gen-pad-info())
 
@@ -321,3 +322,121 @@ public defmethod build-pads (
     (x:False): false
 
 
+doc: \<DOC>
+Quad Grid Planner
+
+This grid planner supports Quad Package components like QFN,
+QFP, etc
+
+The idea is that this constructs a 4-Column grid where:
+1.  Column 0 is in `-X` half plane and orders ascending for +Y to -Y
+2.  Column 1 is in the `-Y` half-plane and is rotated 90 degrees
+3.  Column 2 is in the `+X` half plane and is rotated 180 degrees
+4.  Column 3 is in the `+Y` half-plane and is rotated 270 degrees
+
+This creates the typical numbering scheme for ICs:
+
+```
+Left-Row  Col 0               Col 2    Right-Row
+       Col 3 ->  16 15 14 13
+   0          1               12         3
+   1          2               11         2
+   2          3               10         1
+   3          4               9          0
+       Col 1 ->  5  6  7  8
+```
+
+Notice that the row indices are directed down the edge of the package
+and result in the same flipped on the left and right side pattern as
+in a dual-package.
+<DOC>
+public defstruct QuadGridPlanner <: GridPlanner :
+  doc: \<DOC>
+  Lead Profile Parameter Sets
+  The quad package is assumed to support different Lead-Profiles
+  on the Y-span (-X and +X column) and X-span (-Y and +Y columns).
+  This value is expected to consist of the lead params in the following
+  order:
+  [Y-span, X-span]
+  <DOC>
+  param-sets:[Lead-Profile-Params, Lead-Profile-Params]
+
+  doc: \<DOC>
+  Row Sets for the columns of the grid.
+  This value can optionally be a single number of rows which is
+  applied to all columns. This is the most common for regular
+  square quad packages.
+  This value can also be a `Tuple` of integers identifying unique
+  numbers of rows per column. This is most useful for rectangular
+  quad packages with uneven numbers of pads on each lead span.
+  <DOC>
+  row-sets:Int|Tuple<Int>
+
+  doc: \<DOC>
+  Number of Columns in the Grid
+  By default the quad package is pegged to 4 columns.
+  <DOC>
+  columns:Int with:
+    ensure => ensure-positive!
+    as-method => true
+    default => DEF_QUAD_GRID_COLS
+
+with:
+  constructor => #QuadGridPlanner
+  printer => true
+
+val DEF_QUAD_GRID_COLS = 4
+
+doc: \<DOC>
+Constructor for the Quad Grid Planner
+<DOC>
+public defn QuadGridPlanner (
+  --
+  param-sets:[Lead-Profile-Params, Lead-Profile-Params]
+  row-sets:Int|Tuple<Int>
+  ) -> QuadGridPlanner :
+  #QuadGridPlanner(param-sets, row-sets, DEF_QUAD_GRID_COLS)
+
+defmethod rows (g:QuadGridPlanner) -> Int :
+  match(row-sets(g)):
+    (uneven-row:Tuple<Int>):
+      throw $ ValueError("Unexpected Combination - Uneven Rows but no Column Indicated")
+    (static-row:Int):
+      static-row
+
+defmethod rows (g:QuadGridPlanner, c:Int) -> Int :
+  match(row-sets(g)):
+    (uneven-row:Tuple<Int>):
+      uneven-row[c]
+    (static-row:Int): static-row
+
+defmethod pitch (g:QuadGridPlanner) -> Double|Dims :
+  val given = param-sets(g)
+  Dims(pitch(given[0]), pitch(given[1]))
+
+doc: \<DOC>
+Retrieve the appropriate lead profile parameters depending on column
+@param c Column index as a zero-indexed value.
+<DOC>
+public defn get-params (g:QuadGridPlanner, c:Int) -> Lead-Profile-Params :
+  param-sets(g)[c % 2]
+
+defmethod grid (g:QuadGridPlanner) -> Seq<GridPosition> :
+  if columns(g) != DEF_QUAD_GRID_COLS:
+    throw $ ValueError("Unexpected 'columns=%_' - Expected '%_'" % [columns(g), DEF_QUAD_GRID_COLS])
+
+  for c in 0 to columns(g) seq-cat:
+
+    val params = get-params(g, c)
+
+    val [pad-size, row-C-to-C, row-pitch] = to-tuple(params)
+
+    val rot = to-double(90 * c)
+    val offset = loc(0.0, 0.0, rot) * loc((- row-C-to-C) / 2.0, 0.0)
+
+    val row-set = grid-locs(rows(g, c), 1, 1.0, row-pitch)
+    val raw-grid-locs = for row-loc in row-set seq:
+      offset * row-loc
+
+    for (raw-grid-loc in raw-grid-locs, r in 0 to false) seq:
+      GridPosition(r, c, raw-grid-loc)

--- a/src/landpatterns/two-pin/utils.stanza
+++ b/src/landpatterns/two-pin/utils.stanza
@@ -45,7 +45,7 @@ public defn compute-hole-diam (
 
   hole-diameter
 
-; Helper function to compute the pad and hole size of through hoel components
+; Helper function to compute the pad and hole size of through hole components
 public defn compute-pad-diam (hole-diam:Double, density-level:DensityLevel) -> Double :
   val min-outer-layer-pad-size = MIN-OUTER-LAYER-PAD-SIZE
   val max-hole-size-tolerance  = MAX-HOLE-SIZE-TOLERANCE

--- a/tests/landpatterns/BGA/package.stanza
+++ b/tests/landpatterns/BGA/package.stanza
@@ -24,10 +24,13 @@ deftest(BGA) test-full-simple :
   ; NSMD variant of the recommended land pattern
 
   val planner = Full-Matrix-Planner(
-    PadConfig-D(
+    pad-config = PadConfig-D(
       copper-D-adj = -0.05,
       mask-D-adj = 0.0,
-    )
+    ),
+    rows = 3,
+    columns = 4,
+    pitch = 0.5
   )
 
   val body = PackageBody(
@@ -38,10 +41,7 @@ deftest(BGA) test-full-simple :
 
   val pkg = BGA(
     num-leads = 12,
-    rows = 3,
-    columns = 4,
     lead-diam = 0.3,
-    pitch = 0.5,
     package-body = body,
     pad-planner = planner
   )
@@ -115,10 +115,13 @@ deftest(BGA) test-full-landpattern :
   ; NSMD variant of the recommended land pattern
 
   val planner = Full-Matrix-Planner(
-    PadConfig-D(
+    pad-config = PadConfig-D(
       copper-D-adj = -0.05,
       mask-D-adj = 0.0,
     )
+    rows = 3,
+    columns = 4,
+    pitch = 0.5
   )
 
   val body = PackageBody(
@@ -129,10 +132,7 @@ deftest(BGA) test-full-landpattern :
 
   val pkg = BGA(
     num-leads = 12,
-    rows = 3,
-    columns = 4,
     lead-diam = 0.3,
-    pitch = 0.5,
     package-body = body,
     pad-planner = planner
     density-level = DensityLevelC
@@ -190,7 +190,10 @@ deftest(BGA) test-perimeter-simple :
         density-level = DensityLevelC
         ),
       mask-D-adj = 0.0,
-    )
+    ),
+    rows = num-rows,
+    columns = num-cols,
+    pitch = 0.5
   )
 
   val body = PackageBody(
@@ -201,10 +204,7 @@ deftest(BGA) test-perimeter-simple :
 
   val pkg = BGA(
     num-leads = 9,
-    rows = num-rows,
-    columns = num-cols,
     lead-diam = 0.3,
-    pitch = 0.5,
     package-body = body,
     pad-planner = planner,
     lead-numbering = grid-scheme
@@ -307,10 +307,13 @@ deftest(BGA) test-simple-with-pose:
   ; NSMD variant of the recommended land pattern
 
   val planner = Full-Matrix-Planner(
-    PadConfig-D(
+    pad-config = PadConfig-D(
       copper-D-adj = -0.05,
       mask-D-adj = 0.0,
-    )
+    ),
+    rows = 3,
+    columns = 4,
+    pitch = 0.5
   )
 
   val body = PackageBody(
@@ -321,10 +324,7 @@ deftest(BGA) test-simple-with-pose:
 
   val pkg = BGA(
     num-leads = 12,
-    rows = 3,
-    columns = 4,
     lead-diam = 0.3,
-    pitch = 0.5,
     package-body = body,
     pad-planner = planner
   )

--- a/tests/landpatterns/BGA/planner.stanza
+++ b/tests/landpatterns/BGA/planner.stanza
@@ -1,145 +1,177 @@
 #use-added-syntax(jitx, tests)
 defpackage jsl/tests/landpatterns/BGA/planner:
   import core
+  import collections
   import jitx
   import jitx/commands
 
-  import jsl/landpatterns/pad-planner
-  import jsl/landpatterns/pad-island
-
+  import jsl/landpatterns/framework
   import jsl/landpatterns/BGA
   import jsl/tests/utils
 
 #if-defined(TESTING):
-  defn build-locs (x:BGA-PadPlanner, rows:Int, cols:Int, pitch:Double|Dims) -> Seq<Pose>:
-    val grid = grid(x, rows, cols, pitch)
-    for r in 0 to rows seq-cat:
-      for (c in 0 to cols, pos in grid) seq?:
-        if active?(x, r, c): One(pos)
-        else: None()
+  defn build-locs (x:BGA-PadPlanner) -> Tuple<GridPosition>:
+    to-tuple $ for pos in grid(x) seq?:
+      val [r, c] = [row(pos), column(pos)]
+      if active?(x, r, c): One(pos)
+      else: None()
+
+  defn compare-grid-pos (obs:Tuple<GridPosition>, exps:Tuple<GridPosition>):
+    #EXPECT(length(obs) == length(exps))
+
+    val obs-v = to-vector<GridPosition>(obs)
+    for exp in exps do :
+      val [r,c] = [row(exp), column(exp)]
+      val found = for (ob in obs-v, i in 0 to false) first:
+        if row(ob) == r and column(ob) == c:
+          One([ob, i])
+        else:
+          None()
+
+      match(found):
+        (_:None):
+          val msg = to-string("Failed to Match Grid Position: r=%_ c=%_" % [r, c])
+          #EXPECT(msg == "")
+        (given:One<[GridPosition, Int]>):
+          val [pos, i] = value(given)
+          remove(obs-v, i)
+
+          #EXPECT(almost-equal?(pose(pos), pose(exp)))
+
+    if length(obs-v) > 0 :
+      val msg = to-string("Obs Contained Excess Positions: %," % [obs-v])
+      #EXPECT( msg == "")
+
 
 deftest(BGA) test-full-matrix:
-  val uut = Full-Matrix-Planner()
+  val uut = Full-Matrix-Planner(
+    rows = 3,
+    columns = 3,
+    pitch = 1.0
+    )
 
-  val obs = to-tuple $ build-locs(uut, 3, 3, 1.0)
-
-  #EXPECT(length(obs) == 9)
+  val obs = build-locs(uut)
 
   val exp = [
-    loc(-1.0, 1.0),
-    loc(0.0, 1.0),
-    loc(1.0, 1.0),
-    loc(-1.0, 0.0),
-    loc(0.0, 0.0),
-    loc(1.0, 0.0),
-    loc(-1.0, -1.0),
-    loc(0.0, -1.0),
-    loc(1.0, -1.0),
+    GridPosition(0, 0, loc(-1.0, 1.0)),
+    GridPosition(0, 1, loc(0.0, 1.0)),
+    GridPosition(0, 2, loc(1.0, 1.0)),
+    GridPosition(1, 0, loc(-1.0, 0.0)),
+    GridPosition(1, 1, loc(0.0, 0.0)),
+    GridPosition(1, 2, loc(1.0, 0.0)),
+    GridPosition(2, 0, loc(-1.0, -1.0)),
+    GridPosition(2, 1, loc(0.0, -1.0)),
+    GridPosition(2, 2, loc(1.0, -1.0)),
   ]
 
-  #EXPECT(obs == exp)
+  compare-grid-pos(obs, exp)
 
 deftest(BGA) test-stagger-even-matrix:
-  val uut = Staggered-Matrix-Planner()
+  val uut = Staggered-Matrix-Planner(rows = 5, columns = 5, pitch = 1.0)
 
-  val obs = to-tuple $ build-locs(uut, 5, 5, 1.0)
+  val obs = build-locs(uut)
 
   val exp = [
-    loc(-1.0, 2.0),
-    loc(1.0, 2.0),
-    loc(-2.0, 1.0),
-    loc(0.0, 1.0),
-    loc(2.0, 1.0),
-    loc(-1.0, 0.0),
-    loc(1.0, 0.0),
-    loc(-2.0, -1.0),
-    loc(0.0, -1.0),
-    loc(2.0, -1.0),
-    loc(-1.0, -2.0),
-    loc(1.0, -2.0),
+    GridPosition(0, 1, loc(-1.0, 2.0)),
+    GridPosition(0, 3, loc(1.0, 2.0)),
+    GridPosition(1, 0, loc(-2.0, 1.0)),
+    GridPosition(1, 2, loc(0.0, 1.0)),
+    GridPosition(1, 4, loc(2.0, 1.0)),
+    GridPosition(2, 1, loc(-1.0, 0.0)),
+    GridPosition(2, 3, loc(1.0, 0.0)),
+    GridPosition(3, 0, loc(-2.0, -1.0)),
+    GridPosition(3, 2, loc(0.0, -1.0)),
+    GridPosition(3, 4, loc(2.0, -1.0)),
+    GridPosition(4, 1, loc(-1.0, -2.0)),
+    GridPosition(4, 3, loc(1.0, -2.0)),
   ]
 
-  #EXPECT(length(obs) == length(exp) )
-  #EXPECT(obs == exp)
+  compare-grid-pos(obs, exp)
+
 
 deftest(BGA) test-stagger-odd-matrix:
   val uut = Staggered-Matrix-Planner(
-    Odd-Phase
+    phase = Odd-Phase,
+    rows = 5,
+    columns = 5,
+    pitch = 1.0
   )
 
-  val obs = to-tuple $ build-locs(uut, 5, 5, 1.0)
+  val obs = build-locs(uut)
 
   val exp = [
-    loc(-2.0, 2.0),
-    loc(0.0, 2.0),
-    loc(2.0, 2.0),
-    loc(-1.0, 1.0),
-    loc(1.0, 1.0),
-    loc(-2.0, 0.0),
-    loc(0.0, 0.0),
-    loc(2.0, 0.0),
-    loc(-1.0, -1.0),
-    loc(1.0, -1.0),
-    loc(-2.0, -2.0),
-    loc(0.0, -2.0),
-    loc(2.0, -2.0),
+    GridPosition(0, 0, loc(-2.0, 2.0)),
+    GridPosition(0, 2, loc(0.0, 2.0)),
+    GridPosition(0, 4, loc(2.0, 2.0)),
+    GridPosition(1, 1,loc(-1.0, 1.0)),
+    GridPosition(1, 3,loc(1.0, 1.0)),
+    GridPosition(2, 0,loc(-2.0, 0.0)),
+    GridPosition(2, 2,loc(0.0, 0.0)),
+    GridPosition(2, 4,loc(2.0, 0.0)),
+    GridPosition(3, 1,loc(-1.0, -1.0)),
+    GridPosition(3, 3,loc(1.0, -1.0)),
+    GridPosition(4, 0,loc(-2.0, -2.0)),
+    GridPosition(4, 2,loc(0.0, -2.0)),
+    GridPosition(4, 4,loc(2.0, -2.0)),
   ]
 
-  #EXPECT(length(obs) == length(exp) )
-  #EXPECT(obs == exp)
+  compare-grid-pos(obs, exp)
 
 deftest(BGA) test-equilat-tri-even-matrix:
 
-  val uut = EquilateralTriangle-Matrix-Planner()
+  val uut = EquilateralTriangle-Matrix-Planner(
+    rows = 5,
+    columns = 5,
+    tri-pitch = 1.0
+  )
 
-  val obs = to-tuple $ build-locs(uut, 5, 5, 1.0)
+  val obs = build-locs(uut)
 
   val exp = [
-    loc(-0.5, 1.7320508),
-    loc(0.5, 1.7320508),
-    loc(-1.0, 0.8660254)
-    loc(0.0, 0.8660254)
-    loc(1.0, 0.8660254)
-    loc(-0.5, 0.0),
-    loc(0.5, 0.0),
-    loc(-1.0, -0.8660254)
-    loc(0.0, -0.8660254)
-    loc(1.0, -0.8660254)
-    loc(-0.5, -1.7320508),
-    loc(0.5, -1.7320508),
+    GridPosition(0, 1, loc(-0.5, 1.7320508)),
+    GridPosition(0, 3, loc(0.5, 1.7320508)),
+    GridPosition(1, 0, loc(-1.0, 0.8660254))
+    GridPosition(1, 2, loc(0.0, 0.8660254))
+    GridPosition(1, 4, loc(1.0, 0.8660254))
+    GridPosition(2, 1, loc(-0.5, 0.0)),
+    GridPosition(2, 3, loc(0.5, 0.0)),
+    GridPosition(3, 0, loc(-1.0, -0.8660254))
+    GridPosition(3, 2, loc(0.0, -0.8660254))
+    GridPosition(3, 4, loc(1.0, -0.8660254))
+    GridPosition(4, 1, loc(-0.5, -1.7320508)),
+    GridPosition(4, 3, loc(0.5, -1.7320508)),
   ]
 
-  #EXPECT(length(obs) == length(exp) )
-  for (exp-p in exp, i in 0 to false) do:
-    #EXPECT(almost-equal?(exp-p, obs[i]))
+  compare-grid-pos(obs, exp)
 
 deftest(BGA) test-equilat-tri-odd-matrix:
 
   val uut = EquilateralTriangle-Matrix-Planner(
-    Odd-Phase
+    phase = Odd-Phase
+    rows = 5,
+    columns = 5,
+    tri-pitch = 1.0
   )
 
-  val obs = to-tuple $ build-locs(uut, 5, 5, 1.0)
+  val obs = build-locs(uut)
 
   val exp = [
-    loc(-1.0, 1.7320508)
-    loc(0.0, 1.7320508)
-    loc(1.0, 1.7320508)
-    loc(-0.5, 0.8660254),
-    loc(0.5, 0.8660254),
-    loc(-1.0, 0.0)
-    loc(0.0, 0.0)
-    loc(1.0, 0.0)
-    loc(-0.5, -0.8660254),
-    loc(0.5, -0.8660254),
-    loc(-1.0, -1.7320508)
-    loc(0.0, -1.7320508)
-    loc(1.0, -1.7320508)
+    GridPosition(0, 0, loc(-1.0, 1.7320508))
+    GridPosition(0, 2, loc(0.0, 1.7320508))
+    GridPosition(0, 4, loc(1.0, 1.7320508))
+    GridPosition(1, 1, loc(-0.5, 0.8660254)),
+    GridPosition(1, 3, loc(0.5, 0.8660254)),
+    GridPosition(2, 0, loc(-1.0, 0.0))
+    GridPosition(2, 2, loc(0.0, 0.0))
+    GridPosition(2, 4, loc(1.0, 0.0))
+    GridPosition(3, 1, loc(-0.5, -0.8660254)),
+    GridPosition(3, 3, loc(0.5, -0.8660254)),
+    GridPosition(4, 0, loc(-1.0, -1.7320508))
+    GridPosition(4, 2, loc(0.0, -1.7320508))
+    GridPosition(4, 4, loc(1.0, -1.7320508))
   ]
 
-  #EXPECT(length(obs) == length(exp) )
-  for (exp-p in exp, i in 0 to false) do:
-    #EXPECT(almost-equal?(exp-p, obs[i]))
+  compare-grid-pos(obs, exp)
 
 
 deftest(BGA) test-perim-matrix :
@@ -148,42 +180,43 @@ deftest(BGA) test-perim-matrix :
       2 through 4,
       3 through 3,
     )
+    rows = 5,
+    columns = 5,
+    pitch = 1.0
   )
 
-  val obs = to-tuple $ build-locs(uut, 5, 5, 1.0)
+  val obs = build-locs(uut)
 
   val exp = [
-    loc(-2.0, 2.0),
-    loc(-1.0, 2.0),
-    loc(0.0, 2.0),
-    loc(1.0, 2.0),
-    loc(2.0, 2.0),
+    GridPosition(0, 0, loc(-2.0, 2.0)),
+    GridPosition(0, 1, loc(-1.0, 2.0)),
+    GridPosition(0, 2, loc(0.0, 2.0)),
+    GridPosition(0, 3, loc(1.0, 2.0)),
+    GridPosition(0, 4, loc(2.0, 2.0)),
 
-    loc(-2.0, 1.0),
-    loc(-1.0, 1.0),
-    loc(1.0, 1.0),
-    loc(2.0, 1.0),
+    GridPosition(1, 0, loc(-2.0, 1.0)),
+    GridPosition(1, 1, loc(-1.0, 1.0)),
+    GridPosition(1, 3, loc(1.0, 1.0)),
+    GridPosition(1, 4, loc(2.0, 1.0)),
 
-    loc(-2.0, 0.0),
-    loc(-1.0, 0.0),
-    loc(1.0, 0.0),
-    loc(2.0, 0.0),
+    GridPosition(2, 0, loc(-2.0, 0.0)),
+    GridPosition(2, 1, loc(-1.0, 0.0)),
+    GridPosition(2, 3, loc(1.0, 0.0)),
+    GridPosition(2, 4, loc(2.0, 0.0)),
 
-    loc(-2.0, -1.0),
-    loc(-1.0, -1.0),
-    loc(1.0, -1.0),
-    loc(2.0, -1.0),
+    GridPosition(3, 0, loc(-2.0, -1.0)),
+    GridPosition(3, 1, loc(-1.0, -1.0)),
+    GridPosition(3, 3, loc(1.0, -1.0)),
+    GridPosition(3, 4, loc(2.0, -1.0)),
 
-    loc(-2.0, -2.0),
-    loc(-1.0, -2.0),
-    loc(0.0, -2.0),
-    loc(1.0, -2.0),
-    loc(2.0, -2.0),
+    GridPosition(4, 0, loc(-2.0, -2.0)),
+    GridPosition(4, 1, loc(-1.0, -2.0)),
+    GridPosition(4, 2, loc(0.0, -2.0)),
+    GridPosition(4, 3, loc(1.0, -2.0)),
+    GridPosition(4, 4, loc(2.0, -2.0)),
   ]
 
-  #EXPECT(length(obs) == length(exp) )
-  #EXPECT(obs == exp)
-
+  compare-grid-pos(obs, exp)
 
 deftest(BGA) test-therm-enh-matrix :
   val uut = ThermallyEnhanced-Matrix-Planner(
@@ -194,34 +227,36 @@ deftest(BGA) test-therm-enh-matrix :
     active = PadIsland(
       3 through 3,
       3 through 3,
-    )
+    ),
+    rows = 5,
+    columns = 5,
+    pitch = 1.0
   )
 
-  val obs = to-tuple $ build-locs(uut, 5, 5, 1.0)
+  val obs = build-locs(uut)
 
   val exp = [
-    loc(-2.0, 2.0),
-    loc(-1.0, 2.0),
-    loc(0.0, 2.0),
-    loc(1.0, 2.0),
-    loc(2.0, 2.0),
+    GridPosition(0, 0, loc(-2.0, 2.0)),
+    GridPosition(0, 1, loc(-1.0, 2.0)),
+    GridPosition(0, 2, loc(0.0, 2.0)),
+    GridPosition(0, 3, loc(1.0, 2.0)),
+    GridPosition(0, 4, loc(2.0, 2.0)),
 
-    loc(-2.0, 1.0),
-    loc(2.0, 1.0),
+    GridPosition(1, 0, loc(-2.0, 1.0)),
+    GridPosition(1, 4, loc(2.0, 1.0)),
 
-    loc(-2.0, 0.0),
-    loc(0.0, 0.0),
-    loc(2.0, 0.0),
+    GridPosition(2, 0, loc(-2.0, 0.0)),
+    GridPosition(2, 2, loc(0.0, 0.0)),
+    GridPosition(2, 4, loc(2.0, 0.0)),
 
-    loc(-2.0, -1.0),
-    loc(2.0, -1.0),
+    GridPosition(3, 0, loc(-2.0, -1.0)),
+    GridPosition(3, 4, loc(2.0, -1.0)),
 
-    loc(-2.0, -2.0),
-    loc(-1.0, -2.0),
-    loc(0.0, -2.0),
-    loc(1.0, -2.0),
-    loc(2.0, -2.0),
+    GridPosition(4, 0, loc(-2.0, -2.0)),
+    GridPosition(4, 1, loc(-1.0, -2.0)),
+    GridPosition(4, 2, loc(0.0, -2.0)),
+    GridPosition(4, 3, loc(1.0, -2.0)),
+    GridPosition(4, 4, loc(2.0, -2.0)),
   ]
 
-  #EXPECT(length(obs) == length(exp) )
-  #EXPECT(obs == exp)
+  compare-grid-pos(obs, exp)

--- a/tests/landpatterns/pad-planner.stanza
+++ b/tests/landpatterns/pad-planner.stanza
@@ -187,9 +187,6 @@ deftest(pad-planner) test-funky-planner :
   val f10 = shape-generator(o, 1, 0)
   check-non-rect(f10)
 
-  val f11 = shape-generator(o, 1, 1)
-  #EXPECT(f11 is False)
-
 deftest(pad-planner) test-pth-planner :
 
   val o = PthPadPlanner()


### PR DESCRIPTION
The goal is to:

1.  Reduce duplication in the grid generation. 
2.  Add routines that can support the ethernet connector generator.

This also includes several bugfixes. 

Unit tests pass when I run them locally.

# Notes

1.  This changes the `BGA` interface to put the `rows/columns` management into the BGA Planner instead of on the BGA itself.
    1.  This seems to jive well with the Corner Cut planner from @alijitx 
2.  I've updated dual-row and quad to use GridPlanner for their construction mechanism.
    1.  This works well for both.
    2.  But the helper function only works for the dual not the quad, because of the two separate lead-profile mechanisms the quad supports.
3.  I've updated the headers functionality to use this pad grid concept and added examples of using the headers.

# Future Work 

1.  We need better handling for through-holes. 
     1.  Current implementation creates IPC-based hole and pad sizes. 
     2.  We should give the user the ability to override both 
2.  We need to support implement some ability to do pin-1 pad planners for through-holes.
3.  Need to test generalized stagger grid support for ethernet connector.
4.  We need some rework in the through hole (axial/radial) components to use pad-grid. 


