### PR TITLE
replace pad with pad-def

### DIFF
--- a/src/landpatterns/introspection.stanza
+++ b/src/landpatterns/introspection.stanza
@@ -67,13 +67,13 @@ public pcb-struct jsl/landpatterns/introspection/PadInfo :
 doc: \<DOC>
 Helper functions to consolidate all of the introspection data related to a pad.
 
-@param pd `LandPatternPad` object that we will inspect for data. Typically
+@param lp-pd `LandPatternPad` object that we will inspect for data. Typically
 this accessed using the `pads()` API function or using the {@link get-pads-from-port}
 function.
 @return PadInfo object that captures all of the info related to this pad.
 <DOC>
 public defn get-pad-info (lp-pd:JITXObject) -> PadInfo :
-  val pd = pad(lp-pd)
+  val pd = pad-def(lp-pd)
   PadInfo(
     pad-type(pd)
     pad-shape(pd)

--- a/src/landpatterns/leads.stanza
+++ b/src/landpatterns/leads.stanza
@@ -31,7 +31,7 @@ public defn bounds (
   ) -> Box :
 
   val unionBox = reduce{union, _} $ for lp-pad in lp-pads seq:
-    val pd = pad(lp-pad)
+    val pd = pad-def(lp-pad)
     val l = pose(lp-pad)
     match(layer-spec):
       (_:False):

--- a/tests/design/introspection.stanza
+++ b/tests/design/introspection.stanza
@@ -138,8 +138,8 @@ deftest(design_introspection) test-get-pads-from-port:
         #EXPECT(ref(pad-set[1]) == #R(p[2]))
 
         #EXPECT(side(pad-set[0]) == Top)
-        #EXPECT(pad-type(pad(pad-set[0])) == SMD)
-        #EXPECT(pad-shape(pad(pad-set[0])) is Rectangle)
+        #EXPECT(pad-type(pad-def(pad-set[0])) == SMD)
+        #EXPECT(pad-shape(pad-def(pad-set[0])) is Rectangle)
 
     val GND-pads? = get-pads-from-port(p2p-map, C.GND)
     match(GND-pads?):

--- a/tests/landpatterns/BGA/package.stanza
+++ b/tests/landpatterns/BGA/package.stanza
@@ -83,7 +83,7 @@ deftest(BGA) test-full-simple :
     for lp-pad in lp-pads do:
       ; Here I'm checking that the created pads are
       ;  the right shape and size.
-      val pd = pad(lp-pad)
+      val pd = pad-def(lp-pad)
 
       ; Copper
       val shape = pad-shape(pd) as Circle
@@ -278,7 +278,7 @@ deftest(BGA) test-perimeter-simple :
 
       ; Here I'm checking that the created pads are
       ;  the right shape and size.
-      val pd = pad(lp-pad)
+      val pd = pad-def(lp-pad)
 
       ; Copper
       val shape = pad-shape(pd) as Circle
@@ -370,7 +370,7 @@ deftest(BGA) test-simple-with-pose:
     for lp-pad in lp-pads do:
       ; Here I'm checking that the created pads are
       ;  the right shape and size.
-      val pd = pad(lp-pad)
+      val pd = pad-def(lp-pad)
 
       ; Copper
       val shape = pad-shape(pd) as Circle

--- a/tests/landpatterns/BGA/pads.stanza
+++ b/tests/landpatterns/BGA/pads.stanza
@@ -34,7 +34,7 @@ deftest(BGA) test-bga-pad:
   val row = padrows[0]
   val lp-pad = row[0]
 
-  val p = pad(lp-pad)
+  val p = /pad-def(lp-pad)
   val shape = pad-shape(p) as Circle
   #EXPECT(almost-equal?(radius(shape), 0.525))
   val pad-pose = pose(lp-pad)
@@ -87,7 +87,7 @@ deftest(BGA) test-bga-pad-no-paste:
   val row = padrows[0]
   val lp-pad = row[0]
 
-  val p = pad(lp-pad)
+  val p = /pad-def(lp-pad)
   val shape = pad-shape(p) as Circle
   #EXPECT(almost-equal?(radius(shape), 0.525))
   val pad-pose = pose(lp-pad)
@@ -129,7 +129,7 @@ deftest(BGA) test-bga-pad-explicit-paste:
   val row = padrows[0]
   val lp-pad = row[0]
 
-  val p = pad(lp-pad)
+  val p = /pad-def(lp-pad)
   val shape = pad-shape(p) as Circle
   #EXPECT(almost-equal?(radius(shape), 0.525))
   val pad-pose = pose(lp-pad)
@@ -179,7 +179,7 @@ deftest(BGA) test-bga-nsmd-pad:
   val row = padrows[0]
   val lp-pad = row[0]
 
-  val p = pad(lp-pad)
+  val p = /pad-def(lp-pad)
   val shape = pad-shape(p) as Circle
   #EXPECT(almost-equal?(radius(shape), 0.475))
   val pad-pose = pose(lp-pad)

--- a/tests/landpatterns/BGA/pads.stanza
+++ b/tests/landpatterns/BGA/pads.stanza
@@ -19,10 +19,10 @@ deftest(BGA) test-bga-pad:
     mask-R-adj = (-1 %)
     )
 
