### PR TITLE
Display Port Updates to work with SI-Constraint

### DIFF
--- a/examples/protocols/common/example-board.stanza
+++ b/examples/protocols/common/example-board.stanza
@@ -177,7 +177,7 @@ in the project code because they are dependant on the stack-up and other factors
 public pcb-routing-structure se-50 :
   name = "50 Ohm single-ended"
   layer(Top) :
-    trace-width = 0.10    ; mm
+    trace-width = 0.15    ; mm
     clearance = 0.15     ; mm
     velocity = 0.19e12   ; mm/s
     insertion-loss = 0.008  ; db/mm @ 1GHz
@@ -187,7 +187,7 @@ public pcb-routing-structure se-50 :
     )
 
   layer(Bottom) :
-    trace-width = 0.10    ; mm
+    trace-width = 0.15    ; mm
     clearance = 0.15         ; mm
     velocity = 0.19e12   ; mm/s
     insertion-loss = 0.008  ; db/mm @ 1GHz

--- a/examples/protocols/displayport/displayport-main.stanza
+++ b/examples/protocols/displayport/displayport-main.stanza
@@ -11,6 +11,10 @@ defpackage jsl/examples/protocols/displayport/main:
 
   import jsl/protocols/displayport
   import jsl/si/helpers
+  import jsl/bundles
+  import jsl/si/constraints
+  import jsl/si/pairs
+  import jsl/si/couplers
 
   import jsl/examples/protocols/common/example-board
   import jsl/examples/protocols/common/example-components
@@ -26,13 +30,17 @@ pcb-module displayport-example :
   require src : displayport from dut1
   require dst : displayport from dut2
 
-  val gen = DP1p4
+  val ti = displayport-get-trace-impedance()
+  val dp-constraint = DisplayPort-Constraint(gen = DP2p1, route-struct = diff(ti))
+  constrain(dp-constraint, src, dst)
 
-  val [skew, loss] = displayport-get-skew-loss-vals(gen)
+  for i in 0 to 4 do:
+    inst cap : dp-coupler(block-cap(100.0e-9))
+    topo-pair(src.lane[i] => cap => dst.lane[i])
 
-  connect-displayport(skew, loss, src, dst, block-cap(100.0e-9), [pu-res(50.0e3), VDD])
-  val trace-imped = displayport-get-trace-impedance()
-  displayport-apply-routing-structure(diff(trace-imped), src, dst)
+  inst shunt-r : symmetric-shunt(pu-res(50.0e3))
+  topo-pair(src.aux => shunt-r.A => dst.aux)
+  net (shunt-r.COMMON, VDD)
 
   net (VDD dut1.VDD dut2.VDD)
   net (GND dut1.GND dut2.GND)
@@ -48,5 +56,5 @@ set-main-module(displayport-example)
 ; View the results
 view-board()
 ; view-schematic()
-view-design-explorer()
+;view-design-explorer()
 ; view-bom(BOM-STD)

--- a/examples/protocols/displayport/displayport-main.stanza
+++ b/examples/protocols/displayport/displayport-main.stanza
@@ -27,20 +27,22 @@ pcb-module displayport-example :
   inst dut1 : jsl/examples/protocols/displayport/displayport-src/module(source = true)
   inst dut2 : jsl/examples/protocols/displayport/displayport-src/module(source = false)
 
-  require src : displayport from dut1
-  require dst : displayport from dut2
+  require MCU-src : displayport from dut1
+  require CONN-dst : displayport from dut2
 
   val ti = displayport-get-trace-impedance()
-  val dp-constraint = DisplayPort-Constraint(gen = DP2p1, route-struct = diff(ti))
-  constrain(dp-constraint, src, dst)
+  val DP-limits = DisplayPort-Constraint(gen = DP2p1, route-struct = diff(ti))
 
-  for i in 0 to 4 do:
-    inst cap : dp-coupler(block-cap(100.0e-9))
-    topo-pair(src.lane[i] => cap => dst.lane[i])
+  within [src, dst] = constrain-topology(MCU-src => CONN-dst, DP-limits):
+    inst cap : dp-coupler(block-cap(100.0e-9))[length(src.lane)]
+    for i in 0 to length(src.lane) do:
+      topo-pair(src.lane[i] => cap[i] => dst.lane[i])
 
