### PR TITLE
Create courtyard origins with variable size

### DIFF
--- a/src/landpatterns/courtyard.stanza
+++ b/src/landpatterns/courtyard.stanza
@@ -14,17 +14,30 @@ defpackage jsl/landpatterns/courtyard:
     only => (PackageBody, envelope)
 
 public val DEF_COURTYARD_LINE_WIDTH = 0.1
+public val DEF_COURTYARD_LINE_LEN = 1.0
+public val DEF_COURTYARD_LEN_RATIO = 0.5
+
+defn compute-origin-size (outline:Rectangle) -> Double :
+  ; We look at the outline and use this to determine the
+  ;  origin marker's size. We don't want the marker going
+  ;  outside the boundary. Otherwise, this will throw off
+  ;  other calculations we make with the boundary.
+  val max-dim = min(width(outline), height(outline))
+  val max-2 = max-dim * DEF_COURTYARD_LEN_RATIO
+  min(max-2, DEF_COURTYARD_LINE_LEN)
 
 public defn build-courtyard-origin (
   vp:VirtualLP,
+  outline:Rectangle,
   --
   line-width:Double = DEF_COURTYARD_LINE_WIDTH
   pose:Pose = loc(0.0, 0.0)
   side:Side = Top
-  ) -> False:
-
-  val shape = PlusSymbol(line-width = line-width, pose = pose)
+  ) -> Shape:
+  val line-length = compute-origin-size(outline)
+  val shape = PlusSymbol(line-length = line-length, line-width = line-width, pose = pose)
   add-artwork(vp, Courtyard(side), shape, class = "courtyard")
+  shape
 
 doc: \<DOC>
 Generator for Courtyard Origin Marker
@@ -32,6 +45,8 @@ Generator for Courtyard Origin Marker
 This function generates a `plus` sign marker
 at the origin of a component landpattern.
 
+@param line-length Set the size of the origin marker. The default is 1.0 mm.
+@param line-width Set the line width for the drawn marker. The default is 0.05mm.
 @param pose Override the origin location by applying a
 `pose`. This can both rotate and translate the marker position.
 @param side Indicates which side to place the courtyard on. Default
@@ -39,12 +54,13 @@ per convention is the top.
 <DOC>
 public defn make-courtyard-origin (
   --
+  line-length:Double = DEF_COURTYARD_LINE_LEN,
   line-width:Double = DEF_COURTYARD_LINE_WIDTH
   pose:Pose = loc(0.0, 0.0)
   side:Side = Top
   ):
   inside pcb-landpattern:
-    layer(Courtyard(side)) = PlusSymbol(line-width = line-width, pose = pose)
+    layer(Courtyard(side)) = PlusSymbol(line-length = line-length, line-width = line-width, pose = pose)
 
 
 public defn compute-courtyard-boundary (
@@ -54,7 +70,7 @@ public defn compute-courtyard-boundary (
   excess:Double,
   side:Side,
   pos:Pose,
-  ):
+  ) -> Rectangle:
   ; @NOTE - Here I'm using the soldermask openings for the pads
   ;   as the controlling boundary/outline. By doing this -
   ;   I can enforce at least a sliver of soldermask between
@@ -94,10 +110,11 @@ public defn make-courtyard-boundary (
   excess:Double = 0.5
   side:Side = Top
   pos:Pose = loc(0.0, 0.0),
-  ):
+  ) -> Rectangle:
   inside pcb-landpattern:
     val outline = compute-courtyard-boundary(pads(self), pkg-body, density-level, excess, side, pos)
     layer(Courtyard(side)) = outline
+    outline
 
 doc: \<DOC>
 Create a courtyard boundary in a Virtual Landpattern
@@ -114,9 +131,10 @@ public defn build-courtyard-boundary (
   excess:Double = 0.5
   pos:Pose = loc(0.0, 0.0)
   side:Side = Top,
-  ) -> False:
+  ) -> Rectangle:
   val outline = compute-courtyard-boundary(get-pads(vp), pkg-body, density-level, excess, side, pos)
   add-artwork(vp, Courtyard(side), outline, class = "courtyard")
+  outline
 
 doc: \<DOC>
 Retrieve the Dimensions of the Courtyard Boundary

--- a/src/landpatterns/packages.stanza
+++ b/src/landpatterns/packages.stanza
@@ -238,9 +238,10 @@ public defmethod build-courtyard (
   pkg:Package,
   vp:VirtualLP,
   ) -> False:
-  build-courtyard-origin(vp)
   val excess = courtyard-excess(pkg)
-  build-courtyard-boundary(vp, package-body(pkg), density-level(pkg), excess = excess)
+  val outline = build-courtyard-boundary(vp, package-body(pkg), density-level(pkg), excess = excess)
+  build-courtyard-origin(vp, outline)
+  false
 
 
 doc: \<DOC>

