### PR TITLE
Cja/update resistor capacitor symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 SLM_STANZA ?= jstanza
 STANZA := $(SLM_STANZA)
 CWD := $(shell pwd)
+SLM := $(SLM)
 
 # execute all lines of a target in one shell
 .ONESHELL:
@@ -58,12 +59,18 @@ FILLETS_NAME=jsl/landpatterns/leads/lead-fillets-table
 $(FILLETS): $(FILLETS_CSV) tabgen
 	$(TABGEN) generate $(FILLETS_CSV) -f $@ -pkg-name $(FILLETS_NAME) -force
 
+fetch-deps:
+    # This forces SLM to fetch the dependencies
+    #  it will fail - but we don't care as longs as the
+    #  deps get fetched.
+    -$(SLM) build fetch-deps
+
 .PHONY: tests
-tests:
+tests: fetch-deps
 	$(STANZA) run-test $(JSL_TESTS)
 
 .PHONY: test-%
-test-%:
+test-%: fetch-deps
 	$(STANZA) run-test $(JSL_TESTS) -tagged $(@:test-%=%) | grep -v "SKIP" | awk NF
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -59,11 +59,11 @@ FILLETS_NAME=jsl/landpatterns/leads/lead-fillets-table
 $(FILLETS): $(FILLETS_CSV) tabgen
 	$(TABGEN) generate $(FILLETS_CSV) -f $@ -pkg-name $(FILLETS_NAME) -force
 
+# This forces SLM to fetch the dependencies
+#  it will fail - but we don't care as longs as the
+#  deps get fetched.
 fetch-deps:
-    # This forces SLM to fetch the dependencies
-    #  it will fail - but we don't care as longs as the
-    #  deps get fetched.
-    -$(SLM) build fetch-deps
+	-$(SLM) build fetch-deps
 
 .PHONY: tests
 tests: fetch-deps

--- a/examples/symbols/resistor.stanza
+++ b/examples/symbols/resistor.stanza
@@ -31,6 +31,26 @@ pcb-component test-SMT:
   val lp = create-landpattern(pkg)
   assign-landpattern(lp)
 
+pcb-component test-SMT-2:
+  reference-prefix = "R"
+  pin-properties :
+    [pin:Ref | pads:Ref ... | side:Dir | bank:Int]
+    [p[1] | p[1] | Up |  0]
+    [p[2] | p[2] | Down | 0]
+
+  val override = ResistorSymbolParams( style = OpenRectangle)
+  val symb = ResistorSymbol(params = One $ override)
+  assign-symbol(create-symbol(symb))
+  val chip-def = chips["1206"]
+  val pkg = SMT-Chip(
+    chip-def,
+    density-level = DensityLevelC
+  )
+
+  val lp = create-landpattern(pkg)
+  assign-landpattern(lp)
+
+
 pcb-component test-Var-SMT:
 
   pin-properties :
@@ -96,6 +116,7 @@ pcb-module test-design:
   inst R2 : test-Var-SMT
   inst R3 : test-Photo-SMT
   inst R4 : test-Potentiometer
+  inst R5 : test-SMT-2
 
 ; Set the top level module (the module to be compile into a schematic and PCB)
 set-current-design("Resistor-Symb-TEST")

--- a/src/symbols/capacitors.stanza
+++ b/src/symbols/capacitors.stanza
@@ -5,6 +5,8 @@ defpackage jsl/symbols/capacitors:
   import math
   import jitx
 
+  import maybe-utils
+
   import jsl/ensure
   import jsl/design/Classable
   import jsl/symbols/framework
@@ -13,29 +15,6 @@ val DEF_PORCH_WIDTH = (80 %)
 val DEF_WIDTH = 1.5
 val DEF_LINE_WIDTH = 0.05
 
-public defstruct CapacitorSymbolParams <: Equalable :
-  doc: \<DOC>
-  The porch width is the length of line from the pin to the capacitor plate lines
-  This value can be either an absolute value in symbol grid units or it
-  can be a percentage of the `pitch / 2.0`.
-  <DOC>
-  porch-width:Double|Percentage with: (
-    ensure => ensure-positive!,
-    updater => sub-porch-width
-  )
-  width:Double with: (
-    ensure => ensure-positive!,
-    updater => sub-width,
-  )
-  line-width:Double with: (
-    ensure => ensure-positive!,
-    updater => sub-line-width
-  )
-with:
-  constructor => #CapacitorSymbolParams
-  equalable => true
-  printer => true
-
 doc: \<DOC>
 Construct Parameter Set for a Non-Polarized Capacitor Symbol
 