-  inst shunt-r : symmetric-shunt(pu-res(50.0e3))
-  topo-pair(src.aux => shunt-r.A => dst.aux)
-  net (shunt-r.COMMON, VDD)
+    inst shunt-r : symmetric-shunt(pu-res(50.0e3))
+    topo-pair(src.aux => shunt-r.A => shunt-r.B => dst.aux)
+    net (shunt-r.COMMON, VDD)
+
+    net (src.hpd, dst.hpd)
 
   net (VDD dut1.VDD dut2.VDD)
   net (GND dut1.GND dut2.GND)

--- a/examples/protocols/displayport/displayport-main.stanza
+++ b/examples/protocols/displayport/displayport-main.stanza
@@ -10,15 +10,11 @@ defpackage jsl/examples/protocols/displayport/main:
   import jsl/symbols/SymbolDefn
 
   import jsl/protocols/displayport
-  import jsl/si/helpers
   import jsl/bundles
-  import jsl/si/constraints
-  import jsl/si/pairs
-  import jsl/si/couplers
+  import jsl/si
 
   import jsl/examples/protocols/common/example-board
   import jsl/examples/protocols/common/example-components
-  import jsl/examples/protocols/displayport/displayport-src
 
 pcb-module displayport-example :
   pin VDD
@@ -39,7 +35,9 @@ pcb-module displayport-example :
       topo-pair(src.lane[i] => cap[i] => dst.lane[i])
 
     inst shunt-r : symmetric-shunt(pu-res(50.0e3))
-    topo-pair(src.aux => shunt-r.A => shunt-r.B => dst.aux)
+    topo-pair(src.aux => shunt-r.A)
+    topo-pair(shunt-r.B => dst.aux)
+
     net (shunt-r.COMMON, VDD)
 
     net (src.hpd, dst.hpd)

--- a/examples/protocols/displayport/displayport-src.stanza
+++ b/examples/protocols/displayport/displayport-src.stanza
@@ -112,10 +112,10 @@ public pcb-component component :
   val lp = create-landpattern(BGA-pkg)
   assign-landpattern(lp)
 
-  for i in 0 to 4 do :
-    diff-pin-model(self.DP-TX-P[i], self.DP-TX-N[i],       delay = typ(10.0e-15) loss = typ(0.1))
-    diff-pin-model(self.DP-RX-P[i], self.DP-RX-N[i],       delay = typ(10.0e-15) loss = typ(0.1))
-    diff-pin-model(self.AUX-P, self.AUX-N, delay = typ(10.0e-15) loss = typ(0.1))
+  ;for i in 0 to 4 do :
+  ;  diff-pin-model(self.DP-TX-P[i], self.DP-TX-N[i],       delay = typ(10.0e-15) loss = typ(0.1))
+  ;  diff-pin-model(self.DP-RX-P[i], self.DP-RX-N[i],       delay = typ(10.0e-15) loss = typ(0.1))
+  ;  diff-pin-model(self.AUX-P, self.AUX-N, delay = typ(10.0e-15) loss = typ(0.1))
 
 
 public pcb-module module (-- source:True|False = true) :

--- a/examples/protocols/displayport/displayport-src.stanza
+++ b/examples/protocols/displayport/displayport-src.stanza
@@ -112,10 +112,11 @@ public pcb-component component :
   val lp = create-landpattern(BGA-pkg)
   assign-landpattern(lp)
 
