### PR TITLE
Updated the `molded` landpattern to have configurable pin-1 marker

### DIFF
--- a/src/landpatterns/two-pin/molded.stanza
+++ b/src/landpatterns/two-pin/molded.stanza
@@ -34,9 +34,19 @@ public defstruct Molded-2pin <: Package :
   <DOC>
   lead:SMT-Lead,
   doc: \<DOC>
-
+  Indicates whether `p[1]/p[2]` or `a/c` conventions are used for pads
   <DOC>
   polarized?:True|False
+  doc: \<DOC>
+  Controls which pad will get a dot marker indicating "Pin 1"
+
+  For Diodes, this may need to be `c`. For Polarized capacitors, it may need to be `a`.
+
+  By default - if the `polarized?` arg is false - then this value is `None()`.
+  If the `polarized?` arg is true - then this value is `One(#R(a))` indicating
+  that the `anode` pin gets a pin-1 marker.
+  <DOC>
+  pin-1-id?:Maybe<Int|Ref>
   doc: \<DOC>
   Package Body
   Typically a rectangular {@link PackageBody} but other
@@ -63,18 +73,25 @@ with:
   constructor => #Molded-2pin
 
 
+public defn default-molded-pin-1-id (polarized?:True|False) -> Maybe<Int|Ref> :
+  if polarized?:
+    One $ #R(a)
+  else:
+    None()
+
 public defn Molded-2pin (
   --
   lead-span:Toleranced
   lead:SMT-Lead,
   package-body:PackageBody,
   polarized?:True|False = false,
+  pin-1-id?:Maybe<Ref|Int> = default-molded-pin-1-id(polarized?),
   pad-planner:PadPlanner = RectanglePadPlanner
   lead-numbering:Numbering = select-numbering(polarized?)
   density-level:DensityLevel = DENSITY-LEVEL
   ) -> Molded-2pin :
   #Molded-2pin(
-    lead-span, lead, polarized?,
+    lead-span, lead, polarized?, pin-1-id?,
     package-body, pad-planner, lead-numbering
     density-level
   )
@@ -120,9 +137,18 @@ public defmethod build-silkscreen (
   ):
   val outline = create-silkscreen-pkg-extrema-outline(vp, package-body(pkg), edge = EW-Edge)
 
-  if polarized?(pkg):
-    ; Create the Dot separated from the line
-    val b = bounds(outline)
-    add-pin-1-dot(vp, Point(left(b), up(b) + 0.5))
+  match(pin-1-id?(pkg)):
+    (_:None):false
+    (given:One<Int|Ref>):
+      val pd = get-pad-by-ref!(vp, value(given))
+
+      val pd-pos = center $ loc(pd)
+      val b = bounds(outline)
+      val marker-pt = if y(pd-pos) < 0.0:
+        Point(left(b), down(b) - 0.5)
+      else:
+        Point(left(b), up(b) + 0.5)
+
+      add-pin-1-dot(vp, marker-pt)
 
   add-reference-designator(vp)


### PR DESCRIPTION
This allows different pin 1 marker configurations depending on what pin we want to mark. For example - diodes we want to mark the cathode:
![Screenshot 2024-08-30 140543](https://github.com/user-attachments/assets/b77d963a-37c1-45bb-825c-ba193bd45913)


For inductors and capacitors, we might want to mark the anode:

![image](https://github.com/user-attachments/assets/540e09dc-e41a-4d59-b340-b51a09875104)