@@ -43,13 +22,28 @@ Each keyword argument for this function has a default value
 that can be overriden. These parameters are all of the
 configurable aspects of the symbol.
 <DOC>
-public defn CapacitorSymbolParams (
-  --
-  porch-width:Double|Percentage = DEF_PORCH_WIDTH
-  width:Double = DEF_WIDTH
-  line-width:Double = DEF_LINE_WIDTH
-  ) -> CapacitorSymbolParams :
-  #CapacitorSymbolParams(porch-width, width, line-width)
+public defstruct CapacitorSymbolParams <: Equalable :
+  doc: \<DOC>
+  The porch width is the length of line from the pin to the capacitor plate lines
+  This value can be either an absolute value in symbol grid units or it
+  can be a percentage of the `pitch / 2.0`.
+  <DOC>
+  porch-width:Double|Percentage with:
+    ensure => ensure-positive!
+    updater => sub-porch-width
+    default => DEF_PORCH_WIDTH
+  width:Double with:
+    ensure => ensure-positive!
+    updater => sub-width
+    default => DEF_WIDTH
+  line-width:Double with:
+    ensure => ensure-positive!
+    updater => sub-line-width
+    default => DEF_LINE_WIDTH
+with:
+  keyword-constructor => true
+  equalable => true
+  printer => true
 
 public defn to-tuple (p:CapacitorSymbolParams) -> [Double|Percentage, Double, Double] :
   [porch-width(p), width(p), line-width(p)]
@@ -70,36 +64,6 @@ val DEF_POL_STYLE = Polarized-Straight-Style
 val DEF_POL_RADIUS = 5.0
 val DEF_PLUS_SIZE = (20 %)
 
-public defstruct PolarizedCapacitorSymbolParams <: CapacitorSymbolParams :
-  style:PolarizedStyle
-  doc: \<DOC>
-  The porch width is the length of line from the pin to the capacitor plate lines
-  This value can be either an absolute value in symbol grid units or it
-  can be a percentage of the `pitch / 2.0`.
-  <DOC>
-  porch-width:Double|Percentage with:
-    ensure => ensure-positive!,
-    updater => sub-porch-width,
-    as-method => true
-  width:Double with:
-    ensure => ensure-positive!,
-    updater => sub-width,
-    as-method => true
-  line-width:Double with:
-    ensure => ensure-positive!,
-    updater => sub-line-width
-    as-method => true
-  pol-radius:Double with:
-    ensure => ensure-positive!,
-    updater => sub-pol-radius,
-  plus-size:Double|Percentage with:
-    ensure => ensure-positive!,
-    updater => sub-plus-size
-with:
-  constructor => #PolarizedCapacitorSymbolParams
-  equalable => true
-  printer => true
-
 doc: \<DOC>
 Construct Parameter Set for PolCap Symbol Shape
 
@@ -107,16 +71,41 @@ The parameters of this function are the configurable
 features of a Polarized Capacitor's default symbol shape.
 Each argument has a default value that can be overriden.
 <DOC>
-public defn PolarizedCapacitorSymbolParams (
-  --
-  style:PolarizedStyle = DEF_POL_STYLE
-  porch-width:Double|Percentage = DEF_PORCH_WIDTH
-  width:Double = DEF_WIDTH
-  line-width:Double = DEF_LINE_WIDTH
-  pol-radius:Double = DEF_POL_RADIUS
-  plus-size:Double|Percentage = DEF_PLUS_SIZE
-  ) -> PolarizedCapacitorSymbolParams :
-  #PolarizedCapacitorSymbolParams(style, porch-width, width, line-width, pol-radius, plus-size)
+public defstruct PolarizedCapacitorSymbolParams <: CapacitorSymbolParams :
+  style:PolarizedStyle with:
+    default => DEF_POL_STYLE
+  doc: \<DOC>
+  The porch width is the length of line from the pin to the capacitor plate lines
+  This value can be either an absolute value in symbol grid units or it
+  can be a percentage of the `pitch / 2.0`.
+  <DOC>
+  porch-width:Double|Percentage with:
+    ensure => ensure-positive!
+    updater => sub-porch-width
+    as-method => true
+    default => DEF_PORCH_WIDTH
+  width:Double with:
+    ensure => ensure-positive!
+    updater => sub-width
+    as-method => true
+    default => DEF_WIDTH
+  line-width:Double with:
+    ensure => ensure-positive!
+    updater => sub-line-width
+    as-method => true
+    default => DEF_LINE_WIDTH
+  pol-radius:Double with:
+    ensure => ensure-positive!
+    updater => sub-pol-radius
+    default => DEF_POL_RADIUS
+  plus-size:Double|Percentage with:
+    ensure => ensure-positive!
+    updater => sub-plus-size
+    default => DEF_PLUS_SIZE
+with:
+  keyword-constructor => true
+  equalable => true
+  printer => true
 
 public defn sub-base-params (p:PolarizedCapacitorSymbolParams, b:CapacitorSymbolParams) -> PolarizedCapacitorSymbolParams :
   p $> sub-porch-width{_, porch-width(b)}
