### PR TITLE
Added a Pin1 shaper for Pth Pad planner

### DIFF
--- a/src/landpatterns/pad-planner.stanza
+++ b/src/landpatterns/pad-planner.stanza
@@ -372,6 +372,27 @@ public defmethod hole-generator (x:PthPadPlanner, row:Int, column:Int) -> (Dims 
   to-CircleOrCapsule
 
 
+public defstruct Pin1-PthPadPlanner <: PthPadPlanner :
+  doc: \<DOC>
+  Pin 1 Pad Shapper
+  This function is called for `col=0, row=0` to construct
+  the copper pad shape.
+  <DOC>
+  pin1-shaper:(Dims -> Shape)
+  doc: \<DOC>
+  Copper pad shape
+  Both top and bottom copper for the PTH will
+  have the same shape.
+  <DOC>
+  shaper:(Dims -> Shape) with:
+    as-method => true
+    default => to-CircleOrCapsule
+
+public defmethod shape-generator (x:Pin1-PthPadPlanner, row:Int, column:Int) -> (Dims -> Shape)|False:
+  if column == 0 and row == 0: pin1-shaper(x)
+  else: shaper(x)
+
+
 public defstruct StaggerPthPlanner <: PthPadPlanner :
   doc: \<DOC>
   Copper pad shape


### PR DESCRIPTION
This allows create components where pin 1 is shaped differently in the copper layers that the other pins.

![image](https://github.com/user-attachments/assets/67d3f601-45d3-4b7f-a720-97e54be2bc5a)