-  val pad-def = build-bga-pad(Circle(0.5), cfg)
+  val bga-pad = build-bga-pad(Circle(0.5), cfg)
 
   pcb-landpattern padtest:
-    pad p[1] : pad-def at loc(0.0, 0.0)
+    pad p[1] : bga-pad at loc(0.0, 0.0)
 
 
   val grid = PadGrid(padtest)
@@ -34,7 +34,7 @@ deftest(BGA) test-bga-pad:
   val row = padrows[0]
   val lp-pad = row[0]
 
-  val p = /pad-def(lp-pad)
+  val p = pad-def(lp-pad)
   val shape = pad-shape(p) as Circle
   #EXPECT(almost-equal?(radius(shape), 0.525))
   val pad-pose = pose(lp-pad)
@@ -72,10 +72,10 @@ deftest(BGA) test-bga-pad-no-paste:
     paste-R-adj = NoPasteMask
     )
 
-  val pad-def = build-bga-pad(Circle(0.5), cfg)
+  val bga-pad = build-bga-pad(Circle(0.5), cfg)
 
   pcb-landpattern padtest:
-    pad p[1] : pad-def at loc(0.0, 0.0)
+    pad p[1] : bga-pad at loc(0.0, 0.0)
 
 
   val grid = PadGrid(padtest)
@@ -87,7 +87,7 @@ deftest(BGA) test-bga-pad-no-paste:
   val row = padrows[0]
   val lp-pad = row[0]
 
-  val p = /pad-def(lp-pad)
+  val p = pad-def(lp-pad)
   val shape = pad-shape(p) as Circle
   #EXPECT(almost-equal?(radius(shape), 0.525))
   val pad-pose = pose(lp-pad)
@@ -114,10 +114,10 @@ deftest(BGA) test-bga-pad-explicit-paste:
     paste-R-adj = (-3 %)
     )
 
-  val pad-def = build-bga-pad(Circle(0.5), cfg)
+  val bga-pad = build-bga-pad(Circle(0.5), cfg)
 
   pcb-landpattern padtest:
-    pad p[1] : pad-def at loc(0.0, 0.0)
+    pad p[1] : bga-pad at loc(0.0, 0.0)
 
 
   val grid = PadGrid(padtest)
@@ -129,7 +129,7 @@ deftest(BGA) test-bga-pad-explicit-paste:
   val row = padrows[0]
   val lp-pad = row[0]
 
-  val p = /pad-def(lp-pad)
+  val p = pad-def(lp-pad)
   val shape = pad-shape(p) as Circle
   #EXPECT(almost-equal?(radius(shape), 0.525))
   val pad-pose = pose(lp-pad)
@@ -164,10 +164,10 @@ deftest(BGA) test-bga-nsmd-pad:
     mask-R-adj = (5 %)
     )
 
-  val pad-def = build-bga-pad(Circle(0.5), cfg)
+  val bga-pad = build-bga-pad(Circle(0.5), cfg)
 
   pcb-landpattern padtest:
-    pad p[1] : pad-def at loc(0.0, 0.0)
+    pad p[1] : bga-pad at loc(0.0, 0.0)
 
 
   val grid = PadGrid(padtest)
@@ -179,7 +179,7 @@ deftest(BGA) test-bga-nsmd-pad:
   val row = padrows[0]
   val lp-pad = row[0]
 
-  val p = /pad-def(lp-pad)
+  val p = pad-def(lp-pad)
   val shape = pad-shape(p) as Circle
   #EXPECT(almost-equal?(radius(shape), 0.475))
   val pad-pose = pose(lp-pad)

--- a/tests/landpatterns/QFN.stanza
+++ b/tests/landpatterns/QFN.stanza
@@ -70,14 +70,14 @@ deftest(QFN) test-QFN-basic :
   val col-pads-west = get-column(grid, 0)
   #EXPECT(length(col-pads-west) == 8)
   for lp-pad in col-pads-west do:
