### PR TITLE
Added more introspection of components, modules, and ports

### DIFF
--- a/src/design/introspection.stanza
+++ b/src/design/introspection.stanza
@@ -385,13 +385,46 @@ public defn find-instance-by-ref (r:Ref, cxt:JITXObject = self) -> Maybe<JITXObj
 doc: \<DOC>
 Get the net associated with a module or component port
 
-@param pt Port of a component or module.
+This function must be called from within a `pcb-module` context.
+
+Note that this function will fail to find a net if the passed `pt`
+port is not part of a component or module in the local context.
+For example, If you have: 
+
+```stanza
+pcb-module wrapper:
+  port GND
+  inst C : some-component
+
+  ; `INT` is defined only in the `wrapper`
+  ;   context.
+  net INT (C.internal-port, ...)
+
+pcb-module top-level:
+
+  inst W : wrapper 
+  net GND (W.GND)
+
+  ; This will work
+  val n1 = get-connected-net!(W.GND)
+
+  ; This will not work
+  val n2 = get-connected-net!(W.C.internal-port)
+```
+The value for `n1` will be successfully found as the `GND`
+net because it is defined within the `pcb-module` context.
+
+The `n2` invocation will throw an exception and not be able to find `INT`
+as the net for `W.C.internal-port`.
+
+@param pt Port of a component or module in this module context.
+@param cxt Optional context to search. The default value is `self`.
 @return If a connection is found - this function returns the Net as
 a JITXObject. If no connection is found - then None().
 <DOC>
-public defn get-connected-net (pt:JITXObject) -> Maybe<JITXObject>:
+public defn get-connected-net (pt:JITXObject, cxt:JITXObject = self) -> Maybe<JITXObject>:
   inside pcb-module:
-    for n in nets(self) first :
+    for n in nets(cxt) first :
       if connected?([pt, n]):
         One(n)
       else:
@@ -399,14 +432,20 @@ public defn get-connected-net (pt:JITXObject) -> Maybe<JITXObject>:
 
 doc: \<DOC>
 Get the net associated with a module or component port
-@param pt Port of a component or module.
+
+This function must be called from within a `pcb-module` context.
+
+This function has similar constraints to @{link get-connected-net}.
+
+@param pt Port of a component or module in this module context.
+@param cxt Optional context to search. The default value is `self`.
 @return A `Net` object as a JITXObject if the port is connected.
 @throws ValueError if no net connections are found or if more than one net
 connection is found.
 <DOC>
-public defn get-connected-net! (pt:JITXObject) -> JITXObject:
+public defn get-connected-net! (pt:JITXObject, cxt:JITXObject = self) -> JITXObject:
   inside pcb-module:
-    val n-set = to-tuple $ for n in nets(self) filter :
+    val n-set = to-tuple $ for n in nets(cxt) filter :
       connected?([pt, n])
 
     if length(n-set) == 0:

--- a/src/design/introspection.stanza
+++ b/src/design/introspection.stanza
@@ -5,6 +5,8 @@ defpackage jsl/design/introspection:
   import jitx
   import jitx/commands
 
+  import jsl/errors
+
 
 doc: \<DOC>
 Retrieve the `Instantiable` that generates the instances of the passed object.
@@ -109,7 +111,7 @@ println("N: %_" % [N])
 ; N: GND[0]
 
 val B = #R(some.other.C.VDD)
-val N2 = get-ref-name(A)
+val N2 = get-ref-name(B)
 println("N2: %_" % [N2])
 
 ; Will Print:
@@ -125,6 +127,41 @@ public defn get-ref-name (r:Ref) -> Ref:
     (x): 1
   tail(r, ref-length(r) - nameIndex)
 
+doc: \<DOC>
+Check if the passed object is a `pcb-module` instance
+<DOC>
+public defn is-module? (obj:JITXObject) -> True|False :
+  instance-type(obj) is SingleModule
+
+doc: \<DOC>
+Check if the passed object is a `pcb-component` instance
+<DOC>
+public defn is-component? (obj:JITXObject) -> True|False :
+  instance-type(obj) is SingleComponent
+
+doc: \<DOC>
+Get the parent ref for a particular object
+
+This is useful to get the Ref of the parent
+component when passed a Ref to a `port` of that component.
+@param r Ref to a child object of a parent - ie `some.parent.child`
+@return Ref to the parent of the child object - ie `some.parent`
+<DOC>
+public defn get-parent-ref (r:Ref) -> Maybe<Ref>:
+  val n = get-ref-name(r)
+  val n-len = ref-length(n)
+  val total-len = ref-length(r)
+  if total-len - n-len > 0:
+    One $ base(r, ref-length(r) - n-len)
+  else:
+    None()
+
+public defn get-parent-ref! (r:Ref) -> Ref:
+  match(get-parent-ref(r)):
+    (_:None): throw $ ValueError("No Parent Ref Present for Ref '%_'" % [to-string(r)])
+    (given:One<Ref>):
+      value(given)
+
 
 doc: \<DOC>
 Retrieve a mapping of Ports to Pads
