### PR TITLE
Add Circuit Network Generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ JSL_TESTS :=                              \
     jsl/tests/si/signal-ends              \
     jsl/tests/design/introspection        \
     jsl/tests/design/E-Series             \
+    jsl/tests/circuits/Network            \
     jsl/tests/math
 
 TABGEN=./tabgen/tabgen

--- a/examples/landpatterns/Molded-2pin.stanza
+++ b/examples/landpatterns/Molded-2pin.stanza
@@ -43,7 +43,7 @@ pcb-component this-is-a-cap :
     [ c      | c           | Right ]
 
 
-  val symb = PolarizedCapacitorSymbol(use-AC? = true)
+  val symb = PolarizedCapacitorSymbol()
   assign-symbol $ create-symbol(symb)
 
   val pkg = Molded-2pin(

--- a/examples/symbols/capacitor.stanza
+++ b/examples/symbols/capacitor.stanza
@@ -37,8 +37,8 @@ pcb-component test-pol-cap:
 
   pin-properties :
     [pin:Ref | pads:Ref ... | side:Dir | bank:Int]
-    [p[1] | p[1] | Up |  0]
-    [p[2] | p[2] | Down | 0]
+    [a | p[1] | Up |  0]
+    [c | p[2] | Down | 0]
 
   val symb = PolarizedCapacitorSymbol()
   assign-symbol(create-symbol(symb))
@@ -60,7 +60,7 @@ pcb-component test-pol-cap-2:
     [p[2] | p[2] | Down | 0]
 
   val params = PolarizedCapacitorSymbolParams(style = Polarized-Curved-Style)
-  val symb = PolarizedCapacitorSymbol(params = params)
+  val symb = PolarizedCapacitorSymbol(params = params, polarized? = false)
   assign-symbol(create-symbol(symb))
 
   val chip-def = chips["1206"]

--- a/examples/symbols/diode.stanza
+++ b/examples/symbols/diode.stanza
@@ -17,8 +17,8 @@ pcb-component test-Diode:
   mpn = "1N1234"
   pin-properties :
     [pin:Ref | pads:Ref ... ]
-    [ p[1] | p[1] ]
-    [ p[2] | p[2] ]
+    [ a | p[1] ]
+    [ c | p[2] ]
 
   val symb-defn = DiodeSymbol()
   val symb = create-symbol(symb-defn)
@@ -40,8 +40,8 @@ pcb-component test-Schottky:
   mpn = "1N1235"
   pin-properties :
     [pin:Ref | pads:Ref ... ]
-    [ p[1] | p[1] ]
-    [ p[2] | p[2] ]
+    [ a | p[1] ]
+    [ c | p[2] ]
 
   val symb-defn = SchottkyDiodeSymbol()
   val symb = create-symbol(symb-defn)
@@ -62,8 +62,8 @@ pcb-component test-Zener:
   mpn = "1N1236"
   pin-properties :
     [pin:Ref | pads:Ref ... ]
-    [ p[1] | p[1] ]
-    [ p[2] | p[2] ]
+    [ a | p[1] ]
+    [ c | p[2] ]
 
   val symb-defn = ZenerDiodeSymbol()
   val symb = create-symbol(symb-defn)
@@ -84,8 +84,8 @@ pcb-component test-Tunnel:
   mpn = "1N1237"
   pin-properties :
     [pin:Ref | pads:Ref ... ]
-    [ p[1] | p[1] ]
-    [ p[2] | p[2] ]
+    [ a | p[1] ]
+    [ c | p[2] ]
 
   val symb-defn = TunnelDiodeSymbol()
   val symb = create-symbol(symb-defn)
@@ -106,8 +106,8 @@ pcb-component test-LED:
   mpn = "1N1238"
   pin-properties :
     [pin:Ref | pads:Ref ... ]
-    [ p[1] | p[1] ]
-    [ p[2] | p[2] ]
+    [ a | p[1] ]
+    [ c | p[2] ]
 
   val symb-defn = LEDSymbol()
   val symb = create-symbol(symb-defn)
@@ -128,8 +128,8 @@ pcb-component test-Photodiode:
   mpn = "1N1239"
   pin-properties :
     [pin:Ref | pads:Ref ... ]
-    [ p[1] | p[1] ]
-    [ p[2] | p[2] ]
+    [ a | p[1] ]
+    [ c | p[2] ]
 
   val symb-defn = PhotoDiodeSymbol()
   val symb = create-symbol(symb-defn)

--- a/src/circuits/Network.stanza
+++ b/src/circuits/Network.stanza
@@ -64,7 +64,9 @@ instantiated in the resultant network definition.
 <DOC>
 public defstruct CircuitElement <: ANT:
   doc: \<DOC>
-  Elements of this node - This Empty by default for `CircuitElement`
+  Sub-Elements of the `CircuitElement`
+  A CircuitElement is the Element so this collection is empty by default.
+  We construct the element from the `elem-type` object.
   <DOC>
   elements:IndexedCollection<ANT> with:
     as-method => true

--- a/src/circuits/Network.stanza
+++ b/src/circuits/Network.stanza
@@ -1,0 +1,493 @@
+#use-added-syntax(jitx)
+doc: \<DOC>
+@brief Lump Circuit Networks
+
+The concept of this code is to provide a means for defining a lumped
+circuit network tree. The idea is to provide a "DSL" for defining
+components that are used together to form a circuit network.
+
+In this graph there are Elements and Nodes.
+
+* Elements are the edges of the graph - the resistors, capacitors, etc.
+* Nodes are the pins, ground, nets, etc of the circuit
+
+We can think of the circuit network as a graph. We have the following
+ operations to this graph for 2-pin elements
+
+ 1.  Series (+) - string multiple elements in series
+ 2.  Parallel (|) - put multiple elements in parallel
+ 3.  Tap - For a particular node in the circuit graph, connect this node to
+     an external port on the resultant network instantiable (pcb-module). The
+     components are still connected on both sides in the network.
+ 4.  ShuntTo - Connect a given node to a port through an element.
+     This allows connecting a component that escapes the network. For example,
+     this might be used connect a particular component or sub-network to ground.
+ 5.  Invert (~) - Instead of connecting 1 -> 2 , connect 2 -> 1. reverses the
+       orientation of the component. Useful for polarizing caps, diodes, etc.
+
+
+<DOC>
+defpackage jsl/circuits/Network :
+  import core
+  import collections
+  import jitx
+  import jitx/commands
+
+  import jsl/design/introspection
+  import jsl/errors
+  import jsl/ensure
+
+doc: \<DOC>
+Abstract Network Type
+
+The circuit tree is composed of `ANT` instances that form
+a sequence of operations for the tree.
+<DOC>
+public deftype ANT
+doc: \<DOC>
+Each `ANT` instance contains a recursive set of ANT elements
+
+The elements of each ANT instance are interpreted by that node.
+Some may be empty, others may have a single instance, and others
+may have 1 or more instances.
+<DOC>
+public defmulti elements (a:ANT) -> IndexedCollection<ANT>
+
+
+val DEF_ELEM_NAME = `elem
+val DEF_ELEM_PUBLIC = false
+doc: \<DOC>
+Circuit Element for a Circuit Network
+
+This type typically includes an instantiable that will be
+instantiated in the resultant network definition.
+<DOC>
+public defstruct CircuitElement <: ANT:
+  doc: \<DOC>
+  Elements of this node - This Empty by default for `CircuitElement`
+  <DOC>
+  elements:IndexedCollection<ANT> with:
+    as-method => true
+    default => to-vector<ANT>([])
+  doc: \<DOC>
+  Element Instantiable to be created in the network
+  This instantiable type needs to define either of the following ports:
+  1.  `p[1]/p[2]` like a standard unpolarized 2-pin
+  2.  `c/a` like a standard polarized 2-pin
+
+  When the component/module has more than just these ports - it is often
+  convenient to mark it as `public` so that it can be accessed inside the
+  module.
+  <DOC>
+  elem-type:Instantiable
+  doc: \<DOC>
+  Alternative Instance Name for this Element
+  By default the elements are named `elem` but this can be c
+  confusing when constructing a complex network. This allows for the names to
+  be more explicitly defined by the user.
+  <DOC>
+  name:Symbol with:
+    default => DEF_ELEM_NAME
+  doc: \<DOC>
+  Mark's this component instance as public
+
+  This means that after the network is constructed - it will be accessible
+  by the user using dot-notation.
+  <DOC>
+  is-public?:True|False with:
+    default => DEF_ELEM_PUBLIC
+with:
+  printer => true
+  keyword-constructor => true
+
+doc: \<DOC>
+Short Helper Method for Creating `CircuitElement`
+<DOC>
+public defn Elem (
+  i:Instantiable
+  --
+  name:Symbol = DEF_ELEM_NAME,
+  is-public?:True|False = DEF_ELEM_PUBLIC
+  ) -> CircuitElement :
+  CircuitElement(elem-type = i, name = name, is-public? = is-public?)
+
+
+val DEF_TAP_PORT_ID = 1
+
+doc: \<DOC>
+Tap on a port of an Circuit Element in the Network
+
+This is a method of accessing an internal node
+of the circuit element by creating a named port.
+
+Example:
+
+Given the following circuit
+
+```
+val circ = create-circuit(a + Tap(b, `divOut`))
+```
+
+It will create a module like this:
+
+```
+p[1] -> O -- a -- O -- b -- O -> p[2]
+                  |
+                  ---> divOut
+```
+
+A and B are connected in series as normal and their
+intermediate node is extracted to a port.
+
+<DOC>
+public defstruct Tap <: ANT:
+  doc: \<DOC>
+  Elements of this node - by default has one element.
+  <DOC>
+  elements:IndexedCollection<ANT> with:
+    as-method => true
+  doc: \<DOC>
+  Symbol Name for the tap port on Network Instantiable
+
+  This name is used to construct a `port` on the resulting
+  instantiable of the network.
+  It must be a valid stanza symbol - otherwise, it will not be
+  able to construct the instantiable.
+  <DOC>
+  name:Symbol
+  doc: \<DOC>
+  Port Id for a port on the element of the tap.
+  Typically this will be `1` or `2` for two-pin components,
+  The default value is 1
+  <DOC>
+  ; TODO - Make this `Ref` so we can do any port connection here.
+  port-id:Int with:
+    ensure =>  ensure-in-set!([1, 2])
+    default => DEF_TAP_PORT_ID
+with:
+  printer => true
+  constructor => #Tap
+
+public defn Tap (a:ANT, name:Symbol -- port-id:Int = DEF_TAP_PORT_ID) -> Tap:
+  #Tap(to-vector<ANT>([a]), name, port-id)
+
+public defn Tap (a:Instantiable, name:Symbol -- port-id:Int = DEF_TAP_PORT_ID) -> Tap:
+  Tap(Elem(a), name, port-id = port-id)
+
+doc: \<DOC>
+Series Node in the Circuit Network
+
+The series node encodes a sequence of components connected in
+series. This typically means `N1.p[2] -> N2.p[1]` then `N2.p[2] -> N3.p[1]`, etc
+
+<DOC>
+public defstruct Series <: ANT :
+  elements:Vector<ANT> with:
+    as-method => true
+with:
+  printer => true
+  constructor => #Series
+
+public defn Series (elems:Seqable<ANT> = []) -> Series:
+  #Series(to-vector<ANT>(elems))
+
+doc: \<DOC>
+Parallel Node in the Circuit Network
+
+The parallel node encodes a set of components that are all connected
+in parallel.
+<DOC>
+public defstruct Parallel <: ANT:
+  elements:Vector<ANT> with:
+    as-method => true
+with:
+  printer => true
+  constructor => #Parallel
+
+public defn Parallel (elems:Seqable<ANT> = []) -> Parallel:
+  #Parallel(to-vector<ANT>(elems))
+
+doc: \<DOC>
+Shunt to a Port on the Network
+
+This type is similar to `Tap` except instead of having
+the a continuous component connection in the network, the
+shunted component only has one pin connected in the network.
+The other pin is connected out to an external port on the
+network circuit.
+
+This type will not work with `Series` - it is only
+possible to use this in combination with the Parallel `|` operator.
+
+
+Example:
+This circuit:
+```
+A + (B | ShuntTo(C, "named-shunt-port"))
+```
+
+Results in:
+
+```
+p[1] -> O--A--O--B--O -> p[2]
+              |
+              --C--O -> named-shunt-port
+```
+
+Note that `p[2]` of C is connected to `named-shunt-port`. To
+flip the component see {@link Invert}
+
+<DOC>
+public defstruct ShuntTo <: ANT:
+  elements:IndexedCollection<ANT> with:
+    as-method => true
+  doc: \<DOC>
+  Name for the shunt port on Network Instantiable
+
+  This name is used to construct a `port` on the resulting
+  instantiable of the network.
+  It must be a valid stanza symbol - otherwise, it will not be
+  able to construct the instantiable.
+  <DOC>
+  name:Symbol
+with:
+  printer => true
+  constructor => #ShuntTo
+
+public defn ShuntTo (a:ANT, name:Symbol) -> ShuntTo :
+  #ShuntTo(to-vector<ANT>([a]), name)
+
+public defn ShuntTo (a:Instantiable, name:Symbol) -> ShuntTo :
+  ShuntTo(Elem(a), name)
+
+public defn is-shunted? (x:JITXObject) -> True|False :
+  inside pcb-module:
+    match( property?(x.is-shunted) ):
+      (_:None): false
+      (s:One<True|False>): value(s)
+
+public defn set-shunted (x:JITXObject) -> False :
+  inside pcb-module:
+    property(x.is-shunted) = true
+
+doc: \<DOC>
+Invert Node for the Circuit Network
+
+Invert causes an Element to be connected `2 -> 1` instead of `1 -> 2`
+<DOC>
+public defstruct Invert <: ANT :
+  elements:IndexedCollection<ANT> with:
+    as-method => true
+with:
+  printer => true
+  constructor => #Invert
+
+public defn Invert (a:ANT) -> Invert:
+  #Invert(to-vector<ANT>([a]))
+
+doc: \<DOC>
+Convert the network representation into instantiate components and nets
+
+This function is potentially recursive.
+
+@param a Network to elaborate
+@param taps Accumulator for the external ports of the network.
+@return Sequence of `[p1, p2]` for each element at the top level of the network.
+For Parallel - this sequence may be 2 or more tuples
+For others - this is typically only 1 tuple
+<DOC>
+public defn elaborate-all (a:ANT, taps:Vector<[Symbol,JITXObject]>) -> Seq<[JITXObject, JITXObject]> :
+  inside pcb-module:
+    for elem in elements(a) seq:
+      elaborate(elem, taps)
+
+doc: \<DOC>
+Construct instances and net connectors for a series circuit
+
+@param a Series Network Element
+@param taps Accumulator for the external ports of the network.
+@return The `[p1, p2]` tuple of the ports of the endpoints of the series network.
+This is typically `p[1]` of element 0 and `p[2]` of element `N-1` where `N` is the
+number of elements in series.
+
+@throws ValueError If any of the series components have been marked `ShuntTo`. The
+`ShuntTo` mechanism is not handled in series connections.
+<DOC>
+public defn connect-series (a:Series, taps:Vector<[Symbol,JITXObject]>) -> [JITXObject, JITXObject] :
+  inside pcb-module:
+    val pinSets = to-tuple(elaborate-all(a, taps))
+    val cnt = length(pinSets)
+
+    for pinSet in pinSets do:
+      val [p1, p2] = pinSet
+      if is-shunted?(p1) or is-shunted?(p2):
+        throw $ ValueError("Shunted Elements Are Not Handled in Series Configurations - Try using Tap")
+
+    ; Series connect all of the components
+    for i in 0 to (cnt - 1) do :
+      net (pinSets[i][1], pinSets[i + 1][0])
+
+    ; Return the first pin and the last pin
+    [pinSets[0][0], pinSets[cnt - 1][1]]
+
+doc: \<DOC>
+Instantiate and Connect all parallel elements
+
+@param a Parallel Network Element
+@param taps Accumulator for the external ports of the network.
+@return Tuple of `[p1, p2]` which is typically the first parallel elements ports. All of
+the other element's `p1` and `p2` are netted to t he first parallel element, respectively.
+`ShuntTo` elements are handled differently - typically p1 of the shunted component is connected
+by the `p2` is not connected.
+<DOC>
+public defn connect-parallel (a:Parallel, taps:Vector<[Symbol,JITXObject]>) -> [JITXObject, JITXObject] :
+  inside pcb-module:
+    val pinSets = to-tuple(elaborate-all(a, taps))
+    val cnt = length(pinSets)
+
+    ; Filter out any shunted pins
+    ;  as they get connected to ports instead of to the
+    ;  next element in the sequence.
+
+    val notShunted = {not is-shunted?(_)}
+    defn filter-pins (pSet:Tuple<[JITXObject, JITXObject]>, pinIdx:Int) :
+      to-tuple(filter(notShunted, map(get{_, pinIdx}, pSet)))
+
+    val p1Set = filter-pins(pinSets, 0)
+    val p2Set = filter-pins(pinSets, 1)
+
+    net (p1Set)
+    net (p2Set)
+
+    [p1Set[0], p2Set[0]]
+
+doc: \<DOC>
+Instantiate and Connect the elements of a Circuit Network
+
+This function is recursive.
+
+@param a Circuit network to elaborate
+@param taps Accumulator for the external ports of the network.
+@param Tuple of `[p1, p2]` that are the ports of the endpoints of
+the network.
+<DOC>
+public defn elaborate (a:ANT, taps:Vector<[Symbol,JITXObject]>) -> [JITXObject, JITXObject] :
+  inside pcb-module :
+    match(a) :
+      (s:Series):
+        ; println("elaborate Series: %~" % [s])
+        connect-series(s, taps)
+      (s:Parallel):
+        ;println("elaborate Parallel: %~" % [s])
+        connect-parallel(s, taps)
+      (s:CircuitElement):
+        ;println("elaborate CircuitElement: %~" % [s])
+        val obj = make-inst(name(s), elem-type(s), is-public?(s))
+        get-element-ports(obj)
+      (s:ShuntTo):
+        ;println("elaborate ShuntTo: %~" % [s])
+        val child = elements(s)[0]
+        val [p1, p2] = elaborate(child, taps)
+        val shuntPin = p2
+        set-shunted(shuntPin)
+        add(taps, [name(s), shuntPin])
+        [p1, shuntPin]
+      (s:Invert):
+        ;println("elaborate Invert: %~" % [s])
+        val child = elements(s)[0]
+        val [p1, p2] = elaborate(child, taps)
+        [p2, p1]
+      (s:Tap):
+        ;println("elaborate Tap: %~" % [s])
+        val child = elements(s)[0]
+        val childPins = elaborate(child, taps)
+        ; Add the tap here.
+        val tapPin = childPins[ port-id(s) - 1 ]
+        add(taps, [name(s), tapPin])
+        childPins
+
+
+doc: \<DOC>
+Construct an instantiable for the passed Network
+
+This function will create a `pcb-module` based on the passed
+network description. This network will have at least port `p` with
+two elements. It may optionally have one or more unique `SinglePin`
+ports that are created dynamically by the `Tap` and `ShuntTo` types.
+
+@param a Network definition that will be converted into a `pcb-module`.
+@member p PortArray of 2 pins, `p[1]` and `p[2]`. These are
+the two end points of the network.
+<DOC>
+public defn create-circuit (a:ANT) -> Instantiable :
+
+  pcb-module network-circuit:
+    port p : pin[[1 2]]
+    val taps = Vector<[Symbol,JITXObject]>()
+    val [p1, p2] = elaborate(a, taps)
+    net (p[1], p1)
+    net (p[2], p2)
+
+    ; Programmatically create ports for all the
+    ;   taps
+
+    ; Find all of the unique tap ports that we want to
+    ;  create
+    val unique-ports = unique $ for tap in taps seq:
+      val [name, _] = tap
+      if name == `p:
+        throw $ ValueError("Invalid Tap Name '%_' - Must be unique in 'network-circuit'" % [name])
+      name
+
+    val namedPorts-seq = for unique-port in unique-ports seq:
+      val namedPort = make-port(unique-port, SinglePin())
+      unique-port => namedPort
+
+    val namedPorts = to-hashtable<Symbol,JITXObject>(namedPorts-seq)
+
+    ; Each namedPort can be referenced multiple times
+    ;  for example - ground might be something we want to connect to
+    ;  in multiple locations.
+    for tap in taps do:
+      val [name, pinObj] = tap
+      val namedPort = namedPorts[name]
+      net (namedPort, pinObj)
+
+  network-circuit
+
+
+;;;;;;;;;;;;;;;;;;
+; Operators
+;;;;;;;;;;;;;;;;;;
+
+public defn bit-not (a:ANT) -> ANT:
+  Invert(a)
+
+public defn bit-not (a:Instantiable) -> ANT:
+  Invert(Elem(a))
+
+; @TODO - for Series and Parallel, I kind of figure
+;   there will be multiple plusses in a row like this:
+;  R1 + R2 + (R3|R4|Rg|Rf)
+;
+;  It would be nice if there was some pass that collapses
+;  the Parallel(R3, Parallel(R4, Parallel(Rg, Rf))) into
+;      Parallel(R3, R4, Rg, Rf)
+
+public defn plus (a:ANT, b:ANT) -> ANT:
+  Series([a,b])
+
+public defn plus (a:ANT, b:Instantiable) -> ANT :
+  Series([a, Elem(b)])
+
+public defn plus (a:Instantiable, b:ANT) -> ANT :
+  Series([Elem(a), b])
+
+public defn bit-or (a:ANT, b:ANT) -> ANT:
+  Parallel([a,b])
+
+public defn bit-or (a:ANT, b:Instantiable) -> ANT :
+  Parallel([a, Elem(b)])
+
+public defn bit-or (a:Instantiable, b:ANT) -> ANT :
+  Parallel([Elem(a), b])

--- a/src/circuits/Network.stanza
+++ b/src/circuits/Network.stanza
@@ -168,11 +168,11 @@ with:
   printer => true
   constructor => #Tap
 
-public defn Tap (a:ANT, name:Symbol -- port-id:Int = DEF_TAP_PORT_ID) -> Tap:
+public defn Tap (name:Symbol, a:ANT -- port-id:Int = DEF_TAP_PORT_ID) -> Tap:
   #Tap(to-vector<ANT>([a]), name, port-id)
 
-public defn Tap (a:Instantiable, name:Symbol -- port-id:Int = DEF_TAP_PORT_ID) -> Tap:
-  Tap(Elem(a), name, port-id = port-id)
+public defn Tap (name:Symbol, a:Instantiable,  -- port-id:Int = DEF_TAP_PORT_ID) -> Tap:
+  Tap(name, Elem(a), port-id = port-id)
 
 doc: \<DOC>
 Series Node in the Circuit Network

--- a/src/circuits/Network.stanza
+++ b/src/circuits/Network.stanza
@@ -225,7 +225,7 @@ possible to use this in combination with the Parallel `|` operator.
 Example:
 This circuit:
 ```
-A + (B | ShuntTo(C, "named-shunt-port"))
+A + (B | ShuntTo(C, `named-shunt-port))
 ```
 
 Results in:
@@ -338,9 +338,12 @@ Instantiate and Connect all parallel elements
 @param a Parallel Network Element
 @param taps Accumulator for the external ports of the network.
 @return Tuple of `[p1, p2]` which is typically the first parallel elements ports. All of
-the other element's `p1` and `p2` are netted to t he first parallel element, respectively.
-`ShuntTo` elements are handled differently - typically p1 of the shunted component is connected
-by the `p2` is not connected.
+the other element's `p1` and `p2` are netted to the first parallel element, respectively.
+
+`ShuntTo` elements are handled differently. Typically, `p1` port of the shunted sub-network is
+connected to the `p1` of all the other components in paralle. The `p2` port of the shunted
+sub-network is not connected to the other parallel components, and is instead connected to a
+external port.
 <DOC>
 public defn connect-parallel (a:Parallel, taps:Vector<[Symbol,JITXObject]>) -> [JITXObject, JITXObject] :
   inside pcb-module:

--- a/src/circuits/Network.stanza
+++ b/src/circuits/Network.stanza
@@ -36,6 +36,7 @@ defpackage jsl/circuits/Network :
   import jsl/design/introspection
   import jsl/errors
   import jsl/ensure
+  import jsl/si/signal-ends
 
 doc: \<DOC>
 Abstract Network Type
@@ -424,14 +425,22 @@ ports that are created dynamically by the `Tap` and `ShuntTo` types.
 @member p PortArray of 2 pins, `p[1]` and `p[2]`. These are
 the two end points of the network.
 <DOC>
-public defn create-circuit (a:ANT) -> Instantiable :
+public defn create-circuit (a:ANT -- name?:Maybe<String> = None()) -> Instantiable :
 
   pcb-module network-circuit:
+    match(name?):
+      (_:None): false
+      (given:One<String>):
+        name = value(given)
+
     port p : pin[[1 2]]
     val taps = Vector<[Symbol,JITXObject]>()
     val [p1, p2] = elaborate(a, taps)
     net (p[1], p1)
+    set-signal-end(p[1], p1)
     net (p[2], p2)
+    set-signal-end(p[2], p2)
+
 
     ; Programmatically create ports for all the
     ;   taps
@@ -457,9 +466,24 @@ public defn create-circuit (a:ANT) -> Instantiable :
       val [name, pinObj] = tap
       val namedPort = namedPorts[name]
       net (namedPort, pinObj)
+      set-signal-end(namedPort, pinObj)
+
 
   network-circuit
 
+
+doc: \<DOC>
+Construct an Instantiable given a Union of ANT or Instantiable
+
+@param x Sub-Circuit to form into an Instantiable
+@param name? Optional name to apply to the create ANT sub-circuit. If
+`x` is an `Instantiable` - this argument is ignored.
+<DOC>
+public defn to-instantiable (x:ANT|Instantiable -- name?:Maybe<String> = None()) -> Instantiable:
+  match(x):
+    (x-ANT:ANT):
+        create-circuit(x-ANT, name? = name?)
+    (x-Inst:Instantiable): x-Inst
 
 ;;;;;;;;;;;;;;;;;;
 ; Operators

--- a/src/ensure.stanza
+++ b/src/ensure.stanza
@@ -125,3 +125,12 @@ public defn ensure-non-negative! (
         (x:One<Int|Long|Double|Float|Dims>): helper(field, value(x))
     ensure-func
 
+public defn ensure-in-set! (accepted:Tuple<Int>):
+
+  defn ensure-func (
+    field:String,
+    value:Int
+  ):
+    if not contains?(accepted, value):
+      throw $ ValueError("Value '%_' not in Accepted Value Set: [%,]" % [value, accepted])
+  ensure-func

--- a/src/symbols/DIAC.stanza
+++ b/src/symbols/DIAC.stanza
@@ -109,10 +109,15 @@ public defn build-diac-glyphs (
 
 
 public defstruct DiacSymbol <: TwoPinSymbol :
-  pitch:Double with: (
+  pitch:Double with:
     as-method => true
     default => TWO_PIN_DEF_PITCH
-  )
+  polarized?:True|False with:
+      as-method => true
+      default => false
+with:
+  printer => true
+  keyword-constructor => true
 
 public defmethod name (x:DiacSymbol) -> String :
   "DIAC"

--- a/src/symbols/TwoPinSymbol.stanza
+++ b/src/symbols/TwoPinSymbol.stanza
@@ -43,12 +43,20 @@ all two-pin component symbols. These symbols will:
 4.  The pitch of the component is
 <DOC>
 public defstruct TwoPinSymbol <: SymbolDefn :
-  pitch:Double with: (default => TWO_PIN_DEF_PITCH)
+  pitch:Double with:
+    default => TWO_PIN_DEF_PITCH
+  polarized?:True|False with:
+    default => false
 
 public defn two-pin-build-pins (x:TwoPinSymbol, node:SymbolNode) :
-  val w = pitch(x) / 2.0
-  add-pin(node, PINREF[1], [0.0,    w  ], name = "pin-1")
-  add-pin(node, PINREF[2], [0.0, (- w) ], name = "pin-2")
+  if not polarized?(x):
+    val w = pitch(x) / 2.0
+    add-pin(node, PINREF[1], [0.0,    w  ], name = "pin-1")
+    add-pin(node, PINREF[2], [0.0, (- w) ], name = "pin-2")
+  else:
+    val w = pitch(x) / 2.0
+    add-pin(node, #R(a), [0.0,    w  ], name = "pin-1")
+    add-pin(node, #R(c), [0.0, (- w) ], name = "pin-2")
 
 public defmethod build-pins (x:TwoPinSymbol, node:SymbolNode) :
   two-pin-build-pins(x, node)

--- a/src/symbols/capacitors.stanza
+++ b/src/symbols/capacitors.stanza
@@ -77,30 +77,24 @@ public defstruct PolarizedCapacitorSymbolParams <: CapacitorSymbolParams :
   This value can be either an absolute value in symbol grid units or it
   can be a percentage of the `pitch / 2.0`.
   <DOC>
-  porch-width:Double|Percentage with: (
+  porch-width:Double|Percentage with:
     ensure => ensure-positive!,
     updater => sub-porch-width,
     as-method => true
-  )
-  width:Double with: (
+  width:Double with:
     ensure => ensure-positive!,
     updater => sub-width,
     as-method => true
-  )
-  line-width:Double with: (
+  line-width:Double with:
     ensure => ensure-positive!,
     updater => sub-line-width
     as-method => true
-  )
-  pol-radius:Double with: (
+  pol-radius:Double with:
     ensure => ensure-positive!,
     updater => sub-pol-radius,
-  )
-  plus-size:Double|Percentage with: (
+  plus-size:Double|Percentage with:
     ensure => ensure-positive!,
     updater => sub-plus-size
-  )
-
 with:
   constructor => #PolarizedCapacitorSymbolParams
   equalable => true
@@ -267,10 +261,12 @@ This type is used to generate the two-pin electrical
 symbol for standard capacitors
 <DOC>
 public defstruct CapacitorSymbol <: TwoPinSymbol :
-  pitch:Double with: (
+  pitch:Double with:
     as-method => true
     default => TWO_PIN_DEF_PITCH
-  )
+  polarized?:True|False with:
+    as-method => true
+    default => false
   doc: \<DOC>
   Optional Capacitor Symbol Parameters Override
   If this value is not None, then we will use these
@@ -291,7 +287,7 @@ public defn CapacitorSymbol (
   pitch:Double = TWO_PIN_DEF_PITCH
   params:CapacitorSymbolParams = ?
   ) -> CapacitorSymbol:
-  #CapacitorSymbol(pitch, params)
+  #CapacitorSymbol(pitch, false, params)
 
 public defmethod name (x:CapacitorSymbol) -> String :
   "Capacitor"
@@ -311,25 +307,24 @@ public defn set-default-capacitor-symbol (symb:TwoPinSymbol) :
 
 
 public defstruct PolarizedCapacitorSymbol <: TwoPinSymbol :
-  pitch:Double with: (
+  pitch:Double with:
     as-method => true
     default => TWO_PIN_DEF_PITCH
-  )
-  params:Maybe<PolarizedCapacitorSymbolParams> with: (
+  polarized?:True|False with:
+    as-method => true
+    default => true
+  params:Maybe<PolarizedCapacitorSymbolParams> with:
     default => None()
-  )
-  use-AC?:True|False with:
-    default => false
 with:
   constructor => #PolarizedCapacitorSymbol
 
 public defn PolarizedCapacitorSymbol (
   --
   pitch:Double = TWO_PIN_DEF_PITCH
+  polarized?:True|False = true
   params:PolarizedCapacitorSymbolParams = ?
-  use-AC?:True|False = false
   ) -> PolarizedCapacitorSymbol:
-  #PolarizedCapacitorSymbol(pitch, params, use-AC?)
+  #PolarizedCapacitorSymbol(pitch, polarized?, params)
 
 public defmethod name (x:PolarizedCapacitorSymbol) -> String :
   "Polarized Capacitor"
@@ -341,15 +336,6 @@ public defmethod build-artwork (
     (_:None): get-default-polarized-cap-symbol-params()
     (y:One<PolarizedCapacitorSymbolParams>): value(y)
   build-pol-cap-glyphs(sn, pitch(x), p)
-
-public defmethod build-pins (x:PolarizedCapacitorSymbol, node:SymbolNode) :
-  if not use-AC?(x):
-    two-pin-build-pins(x, node)
-  else:
-    val w = pitch(x) / 2.0
-    add-pin(node, #R(a), [0.0,    w  ], name = "pin-1")
-    add-pin(node, #R(c), [0.0, (- w) ], name = "pin-2")
-
 
 var CURR-POL-CAP-SYMBOL:TwoPinSymbol = PolarizedCapacitorSymbol()
 public defn get-default-polarized-capacitor-symbol () : CURR-POL-CAP-SYMBOL

--- a/src/symbols/crystal.stanza
+++ b/src/symbols/crystal.stanza
@@ -145,6 +145,9 @@ public defstruct CrystalSymbol <: TwoPinSymbol :
     ensure => ensure-positive!
     default => TWO_PIN_DEF_PITCH
     as-method => true
+  polarized?:True|False with:
+      as-method => true
+      default => false
 
   doc: \<DOC>
   Number of Case Ports on the Crystal package

--- a/src/symbols/diodes.stanza
+++ b/src/symbols/diodes.stanza
@@ -32,17 +32,14 @@ The `pitch` of the two-pin component defines the overall length.
 
 <DOC>
 public defstruct DiodeSymbolParams <: Equalable :
-  body-dims:Dims|Double with: (
+  body-dims:Dims|Double with:
     ensure => ensure-positive!,
     updater => sub-body-dims
-  )
-  line-width:Double with: (
+  line-width:Double with:
     ensure => ensure-positive!
     updater => sub-line-width
-  )
-  filled?:True|False with: (
+  filled?:True|False with:
     updater => sub-filled?
-  )
 with:
   constructor => #DiodeSymbolParams
   equalable => true
@@ -119,10 +116,15 @@ public defstruct DiodeSymbol <: TwoPinSymbol :
   Pitch between the Pins of a Diode Symbol
   This value is in symbol grid units (not mm)
   <DOC>
-  pitch:Double with: (
+  pitch:Double with:
     as-method => true
     default => TWO_PIN_DEF_PITCH
-  )
+  polarized?:True|False with:
+    as-method => true
+    default => true
+with:
+  printer => true
+  keyword-constructor => true
 
 public defmethod name (x:DiodeSymbol) -> String :
   "Diode"
@@ -145,24 +147,20 @@ public defn set-default-diode-symbol (symb:TwoPinSymbol) :
 
 public defstruct SchottkyDiodeSymbolParams <: DiodeSymbolParams :
 
-  wing-size:Double with: (
-    ensure => ensure-positive!,
+  wing-size:Double with:
+    ensure => ensure-positive!
     updater => sub-wing-size
-  )
-  body-dims:Dims|Double with: (
-    ensure => ensure-positive!,
+  body-dims:Dims|Double with:
+    ensure => ensure-positive!
     updater => sub-body-dims
     as-method => true
-  )
-  line-width:Double with: (
+  line-width:Double with:
     ensure => ensure-positive!
-    updater => sub-line-width,
+    updater => sub-line-width
     as-method => true
-  )
-  filled?:True|False with: (
-    updater => sub-filled?,
+  filled?:True|False with:
+    updater => sub-filled?
     as-method => true
-  )
 with:
   constructor => #SchottkyDiodeSymbolParams
   equalable => true
@@ -231,10 +229,16 @@ public defstruct SchottkyDiodeSymbol <: TwoPinSymbol :
   Pitch between the Pins of a Diode Symbol
   This value is in symbol grid units (not mm)
   <DOC>
-  pitch:Double with: (
+  pitch:Double with:
     as-method => true
     default => TWO_PIN_DEF_PITCH
-  )
+  polarized?:True|False with:
+    as-method => true
+    default => true
+with:
+  printer => true
+  keyword-constructor => true
+
 
 public defmethod name (x:SchottkyDiodeSymbol) -> String :
   "SchottkyDiode"
@@ -257,24 +261,20 @@ public defn set-default-schottky-diode-symbol (symb:TwoPinSymbol) :
 
 public defstruct ZenerDiodeSymbolParams <: DiodeSymbolParams :
 
-  wing-size:Double with: (
+  wing-size:Double with:
     ensure => ensure-positive!,
     updater => sub-wing-size
-  )
-  body-dims:Dims|Double with: (
+  body-dims:Dims|Double with:
     ensure => ensure-positive!,
     updater => sub-body-dims
     as-method => true
-  )
-  line-width:Double with: (
+  line-width:Double with:
     ensure => ensure-positive!
     updater => sub-line-width,
     as-method => true
-  )
-  filled?:True|False with: (
+  filled?:True|False with:
     updater => sub-filled?,
     as-method => true
-  )
 with:
   constructor => #ZenerDiodeSymbolParams
   equalable => true
@@ -348,10 +348,15 @@ public defstruct ZenerDiodeSymbol <: TwoPinSymbol :
   Pitch between the Pins of a Diode Symbol
   This value is in symbol grid units (not mm)
   <DOC>
-  pitch:Double with: (
+  pitch:Double with:
     as-method => true
     default => TWO_PIN_DEF_PITCH
-  )
+  polarized?:True|False with:
+    as-method => true
+    default => true
+with:
+  printer => true
+  keyword-constructor => true
 
 public defmethod name (x:ZenerDiodeSymbol) -> String :
   "ZenerDiode"
@@ -375,24 +380,20 @@ public defn set-default-zener-diode-symbol (symb:TwoPinSymbol) :
 
 public defstruct TunnelDiodeSymbolParams <: DiodeSymbolParams :
 
-  wing-size:Double with: (
+  wing-size:Double with:
     ensure => ensure-positive!,
     updater => sub-wing-size
-  )
-  body-dims:Dims|Double with: (
+  body-dims:Dims|Double with:
     ensure => ensure-positive!,
     updater => sub-body-dims
     as-method => true
-  )
-  line-width:Double with: (
+  line-width:Double with:
     ensure => ensure-positive!
     updater => sub-line-width,
     as-method => true
-  )
-  filled?:True|False with: (
+  filled?:True|False with:
     updater => sub-filled?,
     as-method => true
-  )
 with:
   constructor => #TunnelDiodeSymbolParams
   equalable => true
@@ -461,10 +462,15 @@ public defstruct TunnelDiodeSymbol <: TwoPinSymbol :
   Pitch between the Pins of a Diode Symbol
   This value is in symbol grid units (not mm)
   <DOC>
-  pitch:Double with: (
+  pitch:Double with:
     as-method => true
     default => TWO_PIN_DEF_PITCH
-  )
+  polarized?:True|False with:
+    as-method => true
+    default => true
+with:
+  printer => true
+  keyword-constructor => true
 
 public defmethod name (x:TunnelDiodeSymbol) -> String :
   "TunnelDiode"
@@ -488,24 +494,19 @@ public defn set-default-tunnel-diode-symbol (symb:TwoPinSymbol) :
 
 public defstruct LEDSymbolParams <: DiodeSymbolParams :
 
-  arrow-params:ArrowSymbolParams with: (
+  arrow-params:ArrowSymbolParams with:
     updater => sub-arrow-params
-  )
-
-  body-dims:Dims|Double with: (
+  body-dims:Dims|Double with:
     ensure => ensure-positive!,
     updater => sub-body-dims
     as-method => true
-  )
-  line-width:Double with: (
+  line-width:Double with:
     ensure => ensure-positive!
     updater => sub-line-width,
     as-method => true
-  )
-  filled?:True|False with: (
+  filled?:True|False with:
     updater => sub-filled?,
     as-method => true
-  )
 with:
   constructor => #LEDSymbolParams
   equalable => true
@@ -587,10 +588,15 @@ public defstruct LEDSymbol <: TwoPinSymbol :
   Pitch between the Pins of a Diode Symbol
   This value is in symbol grid units (not mm)
   <DOC>
-  pitch:Double with: (
+  pitch:Double with:
     as-method => true
     default => TWO_PIN_DEF_PITCH
-  )
+  polarized?:True|False with:
+    as-method => true
+    default => true
+with:
+  printer => true
+  keyword-constructor => true
 
 public defmethod name (x:LEDSymbol) -> String :
   "LED"
@@ -613,24 +619,19 @@ public defn set-default-led-symbol (symb:TwoPinSymbol) :
 
 public defstruct PhotoDiodeSymbolParams <: DiodeSymbolParams :
 
-  arrow-params:ArrowSymbolParams with: (
+  arrow-params:ArrowSymbolParams with:
     updater => sub-arrow-params
-  )
-
-  body-dims:Dims|Double with: (
+  body-dims:Dims|Double with:
     ensure => ensure-positive!,
     updater => sub-body-dims
     as-method => true
-  )
-  line-width:Double with: (
+  line-width:Double with:
     ensure => ensure-positive!
     updater => sub-line-width,
     as-method => true
-  )
-  filled?:True|False with: (
+  filled?:True|False with:
     updater => sub-filled?,
     as-method => true
-  )
 with:
   constructor => #PhotoDiodeSymbolParams
   equalable => true
@@ -696,10 +697,16 @@ public defstruct PhotoDiodeSymbol <: TwoPinSymbol :
   Pitch between the Pins of a Diode Symbol
   This value is in symbol grid units (not mm)
   <DOC>
-  pitch:Double with: (
+  pitch:Double with:
     as-method => true
     default => TWO_PIN_DEF_PITCH
-  )
+  polarized?:True|False with:
+    as-method => true
+    default => true
+with:
+  printer => true
+  keyword-constructor => true
+
 
 public defmethod name (x:PhotoDiodeSymbol) -> String :
   "PhotoDiode"

--- a/src/symbols/ferrite.stanza
+++ b/src/symbols/ferrite.stanza
@@ -81,7 +81,9 @@ public defstruct FerriteSymbol <: TwoPinSymbol :
     ensure => ensure-positive!
     default => TWO_PIN_DEF_PITCH
     as-method => true
-
+  polarized?:True|False with:
+    as-method => true
+    default => false
   params:Maybe<FerriteSymbolParams> with:
     default => None()
 

--- a/src/symbols/inductors.stanza
+++ b/src/symbols/inductors.stanza
@@ -14,24 +14,20 @@ public defenum InductorCoreStyle:
   DoubleBarCore
 
 public defstruct InductorSymbolParams <: Equalable:
-  core-style:InductorCoreStyle with: (
+  core-style:InductorCoreStyle with:
     updater => sub-core-style
-  )
-  porch-width:Double with: (
+  porch-width:Double with:
     ensure => ensure-non-negative!,
     updater => sub-porch-width
-  )
   doc: \<DOC>
   Number of half-circles in the inductor winding shape.
   <DOC>
-  periods:Int with: (
+  periods:Int with:
     ensure => ensure-positive!
     updater => sub-periods
-  )
-  line-width:Double with: (
+  line-width:Double with:
     ensure => ensure-positive!
     updater => sub-line-width
-  )
 with:
   constructor => #InductorSymbolParams
   printer => true
@@ -180,14 +176,16 @@ public defn construct-inductor-shape (
 
 
 public defstruct InductorSymbol <: TwoPinSymbol :
-  pitch:Double with: (
+  pitch:Double with:
     as-method => true
     default => TWO_PIN_DEF_PITCH
-  )
-  params:Maybe<InductorSymbolParams> with: (
+  polarized?:True|False with:
+    as-method => true
+    default => false
+  params:Maybe<InductorSymbolParams> with:
     default => None()
-  )
 with:
+  printer =>true
   constructor => #InductorSymbol
 
 public defn InductorSymbol (
@@ -195,7 +193,7 @@ public defn InductorSymbol (
   pitch:Double = TWO_PIN_DEF_PITCH
   params:InductorSymbolParams = ?
   ) -> InductorSymbol:
-  #InductorSymbol(pitch, params)
+  #InductorSymbol(pitch, false, params)
 
 public defmethod name (x:InductorSymbol) -> String :
   "Inductor"

--- a/src/symbols/potentiometer.stanza
+++ b/src/symbols/potentiometer.stanza
@@ -34,6 +34,18 @@ public defstruct PotentiometerSymbol <: ResistorSymbol :
     as-method => true
     default => TWO_PIN_DEF_PITCH
   )
+  polarized?:True|False with:
+    as-method => true
+    default => false
+with:
+  printer => true
+  constructor => #PotentiometerSymbol
+
+public defn PotentiometerSymbol (
+  --
+  pitch:Double = TWO_PIN_DEF_PITCH
+  ) -> PotentiometerSymbol:
+  #PotentiometerSymbol(pitch)
 
 public defmethod name (x:PotentiometerSymbol) -> String :
   "Potentiometer"

--- a/src/symbols/resistors.stanza
+++ b/src/symbols/resistors.stanza
@@ -190,11 +190,22 @@ public defstruct ResistorSymbol <: TwoPinSymbol :
   Pitch between the Pins of a Resistor Symbol
   This value is in symbol grid units (not mm)
   <DOC>
-  pitch:Double with: (
+  pitch:Double with:
     ensure => ensure-positive!
     default => TWO_PIN_DEF_PITCH
     as-method => true
-  )
+  polarized?:True|False with:
+    as-method => true
+    default => false
+with:
+  printer => true
+  constructor => #ResistorSymbol
+
+public defn ResistorSymbol (
+  --
+  pitch:Double = TWO_PIN_DEF_PITCH,
+  ) -> ResistorSymbol:
+  #ResistorSymbol(pitch, false)
 
 public defmethod name (x:ResistorSymbol) -> String :
   "Resistor"
@@ -277,10 +288,18 @@ public defstruct VariableResistorSymbol <: TwoPinSymbol :
   Pitch between the Pins of a Resistor Symbol
   This value is in symbol grid units (not mm)
   <DOC>
-  pitch:Double with: (
+  pitch:Double with:
     as-method => true
     default => TWO_PIN_DEF_PITCH
-  )
+  polarized?:True|False with:
+    as-method => true
+    default => false
+with:
+  printer => true
+  constructor => #VariableResistorSymbol
+
+public defn VariableResistorSymbol (-- pitch:Double = TWO_PIN_DEF_PITCH) -> VariableResistorSymbol:
+  #VariableResistorSymbol(pitch, false)
 
 public defmethod name (x:VariableResistorSymbol) -> String :
   "Variable-Resistor"
@@ -410,10 +429,18 @@ public defstruct PhotoResistorSymbol <: TwoPinSymbol :
   Pitch between the Pins of a Resistor Symbol
   This value is in symbol grid units (not mm)
   <DOC>
-  pitch:Double with: (
+  pitch:Double with:
     as-method => true
     default => TWO_PIN_DEF_PITCH
-  )
+  polarized?:True|False with:
+    as-method => true
+    default => false
+with:
+  printer => true
+  constructor => #PhotoResistorSymbol
+
+public defn PhotoResistorSymbol (pitch:Double = TWO_PIN_DEF_PITCH) -> PhotoResistorSymbol:
+  #PhotoResistorSymbol(pitch, false)
 
 public defmethod name (x:PhotoResistorSymbol) -> String :
   "Photo-Resistor"

--- a/tests/circuits/Network.stanza
+++ b/tests/circuits/Network.stanza
@@ -120,7 +120,7 @@ deftest(network) test-taps :
 
   val a = Elem(res)
   val b = Elem(diode, name = `scrubber)