-    val pd = pad(lp-pad)
+    val pd = pad-def(lp-pad)
     val shape = pad-shape(pd)
     #EXPECT(shape is Rectangle)
 
   val col-pads-east = get-column(grid, expRowsCols - 1)
   #EXPECT(length(col-pads-east) == 8)
   for lp-pad in col-pads-east do:
-    val pd = pad(lp-pad)
+    val pd = pad-def(lp-pad)
     val shape = pad-shape(pd)
     #EXPECT(shape is Rectangle)
 
@@ -153,14 +153,14 @@ deftest(QFN) test-QFN-non-square :
   val col-pads-west = get-column(grid, 0)
   #EXPECT(length(col-pads-west) == 6)
   for lp-pad in col-pads-west do:
-    val pd = pad(lp-pad)
+    val pd = pad-def(lp-pad)
     val shape = pad-shape(pd)
     #EXPECT(shape is Rectangle)
 
   val col-pads-east = get-column(grid, expColLen - 1)
   #EXPECT(length(col-pads-east) == 6)
   for lp-pad in col-pads-east do:
-    val pd = pad(lp-pad)
+    val pd = pad-def(lp-pad)
     val shape = pad-shape(pd)
     #EXPECT(shape is Rectangle)
 

--- a/tests/landpatterns/SOIC.stanza
+++ b/tests/landpatterns/SOIC.stanza
@@ -82,7 +82,7 @@ deftest(SOIC) test-SOIC-N:
     for row in values(rows(grid)) do:
       #EXPECT(length(row) == 2)
       for lp-pad in row do:
-        val pd = pad(lp-pad)
+        val pd = pad-def(lp-pad)
         val shape = pad-shape(pd)
         #EXPECT(shape is Rectangle)
 
@@ -120,7 +120,7 @@ deftest(SOIC) test-SOIC-W:
     for row in values(rows(grid)) do:
       #EXPECT(length(row) == 2)
       for lp-pad in row do:
-        val pd = pad(lp-pad)
+        val pd = pad-def(lp-pad)
         val shape = pad-shape(pd)
         #EXPECT(shape is Rectangle)
 
@@ -159,7 +159,7 @@ deftest(SOIC) test-fine-pitch:
     for row in values(rows(grid)) do:
       #EXPECT(length(row) == 2)
       for lp-pad in row do:
-        val pd = pad(lp-pad)
+        val pd = pad-def(lp-pad)
         val shape = pad-shape(pd)
         #EXPECT(shape is Rectangle)
 
@@ -216,7 +216,7 @@ deftest(SOIC) test-thermal-lead:
     val thermPad? = find-pad-by-ref(W-lp, 9)
     #EXPECT(thermPad? is-not False)
     val thermPad = thermPad? as LandPatternPad
-    #EXPECT(pad-shape(pad(thermPad)) is RoundedRectangle)
+    #EXPECT(pad-shape(pad-def(thermPad)) is RoundedRectangle)
 
 deftest(SOIC) test-pad-numbering:
   val num-pins = 8
@@ -401,7 +401,7 @@ deftest(SOIC) test-thermal-lead-with-pose:
     val thermPad? = find-pad-by-ref(W-lp, 9)
     #EXPECT(thermPad? is-not False)
     val thermPad = thermPad? as LandPatternPad
-    #EXPECT(pad-shape(pad(thermPad)) is RoundedRectangle)
+    #EXPECT(pad-shape(pad-def(thermPad)) is RoundedRectangle)
 
     val pos = center $ pose(thermPad)
     #EXPECT(almost-equal?(pos, Point(1.0, 0.0)))

--- a/tests/landpatterns/SON.stanza
+++ b/tests/landpatterns/SON.stanza
@@ -91,7 +91,7 @@ deftest(SON) test-SON:
     for row in values(rows(grid)) do:
       #EXPECT(length(row) == 2)
       for lp-pad in row do:
-        val pd = pad(lp-pad)
+        val pd = pad-def(lp-pad)
         val shape = pad-shape(pd)
         #EXPECT(shape is Rectangle)
 

--- a/tests/landpatterns/courtyard.stanza
+++ b/tests/landpatterns/courtyard.stanza
@@ -95,7 +95,6 @@ deftest(courtyard) test-courtyard-build-boundary:
   )
 
   val outline = build-courtyard-boundary(root, body, DensityLevelA, excess = 0.1)
-
   #EXPECT(width(outline) == 3.2)
   val exp-height = 1.2
   #EXPECT(height(outline) == 1.2)

--- a/tests/landpatterns/two-pin/SMT.stanza
+++ b/tests/landpatterns/two-pin/SMT.stanza
@@ -42,7 +42,7 @@ deftest(two-pin) test-basic:
   for row in values(rows(grid)) do:
     #EXPECT(length(row) == 1)
     for lp-pad in row do:
