### PR TITLE
Added a stagger pad planner for SMT

### DIFF
--- a/src/landpatterns/pad-planner.stanza
+++ b/src/landpatterns/pad-planner.stanza
@@ -337,6 +337,36 @@ public defmethod shape-generator (x:Corner-PadPlanner, row:Int, column:Int) -> (
   else:
     shaper(x)
 
+public defn is-omit? (omits:Tuple<[Int, Int]>, row:Int, column:Int) -> True|False :
+  for omit in omits any?:
+    val [o-row, o-col] = omit
+    o-row == row and o-col == column
+
+public defstruct StaggerPadPlanner <: ShapePadPlanner :
+  shaper:(Dims -> Shape) with:
+    as-method => true
+
+  doc: \<DOC>
+  Set the stagger phase for the planner
+  <DOC>
+  phase:StaggerPhase with:
+    default => Odd-Phase
+
+  doc: \<DOC>
+  List of [row, col] combinations that will be non-stuffed
+  <DOC>
+  omits:Tuple<[Int, Int]> with:
+    default => []
+with:
+  printer => true
+  keyword-constructor => true
+
+public defmethod active? (x:StaggerPadPlanner, row:Int, column:Int) -> True|False :
+  if not is-omit?(omits(x), row, column):
+    stagger-pattern(phase(x), row, column)
+  else:
+    false
+
 doc: \<DOC>
 Plated Through-Hole Pad Planner
 


### PR DESCRIPTION
This allows for generating staggered pad patterns like this:

![image](https://github.com/user-attachments/assets/145552cf-6b66-4353-8d94-3745ac8e7adc)


We had one for through-hole but this adds one for SMT