### PR TITLE
[Bugfix] Updated inductor symbol constructor to allow polarized argument

### DIFF
--- a/src/symbols/inductors.stanza
+++ b/src/symbols/inductors.stanza
@@ -191,9 +191,10 @@ with:
 public defn InductorSymbol (
   --
   pitch:Double = TWO_PIN_DEF_PITCH
-  params:InductorSymbolParams = ?
+  params:InductorSymbolParams = ?,
+  polarized?:True|False = false
   ) -> InductorSymbol:
-  #InductorSymbol(pitch, false, params)
+  #InductorSymbol(pitch, polarized?, params)
 
 public defmethod name (x:InductorSymbol) -> String :
   "Inductor"


### PR DESCRIPTION
Sometimes inductors have a pin 1 marker and it is helpful to use a polarized variant for these.