### PR TITLE
[Bugfix] Fixed Diode A/C backwards issue

### DIFF
--- a/examples/symbols/SCR.stanza
+++ b/examples/symbols/SCR.stanza
@@ -23,8 +23,8 @@ pcb-component test-SCR:
   mpn = "3905"
   pin-properties :
     [pin:Ref | pads:Ref ... ]
-    [ C | p[1] ]
-    [ A | p[2] ]
+    [ A | p[1] ]
+    [ C | p[2] ]
     [ G | p[3] ]
 
   assign-symbol(symb)

--- a/src/symbols/SCR.stanza
+++ b/src/symbols/SCR.stanza
@@ -92,7 +92,7 @@ public defn build-scr-glyphs (
   val gh = gate-height(p)
   val Gp = gate-position(pitch, width, p)
 
-  val start = Point(0.0, porch-end)
+  val start = Point(0.0, (- porch-end))
   line(node, [
     start
     Point(x(start) - gh, y(Gp))
@@ -116,7 +116,7 @@ public defmethod name (x:SCRSymbol) -> String :
 
 defn gate-position (pitch:Double, width:Double, p:SCRSymbolParams) -> Point :
   val porch-end = compute-body-start(p as DiodeSymbolParams)
-  Point((- width), porch-end + gate-height(p))
+  Point((- width), (- porch-end + gate-height(p)))
 
 public defmethod build-pins (
   x:SCRSymbol, sn:SymbolNode

--- a/src/symbols/diode-bridge.stanza
+++ b/src/symbols/diode-bridge.stanza
@@ -134,10 +134,10 @@ public defmethod build-artwork (x:DiodeBridgeSymbol, node:SymbolNode) :
   val xy = (side / 2.0) * cos(to-radians(45.0))
 
   val poses = [
-    loc(xy, xy) * loc(0.0, 0.0, -135.0),
-    loc((- xy), xy) * loc(0.0, 0.0, -45.0)
-    loc((- xy), (- xy)) * loc(0.0, 0.0, -135.0)
-    loc(xy, (- xy)) * loc(0.0, 0.0, -45.0)
+    loc(xy, xy) * loc(0.0, 0.0, 45.0),
+    loc((- xy), xy) * loc(0.0, 0.0, 135.0)
+    loc((- xy), (- xy)) * loc(0.0, 0.0, 45.0)
+    loc(xy, (- xy)) * loc(0.0, 0.0, 135.0)
   ]
   for p1 in poses do:
     val child = create-child(node, pose = p1, class = "diode")

--- a/src/symbols/diodes.stanza
+++ b/src/symbols/diodes.stanza
@@ -99,16 +99,16 @@ public defn build-diode-glyphs (
   if h > p2 :
     throw $ ValueError("Invalid Diode Symbol Dimension: Body is too Large: body=%_ pitch=%_" % [body-dims, pitch])
 
-  line(node, [Point(0.0, p2), Point(0.0, h)], width = line-width, name = "front-porch")
-  line(node, [Point( (- bw2), h), Point(bw2, h)], width = line-width, name = "T-bar")
+  line(node, [Point(0.0, (- p2)), Point(0.0, (- h))], width = line-width, name = "front-porch")
+  line(node, [Point( (- bw2), (- h)), Point(bw2, (- h))], width = line-width, name = "T-bar")
 
-  val tri-pts = [Point(0.0, h), Point(bw2, (- h)), Point((- bw2), (- h)), Point(0.0, h)]
+  val tri-pts = [Point(0.0, (- h)), Point(bw2, h), Point((- bw2), h), Point(0.0, (- h))]
   if filled?:
     polygon(node, tri-pts, name = "triangle")
   else:
     line(node, tri-pts, width = line-width, name = "triangle")
 
-  line(node, [Point(0.0, (- h)), Point(0.0, (- p2))], width = line-width, name = "back-porch")
+  line(node, [Point(0.0, h), Point(0.0, p2)], width = line-width, name = "back-porch")
 
 
 public defstruct DiodeSymbol <: TwoPinSymbol :
@@ -218,9 +218,9 @@ public defn build-schottky-diode-glyphs (
 
   val wing-shape = Line(line-width, [Point(0.0, 0.0), Point(0.0, (- wing-size)), Point(wing-size, (- wing-size))])
 
-  val L-wing = loc((- bw2), h) * wing-shape
+  val L-wing = loc((- bw2), (- h)) * wing-shape
   add-glyph(node, L-wing, name? = One("L-wing"))
-  val R-wing = loc(bw2, h, 180.0) * wing-shape
+  val R-wing = loc(bw2, (- h), 180.0) * wing-shape
   add-glyph(node, R-wing, name? = One("R-wing"))
 
 
@@ -337,9 +337,9 @@ public defn build-zener-diode-glyphs (
 
   val wing-shape = Line(line-width, [Point(0.0, 0.0), Point((- wing-size), (- wing-size))])
 
-  val L-wing = loc((- bw2), h) * wing-shape
+  val L-wing = loc((- bw2), (- h)) * wing-shape
   add-glyph(node, L-wing, name? = One("L-wing"))
-  val R-wing = loc(bw2, h, 180.0) * wing-shape
+  val R-wing = loc(bw2, (- h), 180.0) * wing-shape
   add-glyph(node, R-wing, name? = One("R-wing"))
 
 
@@ -449,11 +449,11 @@ public defn build-tunnel-diode-glyphs (
   val bw2 = body-width(params) / 2.0
   val h = compute-body-start(params)
 
-  val wing-shape = Line(line-width, [Point(0.0, 0.0), Point(0.0, (- wing-size))])
+  val wing-shape = Line(line-width, [Point(0.0, 0.0), Point(0.0, wing-size)])
 
-  val L-wing = loc((- bw2), h) * wing-shape
+  val L-wing = loc((- bw2), (- h)) * wing-shape
   add-glyph(node, L-wing, name? = One("L-wing"))
-  val R-wing = loc(bw2, h) * wing-shape
+  val R-wing = loc(bw2, (- h)) * wing-shape
   add-glyph(node, R-wing, name? = One("R-wing"))
 
 
@@ -571,15 +571,15 @@ public defn build-led-glyphs (node:SymbolNode, pitch:Double, params:LEDSymbolPar
 
   val bw2 = body-width(params) / 2.0
   val h = compute-body-start(params)
-  val angle = (- 30.0)
+  val angle = 30.0
 
   val shaft = shaft-length(arrow-params)
   val x-off = (- (bw2 + (1.2 * shaft)))
-  val y-off = (h / 2.0)
-  val y-adj = 0.3 * y-off
-  val arrow-1 = loc(x-off, y-adj + y-off, angle) * arrow
+  val y-off = (h / -2.0)
+  val y-adj = 1.5 * y-off
+  val arrow-1 = loc(x-off, y-off , angle) * arrow
   add-glyph(node, arrow-1, name? = One("arrow-1"))
-  val arrow-2 = loc(x-off, (y-adj - y-off), angle) * arrow
+  val arrow-2 = loc(x-off, (y-off + y-adj), angle) * arrow
   add-glyph(node, arrow-2, name? = One("arrow-2"))
 
 
@@ -681,10 +681,10 @@ public defn build-photo-diode-glyphs (node:SymbolNode, pitch:Double, params:Phot
   val bw2 = body-width(params) / 2.0
   val h = compute-body-start(params)
 
-  val angle = (- (30.0 + 180.0))
+  val angle = (150.0)
 
   val x-off = (- (1.2 * bw2)  )
-  val y-off = (h / 2.0)
+  val y-off = (h / -2.0)
   val y-adj = 0.3 * y-off
   val arrow-1 = loc(x-off, y-adj + y-off, angle) * arrow
   add-glyph(node, arrow-1, name? = One("arrow-1"))


### PR DESCRIPTION
The change to add `polarized?` to the `TwoPinSymbol` base class put the `a` (anode) in the +Y and the `c` (cathode) in -Y. The Diode symbols were unfortunately written with `c` in +Y and `a` in -Y.

This flips them so that the cathode is in the -Y half-plane

I've also fixed the diode bridge and SCR which also use this functionality.

The new symbols now look like this:
![image](https://github.com/user-attachments/assets/c023c56d-bcf9-4771-ab5e-117de1465c56)

Notice that the cathode is in the -Y half-plane