-  val series = a + b + Tap((a|b|cap), `divOut)
+  val series = a + b + Tap(`divOut, (a|b|cap))
 
   pcb-module test:
     val circuit = create-circuit(series)

--- a/tests/circuits/Network.stanza
+++ b/tests/circuits/Network.stanza
@@ -6,6 +6,8 @@ defpackage jsl/tests/circuits/Network :
   import jitx/commands
 
   import jsl/circuits/Network
+  import jsl/symbols
+  import jsl/landpatterns
 
 public pcb-component res :
 
@@ -14,8 +16,13 @@ public pcb-component res :
   reference-prefix = "R"
   mpn = "asdf"
 
-; Use unified generator to create pins
-  port p : pin[[1 2]]
+  pin-properties:
+    [pin:Ref | pads:Int ... ]
+    [p[1]    | 1]
+    [p[2]    | 2]
+
+  assign-symbol $ create-symbol(ResistorSymbol())
+  assign-landpattern $ create-landpattern(get-resistor-pkg("0603"))
 
 public pcb-component cap :
   manufacturer     = "Test"
@@ -23,8 +30,13 @@ public pcb-component cap :
   reference-prefix = "C"
   mpn = "asdf"
 
-; Use unified generator to create pins
-  port p : pin[[1 2]]
+  pin-properties:
+    [pin:Ref | pads:Int ... ]
+    [p[1]    | 1]
+    [p[2]    | 2]
+
+  assign-symbol $ create-symbol(CapacitorSymbol())
+  assign-landpattern $ create-landpattern(get-capacitor-pkg("0603"))
 
 
 public pcb-component diode :
