### PR TITLE
Add SOT Flat Lead type and fix bugs.

### DIFF
--- a/examples/landpatterns/SOT.stanza
+++ b/examples/landpatterns/SOT.stanza
@@ -6,6 +6,7 @@ defpackage jsl/examples/landpatterns/SOT:
 
   import jsl/landpatterns
   import jsl/symbols
+  import jsl/design/settings
 
   import jsl/examples/landpatterns/board
 
@@ -111,12 +112,52 @@ pcb-component test-SOT23-3:
   val lp = create-landpattern(pkg)
   assign-landpattern(lp)
 
+pcb-component test-SOT538:
+  ; TPS6293x - DRL0008A
+  pin-properties :
+    [pin:Ref | pads:Ref ... | side:Dir ]
+
+    [RT | p[1] | Left ]
+    [EN | p[2] | Left ]
+    [VIN | p[3] | Left ]
+    [GND | p[4] | Left ]
+    [SW | p[5] | Left ]
+    [BST | p[6] | Right ]
+    [SS | p[7] | Left ]
+    [FB | p[8] | Left ]
+
+  val b = create-symbol $ BoxSymbol(self)
+  assign-symbol(b)
+
+  val pkg = SOT(
+    num-leads = 8,
+    lead-profile = Lead-Profile(
+      span = min-max(1.5, 1.7),
+      pitch = 0.5,
+      lead = SOTFL-Lead(
+        length = min-max(0.2, 0.4),
+        width = min-max(0.17, 0.27)
+      )
+    ),
+    package-body = PackageBody(
+      width = min-max(1.1, 1.3)
+      length = min-max(2.0, 2.2)
+      height = min-max(0.5, 0.6)
+    ),
+    density-level = DensityLevelB
+  )
+  val lp = create-landpattern(pkg)
+  assign-landpattern(lp)
+
+
+
 pcb-module test-design:
   inst c : test-AP2265x
   place(c) at loc(0.0, 0.0) on Top
 
   inst d : test-REF34-Q1
   inst e : test-SOT23-3
+  inst f : test-SOT538
 
 val board-shape = RoundedRectangle(50.0, 50.0, 0.25)
 

--- a/src/landpatterns/SOT.stanza
+++ b/src/landpatterns/SOT.stanza
@@ -64,9 +64,38 @@ with:
   keyword-constructor => true
 
 
+
+doc: \<DOC>
+Small Outline Transistor Flat Lead (SOTFL) Type
+
+This type defines the parameters of each of the individual leads
+of the IC package. It is typically used with {@link Lead-Profile}
+
+This supports packages like `SOT-23F` or `SOT538` which use a
+flat lead style instead of the Gull-Wing Lead style.
+<DOC>
+public defstruct SOTFL-Lead <: SMT-Lead:
+  lead-type:LeadProtrusion with: (
+      as-method => true,
+      default => SmallOutlineFlatLeads(),
+    )
+  length:Toleranced with: (
+    as-method => true,
+    ensure => ensure-positive!
+    )
+  width:Toleranced with: (
+    as-method => true,
+    ensure => ensure-positive!
+    )
+with:
+  equalable => true
+  hashable => true
+  printer => true
+  keyword-constructor => true
+
+
 val SOT-DEF-PAD-PLANNER = RectanglePadPlanner
 val SOT-DEF-NUM-SCHEME = Column-Major-Numbering{_, DUAL-ROW-COLS}
-
 
 doc: \<DOC>
 SOT Package Type

--- a/src/landpatterns/dual-row.stanza
+++ b/src/landpatterns/dual-row.stanza
@@ -89,7 +89,7 @@ public defmethod build-pads (
 
   val profile = lead-profile(pkg)
   val rows = num-leads(pkg) / DUAL-ROW-COLS
-  val params = compute-params(profile)
+  val params = compute-params(profile, density-level = density-level(pkg))
 
   val pad-seq = pad-grid-smt(
     pad-size = pad-size(params),

--- a/src/landpatterns/leads/lead-types.stanza
+++ b/src/landpatterns/leads/lead-types.stanza
@@ -76,7 +76,8 @@ public defstruct SMT-Lead <: Lead :
 
   TODO - add figure here.
   <DOC>
-  length:Toleranced with: (as-method => true)
+  length:Toleranced with:
+    as-method => true
   doc: \<DOC>
   Width of the electrical lead of an SMT package.
 
@@ -85,7 +86,9 @@ public defstruct SMT-Lead <: Lead :
 
   TODO - add figure here.
   <DOC>
-  width:Toleranced with: (as-method => true)
+  width:Toleranced with:
+    as-method => true
+
 with:
   equalable => true
   hashable => true

--- a/src/landpatterns/quad.stanza
+++ b/src/landpatterns/quad.stanza
@@ -285,8 +285,8 @@ public defmethod build-pads (
   ;   X-grid - 0 (West) & 2 (East)
   ;   Y-grid - 1 (South) & 3 (North)
 
-  val x-params = compute-params(x-leads(profile))
-  val y-params = compute-params(y-leads(profile))
+  val x-params = compute-params(x-leads(profile), density-level = density-level(pkg))
+  val y-params = compute-params(y-leads(profile), density-level = density-level(pkg))
 
   defn gen-pad-info () -> Seq<VirtualPad> :
 

--- a/tests/landpatterns/QFN.stanza
+++ b/tests/landpatterns/QFN.stanza
@@ -181,7 +181,7 @@ deftest(QFN) test-QFN-non-square :
 
     val outline = dims $ silk[0]
     val silk-width = clearance(current-rules(), MinSilkscreenWidth)
-    #EXPECT(almost-equal?(outline, Dims(8.1262 + silk-width, 6.1262 + silk-width)))
+    #EXPECT(almost-equal?(outline, Dims(8.5262 + silk-width, 6.5262 + silk-width)))
 
     val pin-1-silk  = layer(lp, Silkscreen("pin-1-marker", Top))
     ; Expect to see the Dot and the Triangle
@@ -189,7 +189,7 @@ deftest(QFN) test-QFN-non-square :
     for sh in pin-1-silk do:
       match(sh):
         (x:Circle):
-          #EXPECT(almost-equal?(center(x), Point(-4.3274, 1.0 )))
+          #EXPECT(almost-equal?(center(x), Point(-4.5274, 1.0 )))
         (x:Polygon):
           val pts = points(x)
           val b = Box(Point(-4.358, 1.6), Point(-2.780, 3.373))


### PR DESCRIPTION
Fixed a bug in the quad and dual package that was causing the leads not to be generated with respect to the passed density level. 

<img width="400" alt="Screenshot 2024-08-17 at 10 42 43 AM" src="https://github.com/user-attachments/assets/37e37869-64bb-4f4f-ac10-d6462e9f0fcc">
