### PR TITLE
Refactor PCIe to use the `SI-Constraint` model

### DIFF
--- a/examples/protocols/pcie/pcie-main.stanza
+++ b/examples/protocols/pcie/pcie-main.stanza
@@ -9,7 +9,7 @@ defpackage jsl/examples/protocols/pcie/main:
   import jsl/design/settings
 
   import jsl/protocols/pcie
-  import jsl/si/helpers
+  import jsl/si
 
   import jsl/examples/protocols/common/example-board
   import jsl/examples/protocols/common/example-components
@@ -21,20 +21,62 @@ pcb-module pcie-example :
   inst dut1 : jsl/examples/protocols/pcie/pcie-src/module
   inst dut2 : jsl/examples/protocols/pcie/pcie-src/module
 
-  require src : pcie(2) from dut1
-  require dst : pcie(2) from dut2
+  val version = PCIE-V4
+  val trace-imped = pcie-get-trace-impedance(version)
+  val cst = PCIe-Constraint(version, diff(trace-imped))
 
-  require src-p : pcie(2, PCIe-PRSNT#) from dut1 
-  require dst-p : pcie(2, PCIe-PRSNT#) from dut2
+  val b-cap = block-cap(220.0e-9)
 
-  val [skew, loss] = pcie-get-skew-loss-vals(PCIE-V4)
+  ; Construct a typical passive connector setup
+  ;  for a 2 lane configuration. This means a
+  ;  straight through `tx => tx` and `rx => rx`
+  ;  configuration.
 
-  connect-pcie(skew, loss, block-cap(220.0e-9), false, src, dst)
-  connect-pcie(skew, loss, block-cap(220.0e-9), false, src-p, dst-p)
+  require src-ep : pcie(2) from dut1
+  require dst-ep : pcie(2) from dut2
 
-  val trace-imped = pcie-get-trace-impedance(PCIE-V4)
-  pcie-apply-routing-structure(diff(trace-imped), src, dst)
-  pcie-apply-routing-structure(diff(trace-imped), src-p, dst-p)
+  within [src, dst] = constrain-topology(src-ep, dst-ep, cst):
+    ; Here we construct the circuit topology for the link
+    ;   Note that we don't need to worry about any of the constraint
+    ;   application, as that is handled by the `PCIe-Constraint` type.
+    ;   You can add other components in the topology as you wish - below
+    ;   is a typical basic implementation.
+    for i in indices(src.data.lane) do:
+      inst tx-coupler : dp-coupler(b-cap)
+      topo-pair(src.data.lane[i].TX => tx-coupler => dst.data.lane[i].TX)
+      ; No Blocking Caps on the Receive side.
+      topo-net(src.data.lane[i].RX => dst.data.lane[i].RX)
+
+    topo-net(src.data.refclk => dst.data.refclk)
+    ; The control signals do not demand a topology so
+    ;  we just use a straight net connection.
+    net (src.control, dst.control)
+
+  ; Setup an example of an active to active connection between
+  ;  two ICs (ie not to a connector). In this case, we need
+  ;  a null-modem style connection and blocking caps on both rx and
+  ;  tx.
+  ;  Notice that the `reverse-pcie-lane` function handles the null-modem
+  ;  swap. We continue to use `tx => tx` and `rx => rx` inside for
+  ;  consistency.
+  require src-IC : pcie(2, PCIe-PRSNT#) from dut1
+  require dst-IC : pcie(2, PCIe-PRSNT#) from dut2
+
+  ; TODO - the routing structure is not applying through the node here.
+
+  within [src, dst-straight] = constrain-topology(src-IC, dst-IC, cst):
+    ;  Notice that the `reverse-pcie-lane` function handles the null-modem
+    ;  swap. We continue to use `tx => tx` and `rx => rx` inside for
+    ;  consistency.
+    val dst = reverse-pcie-lanes(dst-straight)
+    for i in indices(src.data.lane) do:
+      inst tx-coupler : dp-coupler(b-cap)
+      topo-pair(src.data.lane[i].TX => tx-coupler => dst.data.lane[i].TX)
+      inst rx-coupler : dp-coupler(b-cap)
+      topo-pair(src.data.lane[i].RX => rx-coupler => dst.data.lane[i].RX)
+
+    topo-net(src.data.refclk => dst.data.refclk)
+    net (src.control, dst.control)
 
 set-current-design("pcie-example")
 setup-board()

--- a/examples/protocols/pcie/pcie-src.stanza
+++ b/examples/protocols/pcie/pcie-src.stanza
@@ -13,7 +13,7 @@ defpackage jsl/examples/protocols/pcie/pcie-src :
   import jsl/bundles
   import jsl/protocols/pcie
 
-val body = PackageBody(
+val pkg-body = PackageBody(
   width = 15.0 +/- 0.1,
   length = 15.0 +/- 0.1,
   height = 0.71 +/- [0.06, 0.0]
@@ -25,7 +25,7 @@ val BGA-pkg = BGA(
   columns = 8,
   lead-diam = 0.5,
   pitch = 2.0,
-  package-body = body,
+  package-body = pkg-body,
   density-level = DensityLevelB
 )
 

--- a/src/protocols/pcie.stanza
+++ b/src/protocols/pcie.stanza
@@ -29,6 +29,7 @@ defpackage jsl/protocols/pcie:
 
   import jsl/bundles
   import jsl/errors
+  import jsl/ensure
   import jsl/si
   import jsl/pin-assignment
 
@@ -89,11 +90,6 @@ and it also includes a refclk (100MHz) differential pair
 
 public defn pcie (lanes:Int, opt-pins:PCIePins ...) :
   pcie-b(lanes, opt-pins)
-  ; name = "PCI-e"
-  ; description = "PCI-e Serial Communications Link"
-  ; port control : pcie-control(opt-pins)
-  ; port data : pcie-data(lanes)
-
 
 public pcb-bundle pcie-b (lanes:Int, opt-pins:Collection<PCIePins>) :
   name = "PCI-e"
@@ -114,8 +110,6 @@ public pcb-bundle pcie-data (lanes:Int) :
   name = "PCI-e Data"
   description = "PCI-e Serial Communications Link Data"
   port lane : lane-pair[lanes]
-  ; port rx : diff-pair[lanes]
-  ; port tx : diff-pair[lanes]
   port refclk : diff-pair
 
 pcb-bundle pcie-control-b (pins:Collection<PCIePins>) :
@@ -140,60 +134,6 @@ PCI-e is a serial communication supporting high speed data links
 
 public defn pcie-control (pins:Collection<PCIePins>) :
   pcie-control-b(pins)
-
-doc: \<DOC>
-@brief Construct one direction of a PCIe channel.
-
-This function will construct the `Tx -> Rx` channel of a PCIe bus. The `src` and `dst`
-arguments must both be of type `pcie` with equal lane counts.
-
-@param sw The intra-pair skew time difference for the differential signals being connected.
-@param ml The maximum loss in dB for all differential signals being connected.
-@param src This is assumed to be the "Tx" side of the link. This is expected to be a port of `Bundle` type `pcie`
-@param dst This is assumed to be the "Rx" side of the link. This is expected to be a port of `Bundle` type `pcie`
-@param cap Optional DC blocking capacitor to be inserted between the TX and RX pairs. Note that
-there are 2 blocking caps inserted, one on each of the P,N signals of the pair.
-<DOC>
-public defn connect-pcie-channel (sw:Toleranced, ml:Double, src:JITXObject, dst:JITXObject, cap:Instantiable|False) :
-  inside pcb-module:
-    for i in indices(src.data.lane) do :
-      match(cap) :
-        (c:Instantiable) :
-          inst bl-cap-xy : dp-coupler(c)
-          require tx1 : dual-pair from bl-cap-xy
-          topo-net(src.data.lane[i].TX, tx1.A)
-          topo-net(tx1.B, dst.data.lane[i].RX)
-        (f:False) :
-          topo-net(src.data.lane[i].TX, dst.data.lane[i].RX)
-      constrain-ch(sw, ml, src.data.lane[i].TX, dst.data.lane[i].RX)
-
-doc: \<DOC>
-@brief Construct the PCIe Topology and Constraints
-
-This function constructs the PCIe topology and applies constraints
-to the channel for intra-pair skew and channel loss.
-
-@param sw The intra-pair skew value for the differential signals being connected.
-@param ml The maximum loss for all differential signals being connected.
-@param cap-xy Optional DC blocking capacitor to be inserted between the x.TX and y.RX signal ends. Note that
-there are 2 blocking caps inserted, one on each of the pair of P,N signals. The capacitor needs to have pin models applied to its pins
-in order for the overall skew and loss values to be respected.
-@param cap-yx Optional DC blocking capacitor to be inserted between the y.TX and x.RX signal ends. This capacitor
-covers the reverse direction connection between y.TX and x.RX. If the second component was a connector, then typically
-no capacitor is inserted between y.TX and x.RX (cap-y-x = false).
-@param x This is expected to be a port of `Bundle` type `pcie`
-@param y This is expected to be a port of `Bundle` type `pcie`
-<DOC>
-public defn connect-pcie (sw:Toleranced, ml:Double, cap-xy:Instantiable|False, cap-yx:Instantiable|False, x:JITXObject, y:JITXObject) :
-  inside pcb-module :
-    connect-pcie-channel(sw, ml, x, y, cap-xy)
-    connect-pcie-channel(sw, ml, y, x, cap-yx)
-
-    topo-net(x.data.refclk, y.data.refclk)
-    constrain-ch(sw, ml, x.data.refclk, y.data.refclk)
-    ; no constraints applied to the control sub-bundle
-    net (x.control y.control)
-
 
 doc: \<DOC>
 @brief Curated values for skew and loss of PCIe Channel
@@ -248,18 +188,105 @@ public defn pcie-get-trace-impedance (gen:jsl/protocols/pcie/PCIeVersion) -> Tol
     PCIE-V7 :  85.0 +/- (5 %)  ; 128.0 GT/s
 
 doc: \<DOC>
-@brief Apply the differential routing structure to a PCI-e bundle.
-The function applies the provided DifferentialRoutingStructure
-to all of the differential pairs in the start and endpoints. Note that both start and end points
-need to be connected to physical component pins either directly or via pin assignment.
-@param x This is expected to be a port of `Bundle` type `pcie`
-@param y This is expected to be a port of `Bundle` type `pcie`
-<DOC>
+PCIe SI Constraint Type
 
-public defn pcie-apply-routing-structure (rs:DifferentialRoutingStructure, x:JITXObject, y:JITXObject) :
+This derives from the differential pair constraint
+as most of the controlled signals are differential
+lane pairs (tx/rx). All of these constraints
+will be applied to all of the pairs.
+
+The `constrain` function for this type expects
+two compatible `pcie-b` types.
+<DOC>
+public defstruct PCIe-Constraint <: DP-Constraint :
+  doc: \<DOC>
+  Intra-pair Timing Skew Constraint in Seconds
+  <DOC>
+  skew:Toleranced  with:
+    as-method => true
+  doc: \<DOC>
+  Diff-Pair Max Loss Limit Constraint in dB
+  <DOC>
+  loss:Double with:
+    ensure => ensure-positive!,
+    as-method => true
+  doc: \<DOC>
+  Differential Routing Structure for each Diff-Pair
+  <DOC>
+  route-struct:DifferentialRoutingStructure with:
+    as-method => true
+with:
+  keyword-constructor => true
+  constructor => #PCIe-Constraint
+
+doc: \<DOC>
+Constructor for the PCIe Link Constraint
+
+@param v PCIe Version that we are building
+@param rs Differential Routing Structure constraints for all
+lane pairs and the refclk. This is not applied to the control signals.
+<DOC>
+public defn PCIe-Constraint (v:PCIeVersion, rs:DifferentialRoutingStructure) -> PCIe-Constraint:
+  val [sk, ml] = pcie-get-skew-loss-vals(v)
+  PCIe-Constraint(
+    skew = sk,
+    loss = ml,
+    route-struct = rs
+  )
+
+doc: \<DOC>
+Constrain a PCIe Link
+
+@param cst Constraint Object
+@param src Source End Point - must be of `pcie-b` type
+@param dst Destination End Point - must be of `pcie-b` type and match
+the parameterization of `src`, including lane counts.
+<DOC>
+public defmethod constrain (cst:PCIe-Constraint, src:JITXObject, dst:JITXObject) -> False :
+  inside pcb-module:
+
+    val src-ep = find-signal-end(src)
+    val dst-ep = find-signal-end(dst)
+
+    val src-cnt = length(src-ep.data.lane)
+    val dst-cnt = length(dst-ep.data.lane)
+    if src-cnt != dst-cnt:
+      throw $ ValueError("MisMatched Lane Counted Between Src and Dst: src=%_ dst=%_" % [src-cnt, dst-cnt])
+
+    for i in indices(src-ep.data.lane) do:
+      dp-constrain(cst, src-ep.data.lane[i].TX, dst-ep.data.lane[i].TX)
+      dp-constrain(cst, src-ep.data.lane[i].RX, dst-ep.data.lane[i].RX)
+
+    dp-constrain(cst, src-ep.data.refclk, dst-ep.data.refclk)
+
+
+doc: \<DOC>
+Reverse the PCIe Connection using a `node`
+
+When connecting two active PCIe devices, you will often
+need to create a `null modem` style connection instead
+of the default `tx => tx` and `rx => rx`.
+
+This function allows for a convenient way to create
+`tx => rx` and `rx => tx` lane connections.
+@param p Input port bundle as a `pcie-b` bundle
+@return node of the same type of `p` with the null-modem
+connection applied to the tx/rx lanes. The `refclk` and
+control lines are straight through connections like normal.
+<DOC>
+public defn reverse-pcie-lanes (p:JITXObject) :
   inside pcb-module :
-    for i in indices(x.data.lane) do :
-      diff-structure(rs, x.data.lane[i].TX => y.data.lane[i].RX)
-    for i in indices(y.data.lane) do :
-      diff-structure(rs, y.data.lane[i].TX => x.data.lane[i].RX)
-    diff-structure(rs, x.data.refclk => y.data.refclk)
+    match(port-type(p)):
+      (b:Bundle):
+        node temp:b
+        for i in indices(p.data.lane) do:
+          topo-net(p.data.lane[i].TX => temp.data.lane[i].RX)
+          topo-net(p.data.lane[i].RX => temp.data.lane[i].TX)
+        ; Clock and Controls are straight through.
+        topo-net(p.data.refclk => temp.data.refclk)
+        ; Controls are not usually topologies.
+        net (p.control, temp.control)
+        temp
+      (x):
+        throw $ ValueError("Invalid Port - Expected Bundle - Received: %_" % [x])
+


### PR DESCRIPTION
I've update the PCIe protocol and example to use the `SI-Constraint` model.

Here is the straight through version (ie IC to connector):
![Screenshot 2024-08-07 at 9 29 26 AM](https://github.com/user-attachments/assets/4eeb70c8-06ce-437b-b40b-cf0f7e443f4d)

Notice the blocking caps on only the TX side. 

Here is the null-modem case (ie, IC to IC, TX => RX, RX => TX):

![Screenshot 2024-08-07 at 10 57 55 AM](https://github.com/user-attachments/assets/c6b83642-5d16-4182-81f9-ef1d7befaa78)

Blocking caps on both TX channels. Notice that the routing structure application is not working for the null-modem case because of the use of `node` in `reverse-pcie-lanes`. 