@@ -34,9 +46,13 @@ public pcb-component diode :
   reference-prefix = "D"
   mpn = "asdf"
 
-; Use unified generator to create pins
-  port c : pin
-  port a : pin
+  pin-properties:
+    [pin:Ref | pads:Int ... ]
+    [a    | 1]
+    [c    | 2]
+
+  assign-symbol $ create-symbol(DiodeSymbol())
+  assign-landpattern $ create-landpattern(get-chip-pkg("0603"))
 
 
 deftest(network) test-basic :

--- a/tests/circuits/Network.stanza
+++ b/tests/circuits/Network.stanza
@@ -1,0 +1,116 @@
+#use-added-syntax(jitx, tests)
+defpackage jsl/tests/circuits/Network :
+  import core
+  import collections
+  import jitx
+  import jitx/commands
+
+  import jsl/circuits/Network
+
+public pcb-component res :
+
+  manufacturer     = "Test"
+  description      = "test resistor"
+  reference-prefix = "R"
+  mpn = "asdf"
+
+; Use unified generator to create pins
+  port p : pin[[1 2]]
+
+public pcb-component cap :
+  manufacturer     = "Test"
+  description      = "test resistor"
+  reference-prefix = "C"
+  mpn = "asdf"
+
+; Use unified generator to create pins
+  port p : pin[[1 2]]
+
+
+public pcb-component diode :
+
+  manufacturer     = "Test"
+  description      = "test resistor"
+  reference-prefix = "D"
+  mpn = "asdf"
+
+; Use unified generator to create pins
+  port c : pin
+  port a : pin
+
+
+deftest(network) test-basic :
+
+  val a = CircuitElement(elem-type = res)
+  val b = CircuitElement(elem-type = diode)
+  val series = Series([a,b])
+
+  pcb-module test:
+    val circuit = create-circuit(series)
+    inst c : circuit
+    println("Circuit: %~" % [circuit])
+
+  print-def(test)
+  println("Done")
+
+deftest(network) test-operators :
+
+  val a = CircuitElement(elem-type = res)
+  val b = CircuitElement(elem-type = diode)
+  val series = a + b + (a|b|cap)
+
+  pcb-module test:
+    val circuit = create-circuit(series)
+    inst c : circuit
+    println("Circuit: %~" % [circuit])
+
+  print-def(test)
+  println("Done")
+
+deftest(network) test-invert :
+
+  pcb-module test:
+    val a = CircuitElement(elem-type = res)
+    val b = CircuitElement(elem-type = diode)
+    val series = a + Invert(b) + a + (~ b)
+
+    val circuit = create-circuit(series)
+    inst c : circuit
+    println("Circuit: %~" % [circuit])
+
+  print-def(test)
+  println("Done")
+
+
+deftest(network) test-shunt :
+
+  pcb-module test:
+    port asdf : pin
+    val a = CircuitElement(elem-type = res)
+    val b = CircuitElement(elem-type = diode)
+    val series = a + (b | ShuntTo(cap, `COMMON))
+
+    val circuit = create-circuit(series)
+    inst c : circuit
+    println("Circuit: %~" % [circuit])
+
+    net (c.COMMON, asdf)
+
+  print-def(test)
+  println("Done")
+
+
+deftest(network) test-taps :
+
+  val a = Elem(res)
+  val b = Elem(diode, name = `scrubber)
+  val series = a + b + Tap((a|b|cap), `divOut)
+
+  pcb-module test:
+    val circuit = create-circuit(series)
+    inst c : circuit
+    println("Circuit: %~" % [circuit])
+    net (c.p[2], c.divOut)
+
+  print-def(test)
+  println("Done")


### PR DESCRIPTION
Tool for constructing series, parallel, and other lumped circuit networks.

```

val circ = create-circuit( R1 + Tap(R2, `divOut)) 

```

Creates an instantiable for a resistive divider with a central tap port `divOut` and endpoint ports `p[1]` and `p[2]` like a standard two-pin component. For example:

```
pcb-module representative-circuit:
  port p : pin[[1, 2]]
  port divOut 

  inst r1 : R1 
  inst r2 : R2 
  net (r1.p[1], p[1[)
  net( r1.p[2], r2.p[1], divOut)
  net( r2.p[2], p[2] )
```

This is a simple example - but more complex circuits with `Parallel` and `ShuntTo` are possible. 