### PR TITLE
[Bugfix] Move courtyard origin to a custom layer.

### DIFF
--- a/src/landpatterns/courtyard.stanza
+++ b/src/landpatterns/courtyard.stanza
@@ -16,6 +16,11 @@ defpackage jsl/landpatterns/courtyard:
 public val DEF_COURTYARD_LINE_WIDTH = 0.1
 public val DEF_COURTYARD_LINE_LEN = 1.0
 public val DEF_COURTYARD_LEN_RATIO = 0.5
+; NOTE -
+;   KICAD does not allow for other shapes on the courtyard layer - it
+;   only accepts the boundary shape. So we must place the origin marker
+;   on a separate layer.
+public val DEF_COURTYARD_ORIGIN_LAYER = CustomLayer("origin", Top)
 
 defn compute-origin-size (outline:Rectangle) -> Double :
   ; We look at the outline and use this to determine the
@@ -36,7 +41,7 @@ public defn build-courtyard-origin (
   ) -> Shape:
   val line-length = compute-origin-size(outline)
   val shape = PlusSymbol(line-length = line-length, line-width = line-width, pose = pose)
-  add-artwork(vp, Courtyard(side), shape, class = "courtyard")
+  add-artwork(vp, DEF_COURTYARD_ORIGIN_LAYER, shape, class = "courtyard")
   shape
 
 doc: \<DOC>
@@ -60,7 +65,7 @@ public defn make-courtyard-origin (
   side:Side = Top
   ):
   inside pcb-landpattern:
-    layer(Courtyard(side)) = PlusSymbol(line-length = line-length, line-width = line-width, pose = pose)
+    layer(DEF_COURTYARD_ORIGIN_LAYER) = PlusSymbol(line-length = line-length, line-width = line-width, pose = pose)
 
 
 public defn compute-courtyard-boundary (

--- a/tests/landpatterns/BGA/package.stanza
+++ b/tests/landpatterns/BGA/package.stanza
@@ -142,7 +142,11 @@ deftest(BGA) test-full-landpattern :
 
   ; Check for courtyard
   val cy = layer(lp, Courtyard(Top))
-  #EXPECT(length(cy) == 2)
+  #EXPECT(length(cy) == 1)
+
+  ; Check for Origin
+  val oy = layer(lp, CustomLayer("origin", Top))
+  #EXPECT(length(oy) == 1)
 
   ; Check for the silkscreen
   val silk = layer(lp, Silkscreen("outline", Top))

--- a/tests/landpatterns/SOIC.stanza
+++ b/tests/landpatterns/SOIC.stanza
@@ -163,9 +163,14 @@ deftest(SOIC) test-fine-pitch:
         val shape = pad-shape(pd)
         #EXPECT(shape is Rectangle)
 
+
     ; Check for courtyard
     val cy = layer(W-lp, Courtyard(Top))
-    #EXPECT(length(cy) == 2)
+    #EXPECT(length(cy) == 1)
+
+    ; Check for Origin
+    val oy = layer(W-lp, CustomLayer("origin", Top))
+    #EXPECT(length(oy) == 1)
 
     ; Check for the silkscreen
     val silk = layer(W-lp, Silkscreen("outline", Top))

--- a/tests/landpatterns/courtyard.stanza
+++ b/tests/landpatterns/courtyard.stanza
@@ -28,12 +28,13 @@ deftest(courtyard) test-courtyard-origin :
   val not-empty = to-hashset<LayerSpecifier>([
     SolderMask(Top)
     Paste(Top)
-    Courtyard(Top)
+    CustomLayer("origin", Top)
   ])
 
   expect-empty-others(test-lp, not-empty)
 
-  val cy = layer(test-lp, Courtyard(Top))
+  ; Check for Origin
+  val cy = layer(test-lp, CustomLayer("origin", Top))
   #EXPECT(length(cy) == 1)
 
   val outline = dims(cy[0])


### PR DESCRIPTION
Closes PROD-413

This is required because KICAD won't allow other shapes than the boundary shape on the courtyard layer.

This will allow export to complete successfully.