### PR TITLE
Add Bypass and Pullup Tools

### DIFF
--- a/slm.toml
+++ b/slm.toml
@@ -1,3 +1,4 @@
 name = "jsl"
 version = "0.5.1"
 [dependencies]
+maybe-utils = { git = "StanzaOrg/maybe-utils", version = "0.1.6"}

--- a/src/circuits/Bypass.stanza
+++ b/src/circuits/Bypass.stanza
@@ -1,0 +1,104 @@
+#use-added-syntax(jitx)
+defpackage jsl/circuits/Bypass:
+  import core
+  import jitx
+  import jitx/commands
+
+  import jsl/bundles
+  import jsl/si/signal-ends
+  import jsl/design/introspection
+
+doc: \<DOC>
+Bypass two ports with an element instance
+
+This function is generator and is expected to run in
+a `pcb-module` context.
+
+It is common to bypass voltage rails with capacitors. Typically,
+these capacitors need to be placed close to the rail in question.
+
+The `bypass` function is a general purpose tool for creating
+the net and short-trace statements for bypassing.
+
+@param elem component or module instance with either:
+*  Standard Non-Polar Interface - `p[1]/p[2]`
+*  Standard Polarized Interface - `a/c`
+<DOC>
+public defn bypass (elem:JITXObject, p1:JITXObject, p2:JITXObject):
+  inside pcb-module:
+    val [e-p1, e-p2] = get-element-ports(elem)
+    short-net(e-p1, p1)
+    net (e-p2, p2)
+
+val BYPASS_DEF_QB = CapacitorQuery()
+val BYPASS_DEF_VAL = 0.1e-6 ; Farads
+
+
+defn insert-bypass (pos:JITXObject, neg:JITXObject -- elem-type?:Instantiable|Double, inst-name?:Maybe<String|Symbol> = None(), qb?:Maybe<CapacitorQuery> = None()) :
+
+  val inst-name = to-string $ value-or(inst-name?, "%_-byp" % [get-ref-name $ ref(pos)])
+  val qb = value-or(qb?, BYPASS_DEF_QB)
+
+  inside pcb-module:
+    val elem-type = match(elem-type?):
+      (et:Instantiable): et
+      (C-v:Double): ; Resistance Value
+        create-capacitor(qb, capacitance = C-v)
+
+    val elem = make-inst(to-symbol(inst-name), elem-type, false)
+    bypass(elem, pos, neg)
+    elem
+
+
+doc: \<DOC>
+Insert a bypass capacitor of a particular type.
+
+This function expects to be called from within a `pcb-module` context.
+
+@param pos Voltage Rail Positive Port - This should generally be a
+component port because otherwise the `short-trace` application will fail.
+@param neg Voltage Rail Negative Port - This should generally be a
+component port, but can also be a ground net or module port.
+@param elem-type Instantiable or capacitance value as a `Double`. If an
+`Instantiable`, it should confirm to standard two pin interface definitions.
+As a `Double`, the JITX query API is used to source a capacitor of this many
+farads. By default, this value is set to 100nF. The global default query parameters
+can be used to control the other aspects of the query.
+@param inst-name Optional name for the capacitor instance to be created. If none is
+given, then the Ref name of the `pos` signal will be used to create an instance name
+in the form `<NAME>-byp`.
+@param qb Optional capacitor query builder. This builder will extend the global defaults
+with any customization the user desires. The default value is `CapacitorQuery()` with no
+additional parameters.
+@return Instance for this bypass component
+<DOC>
+public defn insert-bypass (pos:JITXObject, neg:JITXObject -- elem-type:Instantiable|Double = BYPASS_DEF_VAL, inst-name:String|Symbol = ?, qb:CapacitorQuery = ?) :
+  inside pcb-module:
+    insert-bypass(pos, neg, elem-type? = elem-type, inst-name? = inst-name, qb? = qb )
+
+doc: \<DOC>
+Insert a bypass capacitor across a `power` bundle port.
+
+This function expects to be called from within a `pcb-module` context.
+
+@param rail Power Bundle port for the rail to bypass. This port will likely need to
+use the `signal-ends` feature if not a direct `pcb-component` pad.
+@param elem-type Instantiable or capacitance value as a `Double`. If an
+`Instantiable`, it should confirm to standard two pin interface definitions.
+As a `Double`, the JITX query API is used to source a capacitor of this many
+farads. By default, this value is set to 100nF. The global default query parameters
+can be used to control the other aspects of the query.
+@param inst-name Optional name for the capacitor instance to be created. If none is
+given, then the Ref name of the `pos` signal will be used to create an instance name
+in the form `<NAME>-byp`.
+@param qb Optional capacitor query builder. This builder will extend the global defaults
+with any customization the user desires. The default value is `CapacitorQuery()` with no
+additional parameters.
+@return Instance for this bypass component
+<DOC>
+public defn insert-bypass (rail:JITXObject -- elem-type:Instantiable|Double = BYPASS_DEF_VAL, inst-name:String|Symbol = ?, qb:CapacitorQuery = ?) :
+  inside pcb-module:
+    val pos = get-signal-end(rail.V+)
+    val neg = get-signal-end(rail.V-)
+    insert-bypass(pos, neg, elem-type? = elem-type, inst-name? = inst-name, qb? = qb )
+