--- a/tests/landpatterns/courtyard.stanza
+++ b/tests/landpatterns/courtyard.stanza
@@ -11,6 +11,8 @@ defpackage jsl/tests/landpatterns/courtyard:
   import jsl/landpatterns/pads
   import jsl/landpatterns/packages
   import jsl/landpatterns/courtyard
+  import jsl/landpatterns/VirtualLP
+  import jsl/geometry/box
 
 
 deftest(courtyard) test-courtyard-origin :
@@ -75,3 +77,43 @@ deftest(courtyard) test-courtyard-boundary:
   val expHeight = expWidth
   #EXPECT(almost-equal?(x(outline), expWidth))
   #EXPECT(almost-equal?(y(outline), expHeight))
+
+deftest(courtyard) test-courtyard-build-boundary:
+  val root = VirtualLP()
+
+  ; I'm override the soldermask to make the calculations
+  ;  a bit easier.
+  val pad-obj = smd-pad(Circle(0.5), Circle(0.5))
+  append(root, VirtualPad(1, pad-obj, loc(-1.0, 0.0), name = "first"))
+  append(root, VirtualPad(2, pad-obj, loc(1.0, 0.0), name = "number-2"))
+
+  val body = PackageBody(
+    width = 0.75 +/- 0.1,
+    length = 0.3 +/- 0.1,
+    height = 0.25 +/- [0.06, 0.0]
+  )
+
+  val outline = build-courtyard-boundary(root, body, DensityLevelA, excess = 0.1)
+
+  #EXPECT(width(outline) == 3.2)
+  val exp-height = 1.2
+  #EXPECT(height(outline) == 1.2)
+
+  ; Building the origin marker should result in a fore-shortened
+  ;  marker.
+
+  val marker = build-courtyard-origin(root, outline)
+
+  ; Current marker is a union of two lines. To make the math robust
+  ;  I'm going to take the bounds of the shape as a `box` and
+  ;  then measure its dimensions.
+
+  val b = bounds(marker)
+
+  val b-rect = to-Rectangle(b)
+  val exp-marker-len = (exp-height * DEF_COURTYARD_LEN_RATIO) + DEF_COURTYARD_LINE_WIDTH
+  val EPS = 1.0e-6
+  #EXPECT(almost-equal?(width(b-rect), exp-marker-len, EPS))
+  #EXPECT(almost-equal?(height(b-rect), exp-marker-len, EPS))
+
+

--- a/tests/landpatterns/courtyard.stanza
+++ b/tests/landpatterns/courtyard.stanza
@@ -35,8 +35,8 @@ deftest(courtyard) test-courtyard-origin :
   #EXPECT(length(cy) == 1)
 
   val outline = dims(cy[0])
-  #EXPECT(almost-equal?(x(outline), 1.0 + DEF_COURTYARD_WIDTH))
-  #EXPECT(almost-equal?(y(outline), 1.0 + DEF_COURTYARD_WIDTH))
+  #EXPECT(almost-equal?(x(outline), 1.0 + DEF_COURTYARD_LINE_WIDTH))
+  #EXPECT(almost-equal?(y(outline), 1.0 + DEF_COURTYARD_LINE_WIDTH))
 
   val shapes = shapes(cy[0] as Union)
   #EXPECT(length(shapes) == 2)
@@ -71,7 +71,7 @@ deftest(courtyard) test-courtyard-boundary:
   val pad-diam = 1.0
   val line-width = 0.2
   val mask-clear = clearance(current-rules(), MinSilkSolderMaskSpace)
-  val expWidth = position-span + pad-diam + (2.0 * excess) + (2.0 * mask-clear) + DEF_COURTYARD_WIDTH
+  val expWidth = position-span + pad-diam + (2.0 * excess) + (2.0 * mask-clear)
   val expHeight = expWidth
   #EXPECT(almost-equal?(x(outline), expWidth))
   #EXPECT(almost-equal?(y(outline), expHeight))


### PR DESCRIPTION
Previously if you made a very small component - like an 0201 - then you would get an origin marker that was too large: 

![image](https://github.com/user-attachments/assets/933e42eb-f950-47fc-abda-9e78e4bc6eae)

With this PR - the marker gets scaled if it would be larger than some ratio of the minimum(width/height) of the courtyard: 

![Screenshot 2024-07-27 at 10 37 38 AM](https://github.com/user-attachments/assets/23c1eabe-3353-47ff-9af4-01e4ce0f567b)

This allows the functions that rely on the courtyard to accurate compute the distance between components. 

I also fixed a test regression and added a test for this origin builder in the scene graph.