@@ -264,30 +253,32 @@ public defstruct CapacitorSymbol <: TwoPinSymbol :
   pitch:Double with:
     as-method => true
     default => TWO_PIN_DEF_PITCH
+  doc: \<DOC>
+  Indicates whether the symbol will use c/a style pins
+
+  This is typically not used for non-polarized capacitors
+  but it is part of the TwoPinSymbol definition. The default
+  is `false`.
+  <DOC>
   polarized?:True|False with:
     as-method => true
     default => false
   doc: \<DOC>
   Optional Capacitor Symbol Parameters Override
-  If this value is not None, then we will use these
-  parameters to construct the capacitor symbol instead
-  of `get-default-cap-symbol-params()`
+  If this value is None, then this function will
+  consult {@link get-default-cap-symbol-params}
+  when constructing the capacitor symbol. Otherwise,
+  this value will override the existing defaults.
   <DOC>
-  params:Maybe<CapacitorSymbolParams> with: (
+  params:Maybe<CapacitorSymbolParams> with:
     ; NOTE: I'm not using `get-default-cap-symbol-params()` here
     ;  because it would prevent the user from overriding the defaults
     ;  because `CURR-CAPACITOR-SYMBOL` gets instantiate on run.
     default => None()
-  )
 with:
-  constructor => #CapacitorSymbol
+  keyword-constructor => true
+  printer => true
 
-public defn CapacitorSymbol (
-  --
-  pitch:Double = TWO_PIN_DEF_PITCH
-  params:CapacitorSymbolParams = ?
-  ) -> CapacitorSymbol:
-  #CapacitorSymbol(pitch, false, params)
 
 public defmethod name (x:CapacitorSymbol) -> String :
   "Capacitor"
@@ -295,9 +286,7 @@ public defmethod name (x:CapacitorSymbol) -> String :
 public defmethod build-artwork (
   x:CapacitorSymbol, sn:SymbolNode
   ):
-  val p = match(params(x)):
-    (_:None): get-default-cap-symbol-params()
-    (y:One<CapacitorSymbolParams>): value(y)
+  val p = value-or-else(params(x), get-default-cap-symbol-params)
   build-capacitor-glyphs(sn, pitch(x), p)
 
 var CURR-CAPACITOR-SYMBOL:TwoPinSymbol = CapacitorSymbol()
@@ -310,9 +299,24 @@ public defstruct PolarizedCapacitorSymbol <: TwoPinSymbol :
   pitch:Double with:
     as-method => true
     default => TWO_PIN_DEF_PITCH
+  doc: \<DOC>
+  Indicates whether the symbol will use c/a style pins
+
+  This is value defaults to `true` for the Polarized
+  capacitor symbol.
+  <DOC>
   polarized?:True|False with:
     as-method => true
     default => true
+  doc: \<DOC>
+  Optional Override Parameters for Polarized Capacitor Glyph
+
+  This value can be used to override the capacitor glyph
+  parameters and replace them with custom parameters.
+  This value is by default `None()` which will cause
+  {@link get-default-polarized-cap-symbol-params} to be
+  consulted for parameters when the symbol is built.
+  <DOC>
   params:Maybe<PolarizedCapacitorSymbolParams> with:
     default => None()
 with:
@@ -332,9 +336,7 @@ public defmethod name (x:PolarizedCapacitorSymbol) -> String :
 public defmethod build-artwork (
   x:PolarizedCapacitorSymbol, sn:SymbolNode
   ):