@@ -137,7 +174,6 @@ public defn port-to-pads (dev:JITXObject) -> Tuple<KeyValue<JITXObject, Tuple<JI
   inside pcb-module:
     ;Get the landpattern definition of the instance's component.
     val lp = landpattern(instance-definition(dev))
-
     ;Build a table storing each landpattern pad by its ref.
     val pad-table = to-hashtable<Ref, JITXObject>(seq({ref(_0) => _0}, pads(lp)))
     ;Scroll through pin property table to map instance port to landpattern pads.
@@ -173,9 +209,176 @@ public defn get-pads-from-port (p2p-map:Tuple<KeyValue<JITXObject, Tuple<JITXObj
 doc: \<DOC>
 Retrieve the pads associated with a particular port
 
-@param comp A `pcb-component` instance
-@param pt Port of that very same component instance `comp`
-@return If port is found and has pads, a tuple of `Pad` objects for that port. Otherwise `None()`.
+@param pt Port on a component in the passed context.
+@param cxt Context to search for the component instance. The default is `self`.
+@return If compoenent associated with `pt` is found in `cxt` and that port has pads, a tuple of `Pad` objects for that port. Otherwise `None()`.
 <DOC>
-public defn get-pads-from-port (comp:JITXObject, pt:JITXObject) -> Maybe<Tuple<JITXObject>> :
-  get-pads-from-port(port-to-pads(comp), pt)
+
+public defn get-pads-from-port (pt:JITXObject, cxt:JITXObject = self) -> Maybe<Tuple<JITXObject>>:
+  inside pcb-module:
+    val comp? = get-component-from-port(pt, cxt)
+    match(comp?):
+      (_:None):
+        throw $ ValueError("No Parent Component Found for Port '%_'" % [ref(pt)])
+      (given:One<JITXObject>):
+        val p2p-map = port-to-pads(value(given))
+        get-pads-from-port(p2p-map, pt)
+
+doc: \<DOC>
+Retrieve the parent instance (component or module) for a port.
+
+This function expects you to pass something like `comp.GND` which
+is a `port` on `comp` and then this function will get a reference
+to `comp` as a `JITXObject`.
+
+Be careful of child port on bundle ports - these will give a ref
+to the parent bundle port - not the component.
+
+This function expects to be called from `pcb-module` context.
+
+@param pt Port on a component or module
+@return Reference to a `pcb-module` or `pcb-component` instance.
+<DOC>
+public defn get-parent-from-port (pt:JITXObject, cxt:JITXObject = self) -> Maybe<JITXObject>:
+  inside pcb-module:
+    val pt-R = ref(pt)
+    val parent-R? = get-parent-ref(pt-R)
+    match(parent-R?):
+      (_:None): One(self)
+      (given:One<Ref>):
+        find-instance-by-ref(value(given), cxt)
+
+
+doc: \<DOC>
+Get a component instance from a Port
+
+This function can be called from a `pcb-module` context. Calling from
+a `pcb-component` context will likely result in an exception.
+
+@param pt Port on a component instance.
+@param cxt Context to search for components in.
+@return If we
+<DOC>
+public defn get-component-from-port (pt:JITXObject, cxt:JITXObject = self) -> Maybe<JITXObject>:
+  inside pcb-module:
+    val pt-R = ref(pt)
+    val parent-R? = get-parent-ref(pt-R)
+    match(parent-R?):
+      (_:None):
+        ; TODO - I need a way to differentiate between `pcb-module` and `pcb-component`
+        ;   here otherwise, this component might return a module instance breaking the
+        ;   abstraction.
+        throw $ ValueError("UnHandle-able Case - Did you pass a module port or from a `pcb-component` context?")
+        ; One(self)
+      (given:One<Ref>):
+        val parent-R = value(given)
+        ; We need to search because if the user were to have passed
+        ;  a SinglePin port of a bundle port - then we need to continue looking up the tree
+        ;  until we find the component instance and not just bundle port.
+        val trail-comp? = find-instance-by-ref(parent-R, cxt)
+        ; I want to make sure this is a component
+        match(trail-comp?):
+          (_:None): None()
+          (given:One<JITXObject>):
+            val c-or-m? = value(given)
+            if not is-component?(c-or-m?):
+              println("Component: %_" % [c-or-m?])
+              throw $ InstanceTypeError(expects = SingleComponent, observed = instance-type(c-or-m?))
+            given
+
+
+doc: \<DOC>
+Retrieve an Instance from a particular context by Ref
+
+This function must be called from within a `pcb-module`
+context.
+
+This function is not recursive. If you pass `r = some.obj`
+from the `cxt` context, then that object will not be found. This
+function could find `cxt.some` if passed `r = some`.
+
+@param r Ref to an object in `cxt` - Note that the path must be
+referenced from the `cxt`. If you have a prefix - then the
+instance will not be found.
+@param cxt Context from which we will query the instances. By default
+this value is `self`.
+@return An instance from the `cxt` context. Note that this could be either
+a `pcb-module` or a `pcb-component` instance.
+<DOC>
+public defn get-instance-by-ref (r:Ref, cxt:JITXObject = self) -> Maybe<JITXObject>:
+  inside pcb-module:
+    for obj in instances(cxt) first:
+      if ref(obj) == r:
+        One(obj)
+      else:
+        None()
+
+doc: \<DOC>
+Retrieve a Component Instance from a particular context by Ref
+
+This function must be called from within a `pcb-module`
+context.
+
+This function is not recursive. If you pass `r = some.obj`
+from the `cxt` context, then that object will not be found. This
+function could find `cxt.some` if passed `r = some`.
+
+@param r Ref to an object in `cxt` - Note that the path must be
+referenced from the `cxt`. If you have a prefix - then the
+instance will not be found.
+@param cxt Context from which we will query the instances. By default
+this value is `self`.
+@return Instance of a `pcb-component` in the `cxt` context. Note that
+`pcb-module` instances will be filtered out.
+<DOC>
+public defn get-component-by-ref (r:Ref, cxt:JITXObject = self) -> Maybe<JITXObject>:
+  inside pcb-module:
+    for obj in component-instances(cxt) first:
+      if ref(obj) == r:
+        One(obj)
+      else:
+        None()
+
+doc: \<DOC>
+Find an instance by `Ref` by searching the design hierarchy.
+
+This function must be called from within a `pcb-module` context.
+
+@param r Ref of the `Instance` object we wish to find. An instance can
+be either a `pcb-module` or `pcb-component`.
+@param cxt Parent scope to search in. By default this is `self`.
+
+@return If we find an instance by the pass Ref `r` in the `cxt` context, then
+we will return a `JITXObject` for that instance. Otherwise, None().
+<DOC>
+public defn find-instance-by-ref (r:Ref, cxt:JITXObject = self) -> Maybe<JITXObject> :
+  inside pcb-module:
+
+    var search-space = cxt
+    var last-comp:Maybe<JITXObject> = None()
+    val comps = Array<Maybe<JITXObject>>(ref-length(r))
+    for i in 1 through ref-length(r) do:
+      val b = base(r, i)
+      val comp? = for obj in instances(search-space) first:
+        if ref(obj) == b:
+          One(obj)
+        else:
+          None()
+
+      comps[i - 1] = comp?
+      match(comp?:One<JITXObject>):
+        search-space = value!(comp?)
+
+    ; Now I have a list of all of the elements in my ref from start
+    ;  to finish.
+    ; I want to filter this for the last non-None value and confirm
+    ;  that it is a component
+
+    val trail-comp? = for comp in in-reverse(comps) first:
+      if comp is-not None:
+        One(value!(comp))
+      else:
+        None()
+
+    trail-comp?
+

--- a/src/design/introspection.stanza
+++ b/src/design/introspection.stanza
@@ -478,7 +478,10 @@ functions and generators.
 
 <DOC>
 public pcb-struct jsl/design/introspection/PortInfo :
-  connected-net:Maybe<JITXObject>
+  ; Ideally - this is a `Maybe` but that isn't supported
+  ;   yet.
+  ; TODO - consider shifting to `Maybe` in the future.
+  connected-net:JITXObject|False
   pad-set:Tuple<jsl/landpatterns/introspection/PadInfo>
 
 doc: \<DOC>
@@ -496,7 +499,7 @@ public defn get-port-info (pt:JITXObject) -> PortInfo:
         val lp-pds = value(given)
         to-tuple $ for lp-pd in lp-pds seq:
           get-pad-info(lp-pd)
-    PortInfo(
-      get-connected-net(pt)
-      pd-info
-    )
+    val con-net = match(get-connected-net(pt)):
+      (_:None): false
+      (given:One<JITXObject>): value(given)
+    PortInfo(con-net, pd-info)

--- a/src/design/introspection.stanza
+++ b/src/design/introspection.stanza
@@ -37,7 +37,7 @@ throw an error if that port does not exist.
 For `PortArray` ports, if the `name` contains the `[]` indexing
 argument, then this will find individual port array elements.
 If there is not `[]` indexing argument, then the `PortArray`
-port itself will be discovered.
+port itself will be returned.
 
 @param obj Component or Module to interrogate for a port
 @param name Name of port to interrogate. This name can include
@@ -221,7 +221,7 @@ Retrieve the pads associated with a particular port
 
 @param pt Port on a component in the passed context.
 @param cxt Context to search for the component instance. The default is `self`.
-@return If compoenent associated with `pt` is found in `cxt` and that port has pads, a tuple of `Pad` objects for that port. Otherwise `None()`.
+@return If component associated with `pt` is found in `cxt` and the port `pt` has pads, this function returns a tuple of `Pad` objects for that port. Otherwise `None()`.
 <DOC>
 
 public defn get-pads-from-port (pt:JITXObject, cxt:JITXObject = self) -> Maybe<Tuple<JITXObject>>:
@@ -237,11 +237,10 @@ public defn get-pads-from-port (pt:JITXObject, cxt:JITXObject = self) -> Maybe<T
 doc: \<DOC>
 Retrieve the parent instance (component or module) for a port.
 
-This function expects you to pass something like `comp.GND` which
-is a `port` on `comp` and then this function will get a reference
-to `comp` as a `JITXObject`.
+This function expects the caller to pass a port `comp.GND` and then
+this function will return a reference to `comp` as a `JITXObject`.
 
-Be careful of child port on bundle ports - these will give a ref
+Be careful of child ports on bundle ports - these will give a ref
 to the parent bundle port - not the component.
 
 This function expects to be called from `pcb-module` context.
@@ -267,7 +266,9 @@ a `pcb-component` context will likely result in an exception.
 
 @param pt Port on a component instance.
 @param cxt Context to search for components in.
-@return If we
+@return If we successfully, determine the parent component, this returns a reference to that
+component as a JITXObject. If not, we return `None()`.
+@throws ValueError If the user passes a port on a module or we can't determine if this is a component context.
 <DOC>
 public defn get-component-from-port (pt:JITXObject, cxt:JITXObject = self) -> Maybe<JITXObject>:
   inside pcb-module:
@@ -279,7 +280,6 @@ public defn get-component-from-port (pt:JITXObject, cxt:JITXObject = self) -> Ma
         ;   here otherwise, this component might return a module instance breaking the
         ;   abstraction.
         throw $ ValueError("UnHandle-able Case - Did you pass a module port or from a `pcb-component` context?")
-        ; One(self)
       (given:One<Ref>):
         val parent-R = value(given)
         ; We need to search because if the user were to have passed
@@ -292,7 +292,6 @@ public defn get-component-from-port (pt:JITXObject, cxt:JITXObject = self) -> Ma
           (given:One<JITXObject>):
             val c-or-m? = value(given)
             if not is-component?(c-or-m?):
-              println("Component: %_" % [c-or-m?])
               throw $ InstanceTypeError(expects = SingleComponent, observed = instance-type(c-or-m?))
             given
 
@@ -303,13 +302,15 @@ Retrieve an Instance from a particular context by Ref
 This function must be called from within a `pcb-module`
 context.
 
-This function is not recursive. If you pass `r = some.obj`
-from the `cxt` context, then that object will not be found. This
-function could find `cxt.some` if passed `r = some`.
+This function is not recursive. If the caller passes `some.obj`
+from the `cxt` context, then that object will not be found because `obj` is
+within the `some` object context, not `cxt`. This function could find
+`cxt.some` if passed `some`.
 
 @param r Ref to an object in `cxt` - Note that the path must be
-referenced from the `cxt`. If you have a prefix - then the
-instance will not be found.
+referenced from the `cxt`. Any prefix in the ref before `cxt` will likely
+result in a failure to find the instance. Notice that for the `self` context,
+then we can just pass references without the `self.` prefix.
 @param cxt Context from which we will query the instances. By default
 this value is `self`.
 @return An instance from the `cxt` context. Note that this could be either
@@ -330,13 +331,15 @@ Retrieve a Component Instance from a particular context by Ref
 This function must be called from within a `pcb-module`
 context.
 
-This function is not recursive. If you pass `r = some.obj`
-from the `cxt` context, then that object will not be found. This
-function could find `cxt.some` if passed `r = some`.
+This function is not recursive. If the caller passes `some.obj`
+from the `cxt` context, then that object will not be found because `obj` is
+within the `some` object context, not `cxt`. This function could find
+`cxt.some` if passed `some`.
 
 @param r Ref to an object in `cxt` - Note that the path must be
-referenced from the `cxt`. If you have a prefix - then the
-instance will not be found.
+referenced from the `cxt`. Any prefix in the ref before `cxt` will likely
+result in a failure to find the instance. Notice that for the `self` context,
+then we can just pass references without the `self.` prefix.
 @param cxt Context from which we will query the instances. By default
 this value is `self`.
 @return Instance of a `pcb-component` in the `cxt` context. Note that
@@ -400,7 +403,7 @@ This function must be called from within a `pcb-module` context.
 
 Note that this function will fail to find a net if the passed `pt`
 port is not part of a component or module in the local context.
-For example, If you have:
+For example, if the design contains:
 
 ```stanza
 pcb-module wrapper:
@@ -422,11 +425,12 @@ pcb-module top-level:
   ; This will not work
   val n2 = get-connected-net!(W.C.internal-port)
 ```
+
 The value for `n1` will be successfully found as the `GND`
 net because it is defined within the `pcb-module` context.
 
-The `n2` invocation will throw an exception and not be able to find `INT`
-as the net for `W.C.internal-port`.
+The `n2` invocation will fail to find `INT` as the net
+for `W.C.internal-port` and return `None()`.
 
 @param pt Port of a component or module in this module context.
 @param cxt Optional context to search. The default value is `self`.

--- a/src/design/introspection.stanza
+++ b/src/design/introspection.stanza
@@ -7,7 +7,6 @@ defpackage jsl/design/introspection:
 
   import jsl/errors
 
-
 doc: \<DOC>
 Retrieve the `Instantiable` that generates the instances of the passed object.
 
@@ -313,6 +312,7 @@ public defn get-instance-by-ref (r:Ref, cxt:JITXObject = self) -> Maybe<JITXObje
       else:
         None()
 
+
 doc: \<DOC>
 Retrieve a Component Instance from a particular context by Ref
 
@@ -382,3 +382,36 @@ public defn find-instance-by-ref (r:Ref, cxt:JITXObject = self) -> Maybe<JITXObj
 
     trail-comp?
 
+doc: \<DOC>
+Get the net associated with a module or component port
+
+@param pt Port of a component or module.
+@return If a connection is found - this function returns the Net as
+a JITXObject. If no connection is found - then None().
+<DOC>
+public defn get-connected-net (pt:JITXObject) -> Maybe<JITXObject>:
+  inside pcb-module:
+    for n in nets(self) first :
+      if connected?([pt, n]):
+        One(n)
+      else:
+        None()
+
+doc: \<DOC>
+Get the net associated with a module or component port
+@param pt Port of a component or module.
+@return A `Net` object as a JITXObject if the port is connected.
+@throws ValueError if no net connections are found or if more than one net
+connection is found.
+<DOC>
+public defn get-connected-net! (pt:JITXObject) -> JITXObject:
+  inside pcb-module:
+    val n-set = to-tuple $ for n in nets(self) filter :
+      connected?([pt, n])
+
+    if length(n-set) == 0:
+      throw $ ValueError("Invalid Port - No net connection found")
+    else if length(n-set) > 1 :
+      throw $ ValueError("Invalid Port - Multiple Nets Associated - Expected Singular Net")
+
+    n-set[0]

--- a/src/design/introspection.stanza
+++ b/src/design/introspection.stanza
@@ -465,19 +465,10 @@ in the pcb-module / pcb-component hierarchy.
 This object will make requests to retrieve data about a port
 then consolidate into a single pass-able object to various
 functions and generators.
+
 <DOC>
 public pcb-struct jsl/design/introspection/PortInfo :
-  doc: \<DOC>
-  Net connector this port if any.
-  <DOC>
   connected-net:Maybe<JITXObject>
-  doc: \<DOC>
-  The info about the pads associated with this port
-  The component contains a `port -> pad` mapping table
-  that we used to extra the `pad` objects that are associated
-  with this port. Then we extract meta data about each of those
-  pads to reference here.
-  <DOC>
   pad-set:Tuple<jsl/landpatterns/introspection/PadInfo>
 
 doc: \<DOC>

--- a/src/design/introspection.stanza
+++ b/src/design/introspection.stanza
@@ -6,6 +6,7 @@ defpackage jsl/design/introspection:
   import jitx/commands
 
   import jsl/errors
+  import jsl/landpatterns/introspection
 
 doc: \<DOC>
 Retrieve the `Instantiable` that generates the instances of the passed object.
@@ -389,7 +390,7 @@ This function must be called from within a `pcb-module` context.
 
 Note that this function will fail to find a net if the passed `pt`
 port is not part of a component or module in the local context.
-For example, If you have: 
+For example, If you have:
 
 ```stanza
 pcb-module wrapper:
@@ -402,7 +403,7 @@ pcb-module wrapper:
 
 pcb-module top-level:
 
-  inst W : wrapper 
+  inst W : wrapper
   net GND (W.GND)
 
   ; This will work
@@ -454,3 +455,47 @@ public defn get-connected-net! (pt:JITXObject, cxt:JITXObject = self) -> JITXObj
       throw $ ValueError("Invalid Port - Multiple Nets Associated - Expected Singular Net")
 
     n-set[0]
+
+doc: \<DOC>
+Port Info Object
+
+This object is primarily a tool for working around limitations
+in the pcb-module / pcb-component hierarchy.
+
+This object will make requests to retrieve data about a port
+then consolidate into a single pass-able object to various
+functions and generators.
+<DOC>
+public pcb-struct jsl/design/introspection/PortInfo :
+  doc: \<DOC>
+  Net connector this port if any.
+  <DOC>
+  connected-net:Maybe<JITXObject>
+  doc: \<DOC>
+  The info about the pads associated with this port
+  The component contains a `port -> pad` mapping table
+  that we used to extra the `pad` objects that are associated
+  with this port. Then we extract meta data about each of those
+  pads to reference here.
+  <DOC>
+  pad-set:Tuple<jsl/landpatterns/introspection/PadInfo>
+
+doc: \<DOC>
+Extract Port Info from a port `JITXObject`
+@param pt Port referenced from an component object, typically
+using dot notation like `MCU.RESET_n`.
+@return Extracted port data for this port.
+<DOC>
+public defn get-port-info (pt:JITXObject) -> PortInfo:
+  inside pcb-module:
+    val pads? = get-pads-from-port(pt)
+    val pd-info = match(pads?):
+      (_:None): []
+      (given:One<Tuple<JITXObject>>):
+        val lp-pds = value(given)
+        to-tuple $ for lp-pd in lp-pds seq:
+          get-pad-info(lp-pd)
+    PortInfo(
+      get-connected-net(pt)
+      pd-info
+    )

--- a/src/design/introspection.stanza
+++ b/src/design/introspection.stanza
@@ -34,6 +34,11 @@ Retrieve a Port by its symbol name
 This function retrieves a port on a component but doesn't
 throw an error if that port does not exist.
 
+For `PortArray` ports, if the `name` contains the `[]` indexing
+argument, then this will find individual port array elements.
+If there is not `[]` indexing argument, then the `PortArray`
+port itself will be discovered.
+
 @param obj Component or Module to interrogate for a port
 @param name Name of port to interrogate. This name can include
 dot-notation style introspection if needed.
@@ -43,8 +48,13 @@ dot-notation style introspection if needed.
 public defn get-port-by-name (obj:JITXObject, name:String) -> Maybe<JITXObject> :
   label<Maybe<JITXObject>> return:
     val pat = to-string(".%_" % [name])
-    for p in pins(obj) do:
-      val refName = to-string $ ref(p)
+    val has-index? = suffix?(name, "]")
+    for p in ports(obj) do:
+      val refName = to-string $ match(ref(p)):
+        (ir:IndexRef):
+          if not has-index?: ref(ir)
+          else: ir
+        (other): other
       if suffix?(refName, pat) :
         return(One(p))
     return(None())

--- a/src/errors.stanza
+++ b/src/errors.stanza
@@ -79,3 +79,16 @@ public defstruct InvalidComponentSupports <: Exception:
 
 public defmethod print (o:OutputStream, e:InvalidComponentSupports):
   print(o, "Expected Instance to provide one of '%,' supports - but none were found"  % [expected-supports(e)])
+
+
+doc: \<DOC>
+Exception type for Distinguishing between module and component instances
+<DOC>
+public defstruct InstanceTypeError <: Exception:
+  expects:InstanceType
+  observed:InstanceType
+with:
+  keyword-constructor => true
+
+public defmethod print (o:OutputStream, e:InstanceTypeError):
+  print(o, "Expected Instance of type %_ but Received Instance of type %_" % [expects(e), observed(e)])

--- a/src/landpatterns/introspection.stanza
+++ b/src/landpatterns/introspection.stanza
@@ -47,27 +47,21 @@ limitations in the `pcb-module` and `pcb-component` hierarchy.
 This type consolidates much of the meta-data associated with a
 particular pad so that it can be transmitted accross `pcb-module`
 definition boundaries.
+
+It includes data from the following API calls:
+
+ *  `pad-type()`
+ *  `pad-shape()`
+ *  `pose()`
+ *  `side()`
+ *  `layers()`
+
 <DOC>
 public pcb-struct jsl/landpatterns/introspection/PadInfo :
-  doc: \<DOC>
-  See `pad-type()`
-  <DOC>
   type:PadType
-  doc: \<DOC>
-  See `pad-shape()`
-  <DOC>
   shape:Shape
-  doc: \<DOC>
-  See `pose()`
-  <DOC>
   pose:Pose
-  doc: \<DOC>
-  See `side()`
-  <DOC>
   side:Side
-  doc: \<DOC>
-  See `layers()`
-  <DOC>
   layer-data:Tuple<LayerShape>
 
 doc: \<DOC>

--- a/src/landpatterns/introspection.stanza
+++ b/src/landpatterns/introspection.stanza
@@ -36,3 +36,55 @@ public defn get-pad-by-name! (obj:LandPattern, name:String) -> JITXObject :
     (_:None):
       throw $ ValueError("No Pad by name '%_' found in LandPattern '%_'" % [name, obj])
     (v:One<JITXObject>): value(v)
+
+
+doc: \<DOC>
+Info about a Particular Pad of a LandPattern
+
+This type is primarily a helper function for working around
+limitations in the `pcb-module` and `pcb-component` hierarchy.
+
+This type consolidates much of the meta-data associated with a
+particular pad so that it can be transmitted accross `pcb-module`
+definition boundaries.
+<DOC>
+public pcb-struct jsl/landpatterns/introspection/PadInfo :
+  doc: \<DOC>
+  See `pad-type()`
+  <DOC>
+  type:PadType
+  doc: \<DOC>
+  See `pad-shape()`
+  <DOC>
+  shape:Shape
+  doc: \<DOC>
+  See `pose()`
+  <DOC>
+  pose:Pose
+  doc: \<DOC>
+  See `side()`
+  <DOC>
+  side:Side
+  doc: \<DOC>
+  See `layers()`
+  <DOC>
+  layer-data:Tuple<LayerShape>
+
+doc: \<DOC>
+Helper functions to consolidate all of the introspection data related to a pad.
+
+@param pd `LandPatternPad` object that we will inspect for data. Typically
+this accessed using the `pads()` API function or using the {@link get-pads-from-port}
+function.
+@return PadInfo object that captures all of the info related to this pad.
+<DOC>
+public defn get-pad-info (lp-pd:JITXObject) -> PadInfo :
+  val pd = pad(lp-pd)
+  PadInfo(
+    pad-type(pd)
+    pad-shape(pd)
+    pose(lp-pd)
+    side(lp-pd)
+    layers(pd)
+  )
+

--- a/tests/design/introspection.stanza
+++ b/tests/design/introspection.stanza
@@ -9,6 +9,7 @@ defpackage jsl/tests/design/introspection:
   import jsl/design/settings
   import jsl/landpatterns
   import jsl/symbols
+  import jsl/bundles
 
 
 pcb-component two-pin-non-polar :
@@ -46,6 +47,31 @@ pcb-component two-pin-polar :
   val lp = create-landpattern(pkg)
   assign-landpattern(lp)
 
+pcb-component test-comp:
+  port A : diff-pair
+  pin-properties:
+    [pin:Ref | pads:Int ... ]
+    [VDD     | 1, 2]
+    [GND     | 3, 4]
+    [D[0]    | 5]
+    [D[1]    | 6]
+    [A.P     | 7]
+    [A.N     | 8]
+
+  val box = BoxSymbol(self)
+  assign-symbol $ create-symbol(box)
+
+  val pkg = SOIC-N(
+    num-leads = 8,
+    lead-span = min-max(5.8, 6.2),
+    package-length = 4.5 +/- 0.10,
+    density-level = DensityLevelC
+  )
+
+  val lp = create-landpattern(pkg)
+  assign-landpattern(lp)
+
+
 deftest(design_introspection) test-port-introspection :
 
   pcb-module uut:
@@ -61,5 +87,177 @@ deftest(design_introspection) test-port-introspection :
     #EXPECT(length(obs2) == 2)
     #EXPECT(to-string(ref(obs2[0])) == "D.c")
     #EXPECT(to-string(ref(obs2[1])) == "D.a")
+
+  set-main-module(uut)
+
+deftest(design_introspection) test-ref-tools :
+  pcb-module uut:
+    port asdf
+    ; `get-ref-name`
+    val A = #R(some.mod.C.GND[0])
+    val N1 = get-ref-name(A)
+    #EXPECT(N1 == #R(GND[0]))
+
+    val B = #R(some.other.C.VDD)
+    val N2 = get-ref-name(B)
+    #EXPECT(N2 == #R(VDD))
+
+    ; `get-parent-ref`
+    val C1 = #R(some.mod.C.GND[0])
+    val P1 = get-parent-ref(C1)
+    #EXPECT(value!(P1) == #R(some.mod.C))
+
+    val C2 = #R(self.qwer.SPI)
+    val P2 = get-parent-ref(C2)
+    #EXPECT(value!(P2) == #R(self.qwer))
+
+    val C3 = ref(self.asdf)
+    val P3 = get-parent-ref(C3)
+    #EXPECT(P3 is None)
+
+  set-main-module(uut)
+
+deftest(design_introspection) test-get-pads-from-port:
+
+  pcb-module wrapper :
+    public inst M : test-comp
+
+  pcb-module uut:
+    inst C : test-comp
+    inst S : wrapper
+
+    val p2p-map = port-to-pads(C)
+
+    val VDD-pads? = get-pads-from-port(p2p-map, C.VDD)
+    match(VDD-pads?):
+      (_:None): #EXPECT("No Pads Found - Expected 2" == "")
+      (given:One<Tuple<JITXObject>>):
+        val pad-set = value(given)
+        #EXPECT(length(pad-set) == 2)
+        #EXPECT(ref(pad-set[0]) == #R(p[1]))
+        #EXPECT(ref(pad-set[1]) == #R(p[2]))
+
+        #EXPECT(side(pad-set[0]) == Top)
+        #EXPECT(pad-type(pad(pad-set[0])) == SMD)
+        #EXPECT(pad-shape(pad(pad-set[0])) is Rectangle)
+
+    val GND-pads? = get-pads-from-port(p2p-map, C.GND)
+    match(GND-pads?):
+      (_:None): #EXPECT("No Pads Found - Expected 2" == "")
+      (given:One<Tuple<JITXObject>>):
+        val pad-set = value(given)
+        #EXPECT(length(pad-set) == 2)
+        #EXPECT(ref(pad-set[0]) == #R(p[3]))
+        #EXPECT(ref(pad-set[1]) == #R(p[4]))
+
+    val D0-pads? = get-pads-from-port(p2p-map, C.D[0])
+    match(D0-pads?):
+      (_:None): #EXPECT("No Pads Found - Expected 1" == "")
+      (given:One<Tuple<JITXObject>>):
+        val pad-set = value(given)
+        #EXPECT(length(pad-set) == 1)
+        #EXPECT(ref(pad-set[0]) == #R(p[5]))
+
+    val AP-pads? = get-pads-from-port(p2p-map, C.A.P)
+    match(AP-pads?):
+      (_:None): #EXPECT("No Pads Found - Expected 1" == "")
+      (given:One<Tuple<JITXObject>>):
+        val pad-set = value(given)
+        #EXPECT(length(pad-set) == 1)
+        #EXPECT(ref(pad-set[0]) == #R(p[7]))
+
+
+    val D1-pads? = get-pads-from-port(C.D[1])
+    match(D1-pads?):
+      (_:None): #EXPECT("No Pads Found - Expected 1" == "")
+      (given:One<Tuple<JITXObject>>):
+        val pad-set = value(given)
+        #EXPECT(length(pad-set) == 1)
+        #EXPECT(ref(pad-set[0]) == #R(p[6]))
+
+    val AN-pads? = get-pads-from-port(C.A.N)
+    match(AN-pads?):
+      (_:None): #EXPECT("No Pads Found - Expected 1" == "")
+      (given:One<Tuple<JITXObject>>):
+        val pad-set = value(given)
+        #EXPECT(length(pad-set) == 1)
+        #EXPECT(ref(pad-set[0]) == #R(p[8]))
+
+    val GND2-pads? = get-pads-from-port(S.M.GND)
+    match(GND2-pads?):
+      (_:None): #EXPECT("No Pads Found - Expected 2" == "")
+      (given:One<Tuple<JITXObject>>):
+        val pad-set = value(given)
+        #EXPECT(length(pad-set) == 2)
+        #EXPECT(ref(pad-set[0]) == #R(p[3]))
+        #EXPECT(ref(pad-set[1]) == #R(p[4]))
+
+    val D02-pads? = get-pads-from-port(S.M.D[0])
+    match(D02-pads?):
+      (_:None): #EXPECT("No Pads Found - Expected 1" == "")
+      (given:One<Tuple<JITXObject>>):
+        val pad-set = value(given)
+        #EXPECT(length(pad-set) == 1)
+        #EXPECT(ref(pad-set[0]) == #R(p[5]))
+
+    val AN2-pads? = get-pads-from-port(S.M.A.N)
+    match(AN2-pads?):
+      (_:None): #EXPECT("No Pads Found - Expected 1" == "")
+      (given:One<Tuple<JITXObject>>):
+        val pad-set = value(given)
+        #EXPECT(length(pad-set) == 1)
+        #EXPECT(ref(pad-set[0]) == #R(p[8]))
+
+
+  set-main-module(uut)
+
+deftest(design_introspection) test-get-parent-from-port:
+
+  pcb-module wrapper :
+    public inst M : test-comp
+
+  pcb-module uut:
+    port asdf
+    inst D : test-comp
+    inst W : wrapper
+
+    val obj = get-parent-from-port(self.asdf)
+    #EXPECT(value!(obj) == self)
+
+    val obj2 = get-parent-from-port(D.GND)
+    #EXPECT(value!(obj2) == D)
+
+    val obj3 = get-parent-from-port(W.M.VDD)
+    #EXPECT(value!(obj3) == W.M)
+
+  set-main-module(uut)
+
+deftest(design_introspection) test-is-mod-or-comp:
+
+  pcb-module wrapper :
+    public inst M : test-comp
+
+  pcb-module uut:
+    port asdf
+    inst D : test-comp
+    inst W : wrapper
+
+    #EXPECT(is-module?(W) == true)
+    #EXPECT(is-module?(D) == false)
+
+    #EXPECT(is-component?(W) == false)
+    #EXPECT(is-component?(D) == true)
+
+    #EXPECT(is-component?(W.M) == true)
+    #EXPECT(is-module?(W.M) == false)
+
+    val obj = get-parent-from-port(self.asdf)
+    #EXPECT(value!(obj) == self)
+
+    val obj2 = get-parent-from-port(D.GND)
+    #EXPECT(value!(obj2) == D)
+
+    val obj3 = get-parent-from-port(W.M.VDD)
+    #EXPECT(value!(obj3) == W.M)
 
   set-main-module(uut)


### PR DESCRIPTION
This adds features for accessing components and pads from ports. I've refined the existing `get-pads-from-port` so that we don't need to pass an argument anymore.

I've achieved this by creating a `get-component-from-port` which can get the component instance associated with a port. We can then create the pad mapping from that component.

I've added some unit tests for the functionality to confirm that works as expected.