--- a/src/circuits/Bypass.stanza
+++ b/src/circuits/Bypass.stanza
@@ -3,10 +3,14 @@ defpackage jsl/circuits/Bypass:
   import core
   import jitx
   import jitx/commands
+  import jitx/parts
+
+  import maybe-utils
 
   import jsl/bundles
   import jsl/si/signal-ends
   import jsl/design/introspection
+  import jsl/circuits/utils
 
 doc: \<DOC>
 Bypass two ports with an element instance

--- a/src/circuits/Pullups.stanza
+++ b/src/circuits/Pullups.stanza
@@ -1,0 +1,131 @@
+#use-added-syntax(jitx)
+defpackage jsl/circuits/Pullups:
+  import core
+  import jitx
+  import jitx/commands
+
+  import maybe-utils
+
+  import jsl/errors
+  import jsl/design/introspection
+  import jsl/bundles
+
+
+defn add-puller (elem:JITXObject, sig:JITXObject, rail:JITXObject, updown:True|False) :
+  inside pcb-module:
+    val [e-p1, e-p2] = get-element-ports(elem)
+
+    net (e-p1, sig)
+
+    val other = match(rail):
+      (n:Net): n
+      (p:Pin):
+        match(port-type(p)):
+          (_:SinglePin): rail
+          (b:Bundle):
+            if b == power :
+              if updown:
+                rail.V+
+              else:
+                rail.V-
+            else:
+              throw $ ArgumentError("Unexpected 'rail' - Not SinglePin or 'power' bundle: port-type = %_" % [b])
+
+    net (e-p2, other)
+
+
+doc: \<DOC>
+Add connections for a pullup to a net or power rail
+
+@param elem Instance supporting standard two-pin interface
+@param sig Signal that we want to add a pullup resistor to.
+@param rail Power Rail as either a `power` bundle, `SinglePin` or a Net.
+For a `power` bundle, the `rail.V+` port will be used.
+<DOC>
+public defn add-pullup (elem:JITXObject, sig:JITXObject, rail:JITXObject) :
+  inside pcb-module:
+    add-puller(elem, sig, rail, true)
+
+doc: \<DOC>
+Add connections for a pulldown to a net or power rail.
+
+@param elem Instance supporting standard two-pin interface
+@param sig Signal that we want to add a pulldown resistor to.
+@param rail Power Rail as either a `power` bundle, `SinglePin` or `Net`.
+For a `power` bundle, the `rail.V-` port will be used.
+<DOC>
+public defn add-pulldown (elem:JITXObject, sig:JITXObject, rail:JITXObject) :
+  inside pcb-module:
+    add-puller(elem, sig, rail, false)
+
+val PULLUP_DEF_QB =  ResistorQuery(precision = (5 %))
+
+doc: \<DOC>
+Construct a pullup instance from an Instantiable
+
+This function expects to be called from a `pcb-module` context.
+
+See {@link add-pullup} for more info.
+
+@param sig Port or net that we wish to add a pullup to.
+@param rail Port or Net to provide the voltage rail to pull the signal to. If this
+is a `power` bundle, then this function will pull to the `rail.V+` signal.
+@param elem-type Optional value to control the instance definition. If this
+value is an `Instantiable` - we will instantiate it directly.
+Alternatively, the user can provide a resistance value as a `Double`, and a resistor
+of that value will be created using the JITX query API. By default - this function
+will create a 10k resistor for the pullup.
+@param inst-name? Name of the created instance. If no name is provided, we will
+use the Ref of the `sig` argument. For example, `netsw.C.IRQ_N` will be converted
+to `IRQ_N-pu`.
+@param qb? Optional Resistor query builder for the selection of the pullup resistor
+in the case that `elem-type?` is a `Double`. By default, the global query defaults are
+extended with `ResistorQuery(precision = (5 %))`.
+<DOC>
+public defn insert-pullup (sig:JITXObject, rail:JITXObject -- elem-type:Instantiable|Double = 10.0e3, inst-name?:String|Symbol = ?) :
+  val inst-name = to-string $ value-or(inst-name?, "%_-pu" % [get-ref-name $ ref(sig)])
+  val qb = value-or(qb?, PULLUP_DEF_QB)
+
+  inside pcb-module:
+    val et = match(elem-type):
+      (given:Instantiable): given
+      (R-v:Double): ; Resistance Value
+        create-resistor(resistance = R-v, precision = (1 %))
+
+    val elem = make-inst(to-symbol(inst-name), et, false)
+    add-pullup(elem, sig, rail)
+
+doc: \<DOC>
+Construct a pulldown instance from an Instantiable
+
+This function expects to be called from a `pcb-module` context.
+
+See {@link add-pulldown} for more info.
+
+@param sig Port or net that we wish to add a pullup to.
+@param rail Port or Net to provide the voltage rail to pull the signal to. If
+this rail is a `power` bundle, then the signal is pulled to `rail.V-`.
+@param elem-type This function will instantiate a component of this type. Alternatively,
+the user can provide a resistance value, and a resistor of that value will be created
+using the JITX query API. By default - this function will create a 10k 1% resistor by
+default.
+@param inst-name? Optional name of the created instance. If no name is provided, we will
+use the Ref name of the `sig` argument. For example, `netsw.C.IRQ_N` will be converted
+to `IRQ_N-pu`.
+@param qb? Optional Resistor query builder for the selection of the pullup resistor
+in the case that `elem-type?` is a `Double`. By default, the global query defaults are
+extended with `ResistorQuery(precision = (5 %))`.
+<DOC>
+public defn insert-pulldown (sig:JITXObject, rail:JITXObject -- elem-type:Instantiable|Double = 10.0e3, inst-name?:String|Symbol = ?, qb?:ResistorQuery = ?) :
+  val inst-name = to-string $ value-or(inst-name?, "%_-pd" % [get-ref-name $ ref(sig)])
+  val qb = value-or(qb?, PULLUP_DEF_QB)
+
+  inside pcb-module:
+    val et = match(elem-type):
+      (given:Instantiable): given
+      (R-v:Double): ; Resistance Value
+        create-resistor(qb, resistance = R-v)
+
+    val elem = make-inst(to-symbol(inst-name), elem-type, false)
+    add-pulldown(elem, sig, rail)
+