-      val pd = pad(lp-pad)
+      val pd = pad-def(lp-pad)
       val shape = pad-shape(pd) as Rectangle
       ; X Direction
       #EXPECT(almost-equal?(width(shape), 1.05))
@@ -68,7 +68,7 @@ deftest(two-pin) test-basic:
   for row in values(rows(grid)) do:
     #EXPECT(length(row) == 1)
     for lp-pad in row do:
-      val pd = pad(lp-pad)
+      val pd = pad-def(lp-pad)
       val shape = pad-shape(pd) as Rectangle
       ; X Direction
       #EXPECT(almost-equal?(width(shape), 0.95))
@@ -94,7 +94,7 @@ deftest(two-pin) test-basic:
   for row in values(rows(grid)) do:
     #EXPECT(length(row) == 1)
     for lp-pad in row do:
-      val pd = pad(lp-pad)
+      val pd = pad-def(lp-pad)
       val shape = pad-shape(pd) as Rectangle
       ; X Direction
       #EXPECT(almost-equal?(width(shape), 0.85))
@@ -123,7 +123,7 @@ deftest(two-pin) test-chip-table :
   for row in values(rows(grid)) do:
     #EXPECT(length(row) == 1)
     for lp-pad in row do:
-      val pd = pad(lp-pad)
+      val pd = pad-def(lp-pad)
       val shape = pad-shape(pd) as Rectangle
       #EXPECT(almost-equal?(width(shape), exp-W))
       #EXPECT(almost-equal?(height(shape), exp-L))
@@ -139,7 +139,7 @@ deftest(two-pin) test-chip-table :
   for row in values(rows(grid)) do:
     #EXPECT(length(row) == 1)
     for lp-pad in row do:
-      val pd = pad(lp-pad)
+      val pd = pad-def(lp-pad)
       val shape = pad-shape(pd) as Rectangle
       #EXPECT(almost-equal?(width(shape), exp-W))
       #EXPECT(almost-equal?(height(shape), exp-L))
@@ -161,7 +161,7 @@ deftest(two-pin) test-resistor-smt :
   for row in values(rows(grid)) do:
     #EXPECT(length(row) == 1)
     for lp-pad in row do:
-      val pd = pad(lp-pad)
+      val pd = pad-def(lp-pad)
       val shape = pad-shape(pd) as Rectangle
       #EXPECT(almost-equal?(width(shape), 0.5))
       #EXPECT(almost-equal?(height(shape), 0.380278))
@@ -182,7 +182,7 @@ deftest(two-pin) test-capacitor-smt :
   for row in values(rows(grid)) do:
     #EXPECT(length(row) == 1)
     for lp-pad in row do:
-      val pd = pad(lp-pad)
+      val pd = pad-def(lp-pad)
       val shape = pad-shape(pd) as Rectangle
       #EXPECT(almost-equal?(width(shape), 1.88))
       #EXPECT(almost-equal?(height(shape), 0.920156))
@@ -217,7 +217,7 @@ deftest(two-pin) test-capacitor-smt-with-pose:
   for row in values(rows(grid)) do:
     #EXPECT(length(row) == 1)
     for lp-pad in row do:
-      val pd = pad(lp-pad)
+      val pd = pad-def(lp-pad)
       val shape = pad-shape(pd) as Rectangle
       #EXPECT(almost-equal?(width(shape), 1.88))
       #EXPECT(almost-equal?(height(shape), 0.920156))

--- a/tests/landpatterns/two-pin/axial.stanza
+++ b/tests/landpatterns/two-pin/axial.stanza
@@ -58,7 +58,7 @@ deftest(two-pin) test-basic-axial:
   val padcols = to-tuple $ values(columns(grid))
   for col in padcols do:
     for (lp-pad in col, i in 0 to false) do:
-      val p = pad(lp-pad)
+      val p = pad-def(lp-pad)
       val pt = pad-type(p)
       #EXPECT(pt == TH)
       val shape = pad-shape(p) as Circle

--- a/tests/landpatterns/two-pin/radial.stanza
+++ b/tests/landpatterns/two-pin/radial.stanza
@@ -58,7 +58,7 @@ deftest(two-pin) test-basic-radial:
   val padcols = to-tuple $ values(columns(grid))
   for col in padcols do:
     for (lp-pad in col, i in 0 to false) do:
-      val p = pad(lp-pad)
+      val p = pad-def(lp-pad)
       val pt = pad-type(p)
       #EXPECT(pt == TH)
       val shape = pad-shape(p) as Circle


### PR DESCRIPTION
Replace pad with pad-def as part of deprecation process (jitx-client PR 4759)