-  val p = match(params(x)):
-    (_:None): get-default-polarized-cap-symbol-params()
-    (y:One<PolarizedCapacitorSymbolParams>): value(y)
+  val p = value-or-else(params(x), get-default-polarized-cap-symbol-params)
   build-pol-cap-glyphs(sn, pitch(x), p)
 
 var CURR-POL-CAP-SYMBOL:TwoPinSymbol = PolarizedCapacitorSymbol()

--- a/src/symbols/capacitors.stanza
+++ b/src/symbols/capacitors.stanza
@@ -220,14 +220,16 @@ public defn build-pol-cap-glyphs (
       val pol-r = pol-radius(params)
       val half-angle = to-degrees $ atan( w2 / pol-r )
 
+      val porch-line = Line(line-width, [Point(0.0, (- h)), Point(0.0, (- cross-y))])
+      val pol-r-center = Point(0.0, (- (cross-y + pol-r)))
       val pline = Polyline(line-width,[
         [
-          Point(0.0, (- h)), Point(0.0, (- cross-y)), ; Shaft
-          Arc(Point(0.0, (- pol-r)), pol-r, 90.0 + half-angle, (- 2.0 * half-angle))
-          Arc(Point(0.0, (- pol-r)), pol-r, 90.0 - half-angle, (2.0 * half-angle))
+          Arc(pol-r-center, pol-r, 90.0 + half-angle, (- 2.0 * half-angle))
+          Arc(pol-r-center, pol-r, 90.0 - half-angle, (2.0 * half-angle))
           ]
       ] )
-      pline
+      ; pline
+      Union([porch-line, pline])
   add-glyph(node, bot-plate, name? = One("bot-plate"))
 
   val plus-len = match(plus-size(params)):

--- a/src/symbols/resistors.stanza
+++ b/src/symbols/resistors.stanza
@@ -5,6 +5,8 @@ defpackage jsl/symbols/resistors:
   import jitx
   import math
 
+  import maybe-utils
+
   import jsl/errors
   import jsl/ensure
   import jsl/geometry/LineRectangle
@@ -30,14 +32,16 @@ of a triangle-wave style resistor sybmol.
 TODO - Diagram here showing parameters.
 <DOC>
 public defstruct ResistorSymbolParams <: Equalable:
-  style:ResistorStyle
+  style:ResistorStyle with:
+    default => DEF_RES_STYLE
   doc: \<DOC>
   Length of the line from the pin to the start of the resistor body.
   <DOC>
-  porch-width:Double with: (
+  porch-width:Double with:
     ensure => ensure-positive!,
     updater => sub-porch-width
-  )
+    default => DEF_PORCH_WIDTH
+
   doc: \<DOC>
   Width of the body of the resistor
   For triangle wave versions, this is the amplitude of the
@@ -45,10 +49,11 @@ public defstruct ResistorSymbolParams <: Equalable:
   For the rectangle shaped version, this is the distance from
   X=0 to either edge of the rectangle shape.
   <DOC>
-  amplitude:Double with: (
+  amplitude:Double with:
     ensure => ensure-positive!
     updater => sub-amplitude
-  )
+    default => DEF_AMPLITUDE
+
   doc: \<DOC>
   Number of oscillation periods in the triangle wave.
   This value should typically be a whole- or half-number,
@@ -56,31 +61,23 @@ public defstruct ResistorSymbolParams <: Equalable:
   This values does not apply to the rectangular shaped
   variants.
   <DOC>
-  periods:Double with: (
+  periods:Double with:
     ensure => ensure-positive!
     updater => sub-periods
-  )
+    default => DEF_PERIODS
+
   doc: \<DOC>
   Line width for the shapes drawn
   <DOC>
-  line-width:Double with: (
+  line-width:Double with:
     ensure => ensure-positive!
     updater => sub-line-width
-  )
+    default => DEF_LINE_WIDTH
+
 with:
-  constructor => #ResistorSymbolParams
+  keyword-constructor => true
   printer => true
   equalable => true
-
-public defn ResistorSymbolParams (
-  --
-  style:ResistorStyle = DEF_RES_STYLE
-  porch-width:Double = DEF_PORCH_WIDTH
-  amplitude:Double = DEF_AMPLITUDE
-  periods:Double = DEF_PERIODS
-  line-width:Double = DEF_LINE_WIDTH
-  ) -> ResistorSymbolParams :
-  #ResistorSymbolParams(style, porch-width, amplitude, periods, line-width)
 
 public defn to-tuple (p:ResistorSymbolParams) -> [ResistorStyle, Double, Double, Double, Double] :
   [style(p), porch-width(p), amplitude(p), periods(p), line-width(p)]
@@ -194,26 +191,41 @@ public defstruct ResistorSymbol <: TwoPinSymbol :
     ensure => ensure-positive!
     default => TWO_PIN_DEF_PITCH
     as-method => true
+  doc: \<DOC>
+  Indicates whether the symbol will use c/a style pins
+
+  This is typically not used in resistors because they
+  are not polarized - but it is part of the TwoPinSymbol
+  definition. The default is `false`.
+  <DOC>
   polarized?:True|False with:
     as-method => true
     default => false
-with:
-  printer => true
-  constructor => #ResistorSymbol
+  doc: \<DOC>
+  Optional Override Parameters for Resistor Glyph
 
-public defn ResistorSymbol (
-  --
-  pitch:Double = TWO_PIN_DEF_PITCH,
-  ) -> ResistorSymbol:
-  #ResistorSymbol(pitch, false)
+  This value can be used to override the resistor glyph
+  parameters and replace them with custom parameters.
+  This value is by default `None()` which will cause
+  {@link get-default-resistor-symbol-params} to be
+  consulted for parameters when the symbol is built.
+  <DOC>
+  params:Maybe<ResistorSymbolParams> with:
+    default => None()
+with:
+  keyword-constructor => true
+  printer => true
 
 public defmethod name (x:ResistorSymbol) -> String :
   "Resistor"
 
+defn get-params (x:ResistorSymbol) -> ResistorSymbolParams :
+  value-or-else(params(x), get-default-resistor-symbol-params)
+
 public defmethod build-artwork (
   x:ResistorSymbol, sn:SymbolNode
   ):
-  val p = get-default-resistor-symbol-params()
+  val p = get-params(x)
   build-resistor-glyphs(sn, pitch(x), p)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -234,42 +246,31 @@ public defstruct VariableResistorSymbolParams <: Equalable :
   doc: \<DOC>
   Override the default resistor symbol parameters with this value.
   <DOC>
-  res-params?:Maybe<ResistorSymbolParams> with: (
+  res-params?:Maybe<ResistorSymbolParams> with:
     default => None()
     updater => sub-res-params
-  )
   doc: \<DOC>
   Override the default arrow parameters with this value.
   We will grab `get-default-arrow-symbol-params()` by
   default if this value is `None`.
   <DOC>
-  arrow-params?:Maybe<ArrowSymbolParams> with: (
+  arrow-params?:Maybe<ArrowSymbolParams> with:
     default => None()
     updater => sub-arrow-params
-  )
   doc: \<DOC>
   Set the X span of the arrow
   This, along with the body length of the resistor symbol, defines
   the shaft length of the arrow. This value is relative to the
   `amplitude` of the resistor body.
   <DOC>
-  arrow-span:Percentage with: (
+  arrow-span:Percentage with:
     ensure => ensure-positive!
     default => DEF_VAR_ARROW_SPAN
     updater => sub-arrow-span
-  )
 with:
-  constructor => #VariableResistorSymbolParams
+  keyword-constructor => true
   equalable => true
   printer => true
-
-public defn VariableResistorSymbolParams (
-  --
-  res-params:ResistorSymbolParams = ?
-  arrow-params:ArrowSymbolParams = ?,
-  arrow-span:Percentage = DEF_VAR_ARROW_SPAN
-  ) -> VariableResistorSymbolParams :
-  #VariableResistorSymbolParams(res-params, arrow-params, arrow-span)
 
 
 var DEF_VAR_RESISTOR_PARAMS = VariableResistorSymbolParams()
@@ -291,28 +292,43 @@ public defstruct VariableResistorSymbol <: TwoPinSymbol :
   pitch:Double with:
     as-method => true
     default => TWO_PIN_DEF_PITCH
+  doc: \<DOC>
+  Indicates whether the symbol will use c/a style pins
+
+  This is typically not used in resistors because they
+  are not polarized - but it is part of the TwoPinSymbol
+  definition. The default is `false`.
+  <DOC>
   polarized?:True|False with:
     as-method => true
     default => false
+  doc: \<DOC>
+  Optional Override Parameters for Variable Resistor Glyph
+
+  This value can be used to override the resistor glyph
+  parameters and replace them with custom parameters.
+  This value is by default `None()` which will cause
+  {@link get-default-variable-resistor-symbol-params} to be
+  consulted for parameters when the symbol is built.
+  <DOC>
+  params:Maybe<VariableResistorSymbolParams> with:
+    default => None()
 with:
   printer => true
-  constructor => #VariableResistorSymbol
-
-public defn VariableResistorSymbol (-- pitch:Double = TWO_PIN_DEF_PITCH) -> VariableResistorSymbol:
-  #VariableResistorSymbol(pitch, false)
+  keyword-constructor => true
 
 public defmethod name (x:VariableResistorSymbol) -> String :
   "Variable-Resistor"
+
+defn get-params (x:VariableResistorSymbol) -> VariableResistorSymbolParams :
+  value-or-else(params(x), get-default-variable-resistor-symbol-params)
 
 public defn build-variable-resistor-glyphs (
   sn:SymbolNode,
   pitch:Double,
   x:VariableResistorSymbolParams
   ):
-  val p = match(res-params?(x)):
-    (_:None): get-default-resistor-symbol-params()
-    (def-p:One<ResistorSymbolParams>): value(def-p)
-
+  val p = value-or-else(res-params?(x), get-default-resistor-symbol-params)
   build-resistor-glyphs(sn, pitch, p)
 
   ; Draw arrow here.
@@ -330,10 +346,7 @@ public defn build-variable-resistor-glyphs (
   )
   val angle = to-degrees $ atan2((- y-dim), (- x-dim))
 
-  val curr-params = match(arrow-params?(x)):
-    (_:None): get-default-arrow-symbol-params()
-    (p:One<ArrowSymbolParams>): value(p)
-
+  val curr-params = value-or-else(arrow-params?(x), get-default-arrow-symbol-params)
   val arrow-params = sub-shaft-length(curr-params, shaft)
   val arrow-sh = loc(start, angle) * construct-arrow(arrow-params)
   add-glyph(sn, arrow-sh, name? = One("arrow"))
@@ -341,7 +354,7 @@ public defn build-variable-resistor-glyphs (
 public defmethod build-artwork (
   x:VariableResistorSymbol, sn:SymbolNode
   ):
-  val p = get-default-variable-resistor-symbol-params()
+  val p = get-params(x)
   build-variable-resistor-glyphs(sn, pitch(x), p)
 
 var CURR-VARRES-SYMBOL:TwoPinSymbol = VariableResistorSymbol()
@@ -361,57 +374,42 @@ public defstruct PhotoResistorSymbolParams <: Equalable :
   doc: \<DOC>
   Override the default resistor symbol parameters with this value.
   <DOC>
-  res-params?:Maybe<ResistorSymbolParams> with: (
+  res-params?:Maybe<ResistorSymbolParams> with:
     default => None()
     updater => sub-res-params
-  )
   doc: \<DOC>
   Override the default arrow parameters with this value.
   We will grab `get-default-arrow-symbol-params()` by
   default if this value is `None`.
   <DOC>
-  arrow-params?:Maybe<ArrowSymbolParams> with: (
+  arrow-params?:Maybe<ArrowSymbolParams> with:
     default => None()
     updater => sub-arrow-params
-  )
   doc: \<DOC>
   Margin between the start of the arrows and the body of the resistors
   <DOC>
-  arrow-margin:Double with: (
+  arrow-margin:Double with:
     ensure => ensure-positive!
     default => DEF_PHOTO_ARR_MARGIN
     updater => sub-arrow-margin
-  )
   doc: \<DOC>
   Distance between the photo symbol arrows (pointing at the body)
   <DOC>
-  arrow-pitch:Double with: (
+  arrow-pitch:Double with:
     ensure => ensure-positive!
     default => DEF_PHOTO_ARR_PITCH
     updater => sub-arrow-pitch
-  )
   doc: \<DOC>
   Angle of the arrows with respect to the X-axis in Degrees
   <DOC>
-  arrow-angle:Double with: (
+  arrow-angle:Double with:
     ensure => ensure-positive!
     default => DEF_PHOTO_ARR_ANGLE
     updater => sub-arrow-angle
-  )
 with:
-  constructor => #PhotoResistorSymbolParams
+  keyword-constructor => true
   equalable => true
   printer => true
-
-public defn PhotoResistorSymbolParams (
-  --
-  res-params:ResistorSymbolParams = ?
-  arrow-params:ArrowSymbolParams = ?,
-  arrow-margin:Double = DEF_PHOTO_ARR_MARGIN
-  arrow-pitch:Double = DEF_PHOTO_ARR_PITCH
-  arrow-angle:Double = DEF_PHOTO_ARR_ANGLE
-  ) -> PhotoResistorSymbolParams :
-  #PhotoResistorSymbolParams(res-params, arrow-params, arrow-margin, arrow-pitch, arrow-angle)
 
 
 var DEF_PHOTO_RESISTOR_PARAMS = PhotoResistorSymbolParams()
@@ -432,15 +430,30 @@ public defstruct PhotoResistorSymbol <: TwoPinSymbol :
   pitch:Double with:
     as-method => true
     default => TWO_PIN_DEF_PITCH
+  doc: \<DOC>
+  Indicates whether the symbol will use c/a style pins
+
+  This is typically not used in resistors because they
+  are not polarized - but it is part of the TwoPinSymbol
+  definition. The default is `false`.
+  <DOC>
   polarized?:True|False with:
     as-method => true
     default => false
-with:
-  printer => true
-  constructor => #PhotoResistorSymbol
+  doc: \<DOC>
+  Optional Override Parameters for Photo Resistor Glyph
 
-public defn PhotoResistorSymbol (pitch:Double = TWO_PIN_DEF_PITCH) -> PhotoResistorSymbol:
-  #PhotoResistorSymbol(pitch, false)
+  This value can be used to override the resistor glyph
+  parameters and replace them with custom parameters.
+  This value is by default `None()` which will cause
+  {@link get-default-photo-resistor-symbol-params} to be
+  consulted for parameters when the symbol is built.
+  <DOC>
+  params:Maybe<PhotoResistorSymbolParams> with:
+    default => None()
+with:
+  keyword-constructor => true
+  printer => true
 
 public defmethod name (x:PhotoResistorSymbol) -> String :
   "Photo-Resistor"
@@ -451,13 +464,8 @@ public defn build-photo-resistor-glyphs (
   x:PhotoResistorSymbolParams
   ) :
 
-  val p = match(res-params?(x)):
-    (_:None): get-default-resistor-symbol-params()
-    (def-p:One<ResistorSymbolParams>): value(def-p)
-
-  val arrow-params = match(arrow-params?(x)):
-    (_:None): get-default-arrow-symbol-params()
-    (p:One<ArrowSymbolParams>): value(p)
+  val p = value-or-else(res-params?(x), get-default-resistor-symbol-params)
+  val arrow-params = value-or-else(arrow-params?(x), get-default-arrow-symbol-params)
 
   build-resistor-glyphs(sn, pitch, p)
 
@@ -473,10 +481,13 @@ public defn build-photo-resistor-glyphs (
   val arrow-2 = loc(Point(amp + margin, (- y-offset)), angle) * arrow-sh
   add-glyph(sn, arrow-2, name? = One("arrow-2"))
 
+defn get-params (x:PhotoResistorSymbol) -> PhotoResistorSymbolParams:
+  value-or-else(params(x), get-default-photo-resistor-symbol-params)
+
 public defmethod build-artwork (
   x:PhotoResistorSymbol, sn:SymbolNode
   ):
-  val p = get-default-photo-resistor-symbol-params()
+  val p = get-params(x)
   build-photo-resistor-glyphs(sn, pitch(x), p)
 
 

--- a/stanza.proj
+++ b/stanza.proj
@@ -1,5 +1,15 @@
+include? ".slm/stanza.proj"  ; Dependencies
+pkg-cache: ".slm/pkg-cache"
+
 packages jsl/* defined-in "./src/"
 
 packages jsl/tests/* defined-in "./tests/"
 packages jsl/tests/landpatterns/* defined-in "./tests/landpatterns/"
 packages jsl/examples/* defined-in "./examples/"
+
+; This target's only purpose is to allow a target that
+;  SLM can build to drive the dependency resolution.
+build fetch-deps:
+    inputs:
+        jsl/tests/math
+    o: "quadand"


### PR DESCRIPTION
This makes some improvements to the resistor and capacitor symbol generator code. 

I've also fixed a bug in the polarized capacitor rendering: 

Broken:
![Screenshot 2024-09-12 155854](https://github.com/user-attachments/assets/82de9a5b-57d9-40f1-90b0-dae2cb8a6351)

Now Fixed
![Screenshot 2024-09-12 155909](https://github.com/user-attachments/assets/f9be69b9-449a-4dea-8841-e9b4aa7b0dd3)