--- a/src/circuits/Pullups.stanza
+++ b/src/circuits/Pullups.stanza
@@ -3,6 +3,7 @@ defpackage jsl/circuits/Pullups:
   import core
   import jitx
   import jitx/commands
+  import jitx/parts
 
   import maybe-utils
 
@@ -82,7 +83,7 @@ to `IRQ_N-pu`.
 in the case that `elem-type?` is a `Double`. By default, the global query defaults are
 extended with `ResistorQuery(precision = (5 %))`.
 <DOC>
-public defn insert-pullup (sig:JITXObject, rail:JITXObject -- elem-type:Instantiable|Double = 10.0e3, inst-name?:String|Symbol = ?) :
+public defn insert-pullup (sig:JITXObject, rail:JITXObject -- elem-type:Instantiable|Double = 10.0e3, inst-name?:String|Symbol = ?, qb?:ResistorQuery = ?) :
   val inst-name = to-string $ value-or(inst-name?, "%_-pu" % [get-ref-name $ ref(sig)])
   val qb = value-or(qb?, PULLUP_DEF_QB)
 
@@ -126,6 +127,6 @@ public defn insert-pulldown (sig:JITXObject, rail:JITXObject -- elem-type:Instan
       (R-v:Double): ; Resistance Value
         create-resistor(qb, resistance = R-v)
 
-    val elem = make-inst(to-symbol(inst-name), elem-type, false)
+    val elem = make-inst(to-symbol(inst-name), et, false)
     add-pulldown(elem, sig, rail)
 

--- a/src/circuits/utils.stanza
+++ b/src/circuits/utils.stanza
@@ -3,10 +3,12 @@ defpackage jsl/circuits/utils:
   import core
   import jitx
   import jitx/commands
+  import jitx/parts
+
+  import maybe-utils
 
   import jsl/si/signal-ends
   import jsl/design/introspection
-  import jsl/bundles
   import jsl/errors
 
 doc: \<DOC>
@@ -77,43 +79,6 @@ public defn short-net (ports:JITXObject ...):
     net (ports)
     short-signal-ends(ports = ports)
 
-doc: \<DOC>
-Bypass two ports with an element instance
-
-This function is generator and is expected to run in
-a `pcb-module` context.
-
-It is common to bypass voltage rails with capacitors. Typically,
-these capacitors need to be placed close to the rail in question.
-
-The `bypass` function is a general purpose tool for creating
-the net and short-trace statements for bypassing.
-
-@param elem component or module instance with either:
-*  Standard Non-Polar Interface - `p[1]/p[2]`
-*  Standard Polarized Interface - `a/c`
-<DOC>
-public defn bypass (elem:JITXObject, p1:JITXObject, p2:JITXObject):
-  inside pcb-module:
-    val [e-p1, e-p2] = get-element-ports(elem)
-    short-net(e-p1, p1)
-    net (e-p2, p2)
-
-
-public defn add-pullup (elem:JITXObject, sig:JITXObject, rail:JITXObject) :
-  inside pcb-module:
-    val [e-p1, e-p2] = get-element-ports(elem)
-
-    net (e-p1, sig)
-
-    match(port-type(rail)):
-      (_:SinglePin):
-        net (e-p2, rail)
-      (b:Bundle):
-        if b == power :
-          net (e-p2, rail.V+)
-        else:
-          throw $ ArgumentError("Unexpected 'rail' - Not SinglePin or 'power' bundle: port-type = %_" % [b])
 
 doc: \<DOC>
 Forward a component port/pad through a module port

--- a/src/circuits/utils.stanza
+++ b/src/circuits/utils.stanza
@@ -5,8 +5,6 @@ defpackage jsl/circuits/utils:
   import jitx/commands
   import jitx/parts
 
-  import maybe-utils
-
   import jsl/si/signal-ends
   import jsl/design/introspection
   import jsl/errors


### PR DESCRIPTION
For example: 

```

  val fine-C = create-capacitor(
    bypass-query,
    capacitance = 0.1e-6,
    rated-voltage = Interval(max-rail-V, max-voltage)
  )

  for p in pins(C.VDDIO) do:
    net (p, rail-IO.V+)
    val c = insert-bypass(p, GND, elem-type = fine-C)
    schematic-group(c) = bypass-cap-IO

```

```
  insert-pullup(ROM.C.CS, VDD-3v3)
  insert-pullup(ROM.C.CLK, VDD-3v3)
  insert-pullup(ROM.C.DO, VDD-3v3)
```

This functions work with both nets, SinglePin ports, and `power` bundle ports. 


-------

I've added `maybe-utils` as a dependency. I think it could help reduce complexity in some of the code.