-  ;for i in 0 to 4 do :
-  ;  diff-pin-model(self.DP-TX-P[i], self.DP-TX-N[i],       delay = typ(10.0e-15) loss = typ(0.1))
-  ;  diff-pin-model(self.DP-RX-P[i], self.DP-RX-N[i],       delay = typ(10.0e-15) loss = typ(0.1))
-  ;  diff-pin-model(self.AUX-P, self.AUX-N, delay = typ(10.0e-15) loss = typ(0.1))
+  for i in 0 to 4 do :
+    diff-pin-model(self.DP-TX-P[i], self.DP-TX-N[i],       delay = typ(10.0e-15) loss = typ(0.1))
+    diff-pin-model(self.DP-RX-P[i], self.DP-RX-N[i],       delay = typ(10.0e-15) loss = typ(0.1))
+
+  diff-pin-model(self.AUX-P, self.AUX-N, delay = typ(10.0e-15) loss = typ(0.1))
 
 
 public pcb-module module (-- source:True|False = true) :

--- a/src/protocols/displayport.stanza
+++ b/src/protocols/displayport.stanza
@@ -1,4 +1,22 @@
 #use-added-syntax(jitx)
+doc: \<DOC>
+@brief DisplayPort Protocol
+
+DisplayPort is a serial protocol supporting high speed links for video+audio
+@see https://en.wikipedia.org/wiki/DisplayPort
+
+The functions and definitions in this file support defining DisplayPort
+connections between sources and receivers on a printed circuit board.
+
+## DisplayPort Blocking Capacitors
+
+The DisplayPort specification calls for AC coupling for the data lanes. This is typically
+achieved using a blocking capacitor.
+
+The best way to achieve this is to use the {@link /jsl/si/constraints/constrain-topology}
+mechanism.
+
+<DOC>
 defpackage jsl/protocols/displayport:
   import core
   import jitx

--- a/src/protocols/displayport.stanza
+++ b/src/protocols/displayport.stanza
@@ -1,25 +1,3 @@
-doc: \<DOC>
-@brief DisplayPort Protocol
-
-DisplayPort is a serial protocol supporting high speed links for video+audio
-@see https://en.wikipedia.org/wiki/DisplayPort
-
-This functions and definitions in this file support defining DisplayPort
-connections between sources and receivers on a printed circuit board.
-
-## DisplayPort Blocking Capacitors
-
-The DisplayPort specification calls for AC coupling for the data lanes. This is typically
-achieved using a blocking capacitor. When connecting two active components, this typically
-means blocking caps from `Tx -> Rx` on both sides of the link. When connecting an
-active component to a passive component, this typically means adding the blocking caps only on
-the `Tx -> Rx` side of the link.
-
-The functions in this module allow you to pass a blocking capacitor as an `Instantiable`.
-This component will get instantiated for each leg of the diff-pair. These functions handle
-the topology configuration, but the user needs to set a `pin-model` statement on the capacitor component.
-
-<DOC>
 #use-added-syntax(jitx)
 defpackage jsl/protocols/displayport:
   import core
@@ -28,6 +6,7 @@ defpackage jsl/protocols/displayport:
 
   import jsl/bundles
   import jsl/errors
+  import jsl/ensure
   import jsl/si
   import jsl/pin-assignment
 
@@ -89,105 +68,6 @@ public pcb-bundle displayport-connector :
   port config : pin[DISPLAYPORT_NUM_CONFIGS]
 
 doc: \<DOC>
