### PR TITLE
Added `jitx/emodels` to fix broken examples

### DIFF
--- a/examples/protocols/common/example-components.stanza
+++ b/examples/protocols/common/example-components.stanza
@@ -4,6 +4,7 @@ defpackage jsl/examples/protocols/common/example-components:
   import collections
   import jitx
   import jitx/commands
+  import jitx/emodels
 
   import jsl/design/settings
   import jsl/symbols


### PR DESCRIPTION
I spot checked and it seems like the issue is only in the via structures and protocols examples. Basically anywhere we use the `block-cap` or `pu-res` components.