### PR TITLE
Update to resolve failing unit tests in develop

### DIFF
--- a/tests/utils.stanza
+++ b/tests/utils.stanza
@@ -39,7 +39,7 @@ defpackage jsl/tests/utils:
     min-soldermask-bridge = 0.102
     min-hole-to-hole = 0.254
     min-pth-pin-solder-clearance = 3.0
-  set-default-rules(default-rules)
+  set-rules(default-rules)
 
   val DEF-EPS = 1.0e-6
 


### PR DESCRIPTION
The latest develop makes a change to `set-default-rules` that seems to break the tests. By changing it to `set-rules` - I can resolve these problems and the tests pass.