-@brief Construct a DisplayPort lane.
-
-This function will construct the lane connections of a DisplayPort connection. The `src` and `dst`
-arguments must both be of type `displayport`.
-
-@param sw The intra-pair skew time difference for the differential signals being connected.
-@param ml The maximum loss in dB for all differential signals being connected.
-@param src This is assumed to be the "Tx" side of the link. This is expected to be a port of `Bundle` type `displayport`
-@param sink This is assumed to be the "Rx" side of the link. This is expected to be a port of `Bundle` type `displayport`
-@param cap Optional DC blocking capacitor to be inserted between the TX and RX pairs. Note that
-there are 2 blocking caps inserted, one on each of the P,N signals of the pair.
-
-<DOC>
-public defn connect-displayport-lane (sw:Toleranced, ml:Double, src:JITXObject, sink:JITXObject, cap:Instantiable|False) :
-  inside pcb-module:
-    check-bundle(displayport, src, sink)
-    for i in indices(src.lane) do :
-      match(cap) :
-        (c:Instantiable) :
-          inst bl-cap : dp-coupler(c)
-          require tx1 : dual-pair from bl-cap
-          topo-net(src.lane[i], tx1.A)
-          topo-net(tx1.B, sink.lane[i])
-        (f:False) :
-          topo-net(src.lane[i], sink.lane[i])
-      constrain-ch(sw, ml, src.lane[i], sink.lane[i])
-
-doc: \<DOC>
-@brief Construct aux connection of a DisplayPort connection.
-
-This function will construct the AUX channel of a DisplayPort connection with the 
-optional blocking cap and pull-up resistors.
-The `src` and `dst` arguments must both be of type `displayport`.
-
-@param sw The intra-pair skew time difference for the differential signals being connected.
-@param ml The maximum loss in dB for all differential signals being connected.
-@param src This is assumed to be the source side of the link. This is expected to be a port of `Bundle` type `displayport`
-@param dst This is assumed to be the sink side of the link. This is expected to be a port of `Bundle` type `displayport`
-@param cap Optional DC blocking capacitor to be inserted between the AUX pair. Note that
-there are 2 blocking caps inserted, one on each of the P,N signals of the pair.
-@param term Optional pull-up resistor and common net to be added to the AUX pair before the capacitor. 
-Note that there are 2 resistors added, one on each of the P,N signals of the pair. Power supply pin to be 
-used for the pull-up resistors. Must be valid if the resistors are used.
-
-<DOC>
-public defn connect-displayport-aux (sw:Toleranced, ml:Double, src:JITXObject, sink:JITXObject, cap:Instantiable|False, term:[Instantiable, JITXObject]|False) :
-  inside pcb-module:
-    match(term, cap) :
-      (t:[Instantiable, JITXObject], c:Instantiable) :
-        inst shunt-r : symmetric-shunt(t[0] as Instantiable)
-        inst bl-cap : dp-coupler(c)
-        require tx1 : dual-pair from bl-cap
-        topo-net(src.aux, shunt-r.A)
-        topo-net(shunt-r.B, tx1.A)
-        topo-net(tx1.B, sink.aux)
-        topo-net(shunt-r.COMMON, t[1] as JITXObject)
-      (f:False, c:Instantiable|False) :
-        connect-displayport-aux(sw, ml, src, sink, c)
-    constrain-ch(sw, ml, src.aux, sink.aux)
-
-public defn connect-displayport-aux (sw:Toleranced, ml:Double, src:JITXObject, sink:JITXObject, cap:Instantiable|False) :
-  inside pcb-module:
-    match(cap) :
-      (c:Instantiable) :
-        inst bl-cap : dp-coupler(c)
-        require d-p : dual-pair from bl-cap
-        topo-net(src.aux, d-p.A)
-        topo-net(d-p.B, sink.aux)
-      (f:False) :
-        topo-net(src.aux, sink.aux)
-    constrain-ch(sw, ml, src.aux, sink.aux)
-
-doc: \<DOC>
-@brief Construct the DisplayPort Topology and Constraints
-
-This function constructs the DisplayPort topology and applies constraints
-to the channel for intra-pair skew and channel loss.
-
-@param sw The intra-pair skew value for the differential signals being connected.
-@param ml The maximum loss for all differential signals being connected.
-@param src This is expected to be a port of `Bundle` type `displayport`
-@param sink This is expected to be a port of `Bundle` type `displayport`
-@param cap Optional DC blocking capacitor to be inserted between the src.tx and sink.rx channel. Note that
-there are 2 blocking caps inserted, one on each of the pair of P,N signals. The capacitor needs to have 
-pin models applied to its pins in order for the overall skew and loss values to be respected.
-
-@param term Optional tuple of pull-up resistor and common net to be added to the AUX pair before the capacitor. 
-Note that there are 2 resistors added, one on each of the P,N signals of the pair. Common net is to be used 
-for the pull-up resistors and can be a power supply net.
-<DOC>
-public defn connect-displayport (sw:Toleranced, ml:Double, src:JITXObject, sink:JITXObject, cap:Instantiable|False, term:[Instantiable, JITXObject]|False) :
-  inside pcb-module :
-    connect-displayport-lane(sw, ml, src, sink, cap)
-    connect-displayport-aux(sw, ml, src, sink, cap, term)
-    ; no constraints applied to the hot plug detect
-    net (src.hpd sink.hpd)
-
-
-doc: \<DOC>
 @brief Curated values for skew and loss of DisplayPort Channel
 This is a helper function that returns the bounds on the intra-pair
 skew timing and maximum loss as expected by the particular standard targeted by
@@ -214,6 +94,33 @@ public defn displayport-get-skew-loss-vals (gen:jsl/protocols/displayport/DPVers
     DP2p1a : [0.0 +/- 20.0e-12, 15.0] ; 
 
 doc: \<DOC>
+@brief Get inter-pair skew values for DisplayPort Channel
+This function returns the allowable inter-pair skew timing for DisplayPort lanes
+as expected by the particular standard targeted by the user. The returned value
+is a Toleranced value with upper/lower limits for the inter-pair skew.
+
+Inter-pair skew refers to the timing difference between different differential pairs
+in the DisplayPort interface, which is critical for maintaining signal integrity
+across multiple high-speed lanes.
+
+@param gen The DisplayPort generation (version) to get the inter-pair skew for
+@return Allowable inter-pair skew as a Toleranced value in seconds
+<DOC>
+public defn displayport-get-inter-skew (gen:jsl/protocols/displayport/DPVersion) -> Toleranced:
+  switch(gen) :
+    DP1p0  : 0.0 +/- (2.0 * 400.0e-12) ; 2 symbol lengths at 2.7 Gbps
+    DP1p1  : 0.0 +/- (2.0 * 371.0e-12) ; 2 symbol lengths at 2.7 Gbps
+    DP1p2  : 0.0 +/- (2.0 * 337.0e-12) ; 2 symbol lengths at 5.4 Gbps
+    DP1p2a : 0.0 +/- (2.0 * 337.0e-12) ; 2 symbol lengths at 5.4 Gbps
+    DP1p3  : 0.0 +/- (2.0 * 231.0e-12) ; 2 symbol lengths at 8.1 Gbps
+    DP1p4  : 0.0 +/- (2.0 * 231.0e-12) ; 2 symbol lengths at 8.1 Gbps
+    DP1p4a : 0.0 +/- (2.0 * 231.0e-12) ; 2 symbol lengths at 8.1 Gbps
+    DP2p0  : 0.0 +/- (2.0 * 100.0e-12) ; 2 symbol lengths at 20.0 Gbps
+    DP2p1  : 0.0 +/- (2.0 * 100.0e-12) ; 2 symbol lengths at 20.0 Gbps
+    DP2p1a : 0.0 +/- (2.0 * 100.0e-12) ; 2 symbol lengths at 20.0 Gbps
+
+
+doc: \<DOC>
 @brief Differential impedance specified by the DisplayPort standard
 This is a helper function that returns the expected differential
 trace impedance for the specified generation of the DisplayPort standard.
@@ -224,18 +131,57 @@ trace impedance for the specified generation of the DisplayPort standard.
 public defn displayport-get-trace-impedance () -> Toleranced :
   100.0 +/- (10 %)
 
-doc: \<DOC>
-@brief Apply the differential routing structure to a DisplayPort bundle.
-The function applies the provided DifferentialRoutingStructure
-to all of the differential pairs in the start and endpoints. Note that both start and end points
-need to be connected to physical component pins either directly or via pin assignment.
-@param rs This is the DifferentialRoutingStructure to be used to realize the differential signals.
-@param x This is expected to be a port of `Bundle` type `displayport`
-@param y This is expected to be a port of `Bundle` type `displayport`
-<DOC>
+public defstruct DisplayPort-Constraint <: DP-Constraint :
+  skew:Toleranced  with: (as-method => true)
+  loss:Double with: (
+    ensure => ensure-positive!,
+    as-method => true
+    )
+  route-struct:DifferentialRoutingStructure with: (as-method => true)
+  inter-skew:Toleranced
+with:
+  constructor => #DisplayPort-Constraint
 
-public defn displayport-apply-routing-structure (rs:DifferentialRoutingStructure, x:JITXObject, y:JITXObject) :
-  inside pcb-module :
-    for i in indices(x.lane) do :
-      diff-structure(rs, x.lane[i] => y.lane[i])
-    diff-structure(rs, x.aux => y.aux)
+doc: \<DOC>
+SI Constraint For DisplayPort
+
+This constraint assumes the endpoints are {@link displayport} bundles. 
+The code will construct the necessary skew and loss constraints for 
+this bundle according to the DisplayPort specifications.
+
+@param skew Intra-pair skew for the P/N of each differential pair (lanes and AUX)
+@param loss Max Loss for any of the differential pairs
+@param route-struct User provided routing structure for each of the
+differential pair bundles of the DisplayPort interface
+@param inter-skew Inter-pair skew between data lanes
+<DOC>
+public defn DisplayPort-Constraint (
+  --
+  skew:Toleranced
+  loss:Double
+  route-struct:DifferentialRoutingStructure
+  inter-skew:Toleranced
+  ) -> DisplayPort-Constraint:
+  #DisplayPort-Constraint(skew, loss, route-struct, inter-skew)
+
+public defn DisplayPort-Constraint (
+  --
+  route-struct:DifferentialRoutingStructure
+  gen:DPVersion = DP1p2
+  ) -> DisplayPort-Constraint :
+  val [s, ml] = displayport-get-skew-loss-vals(gen)
+  val ins = displayport-get-inter-skew(gen)
+  #DisplayPort-Constraint(s, ml, route-struct, ins)
+
+public defmethod constrain (cst:DisplayPort-Constraint, src:JITXObject, dst:JITXObject) -> False :
+  for i in 0 to DISPLAYPORT_NUM_LANES do:
+    dp-constrain(cst, src.lane[i], dst.lane[i])
+  
+  dp-constrain(cst, src.aux, dst.aux)
+
+  ; Apply inter-pair skew constraint
+  timing-window(
+    inter-skew(cst)
+    src.lane[0].P => dst.lane[0].P,
+    src.lane => dst.lane
+  )

--- a/src/protocols/displayport.stanza
+++ b/src/protocols/displayport.stanza
@@ -82,16 +82,16 @@ tpd 147 ps/in 170 ps/in -> 147 fs/mil to 170 fs/mil
 
 public defn displayport-get-skew-loss-vals (gen:jsl/protocols/displayport/DPVersion) -> [Toleranced, Double]:
   switch(gen) :
-    DP1p0  : [0.0 +/- 20.0e-12, 15.0] ; 
-    DP1p1  : [0.0 +/- 20.0e-12, 15.0] ; 
-    DP1p2  : [0.0 +/- 20.0e-12, 15.0] ; 
-    DP1p2a : [0.0 +/- 20.0e-12, 15.0] ; 
-    DP1p3  : [0.0 +/- 20.0e-12, 15.0] ; 
-    DP1p4  : [0.0 +/- 20.0e-12, 15.0] ; 
-    DP1p4a : [0.0 +/- 20.0e-12, 15.0] ; 
-    DP2p0  : [0.0 +/- 20.0e-12, 15.0] ; 
-    DP2p1  : [0.0 +/- 20.0e-12, 15.0] ; 
-    DP2p1a : [0.0 +/- 20.0e-12, 15.0] ; 
+    DP1p0  : [0.0 +/- 20.0e-12, 15.0] ;
+    DP1p1  : [0.0 +/- 20.0e-12, 15.0] ;
+    DP1p2  : [0.0 +/- 20.0e-12, 15.0] ;
+    DP1p2a : [0.0 +/- 20.0e-12, 15.0] ;
+    DP1p3  : [0.0 +/- 20.0e-12, 15.0] ;
+    DP1p4  : [0.0 +/- 20.0e-12, 15.0] ;
+    DP1p4a : [0.0 +/- 20.0e-12, 15.0] ;
+    DP2p0  : [0.0 +/- 20.0e-12, 15.0] ;
+    DP2p1  : [0.0 +/- 20.0e-12, 15.0] ;
+    DP2p1a : [0.0 +/- 20.0e-12, 15.0] ;
 
 doc: \<DOC>
 @brief Get inter-pair skew values for DisplayPort Channel
@@ -131,39 +131,50 @@ trace impedance for the specified generation of the DisplayPort standard.
 public defn displayport-get-trace-impedance () -> Toleranced :
   100.0 +/- (10 %)
 
-public defstruct DisplayPort-Constraint <: DP-Constraint :
-  skew:Toleranced  with: (as-method => true)
-  loss:Double with: (
-    ensure => ensure-positive!,
-    as-method => true
-    )
-  route-struct:DifferentialRoutingStructure with: (as-method => true)
-  inter-skew:Toleranced
-with:
-  constructor => #DisplayPort-Constraint
-
 doc: \<DOC>
 SI Constraint For DisplayPort
 
-This constraint assumes the endpoints are {@link displayport} bundles. 
-The code will construct the necessary skew and loss constraints for 
+This constraint assumes the endpoints are {@link displayport} bundles.
+The code will construct the necessary skew and loss constraints for
 this bundle according to the DisplayPort specifications.
 
-@param skew Intra-pair skew for the P/N of each differential pair (lanes and AUX)
-@param loss Max Loss for any of the differential pairs
-@param route-struct User provided routing structure for each of the
-differential pair bundles of the DisplayPort interface
-@param inter-skew Inter-pair skew between data lanes
+When used with `constrain-topology`, the `src` and `dst` must be bundles
+of type {@link displayport}.
 <DOC>
-public defn DisplayPort-Constraint (
-  --
-  skew:Toleranced
-  loss:Double
-  route-struct:DifferentialRoutingStructure
+public defstruct DisplayPort-Constraint <: DP-Constraint :
+  doc: \<DOC>
+  Intra-pair Timing Skew Constraint in Seconds
+  <DOC>
+  skew:Toleranced  with:
+    as-method => true
+  doc: \<DOC>
+  Diff-Pair Max Loss Limit Constraint in dB
+  <DOC>
+  loss:Double with:
+    ensure => ensure-positive!,
+    as-method => true
+  doc: \<DOC>
+  Differential Routing Structure for each Diff-Pair
+  <DOC>
+  route-struct:DifferentialRoutingStructure with:
+    as-method => true
+  doc: \<DOC>
+  Inter-pair Timing Skew Constraint in Seconds.
+  <DOC>
   inter-skew:Toleranced
-  ) -> DisplayPort-Constraint:
-  #DisplayPort-Constraint(skew, loss, route-struct, inter-skew)
+with:
+  keyword-constructor => true
+  constructor => #DisplayPort-Constraint
 
+
+doc: \<DOC>
+Constructor for DisplayPort Constraint
+
+@param route-struct Differential Pair routing structure to be applied
+to each of the data lanes.
+@param gen Version Identifier. This value will be used to consult
+what specific skew, timing, etc tolerances to use for this topology.
+<DOC>
 public defn DisplayPort-Constraint (
   --
   route-struct:DifferentialRoutingStructure
@@ -176,7 +187,7 @@ public defn DisplayPort-Constraint (
 public defmethod constrain (cst:DisplayPort-Constraint, src:JITXObject, dst:JITXObject) -> False :
   for i in 0 to DISPLAYPORT_NUM_LANES do:
     dp-constrain(cst, src.lane[i], dst.lane[i])
-  
+
   dp-constrain(cst, src.aux, dst.aux)
 
   ; Apply inter-pair skew constraint


### PR DESCRIPTION
I can route - but the Aux diff-pair isn't getting a routing structure. Probably related to `symmetric-shunt` somehow. 

![Screenshot 2024-07-26 at 5 21 33 PM](https://github.com/user-attachments/assets/871fa61b-ea07-44d9-bec4-768238a52117)


I'm not sure why we lost the package level docstring on display port. 