### PR TITLE
Added a thermal pad generator with paste subdivision

### DIFF
--- a/examples/landpatterns/QFN.stanza
+++ b/examples/landpatterns/QFN.stanza
@@ -74,7 +74,7 @@ pcb-component test-QFN:
       lead-length = 0.4 +/- 0.05,
       lead-width = 0.25 +/- 0.05
     ),
-    thermal-lead? = Rectangle(3.7, 3.7),
+    thermal-lead? = ThermalPad(Rectangle(3.7, 3.7), padding = 0.25),
     package-body = PackageBody(
       width = 5.0 +/- 0.05,
       length = 5.0 +/- 0.05,

--- a/examples/landpatterns/SOP.stanza
+++ b/examples/landpatterns/SOP.stanza
@@ -22,7 +22,7 @@ defn create-PWP0014A ():
         width = min-max(0.19, 0.3)
       )
     ),
-    thermal-lead? = Rectangle(3.155, 3.255),
+    thermal-lead? = ThermalPad(Rectangle(3.155, 3.255), padding = 0.25),
     package-body = PackageBody(
       width = min-max(4.3, 4.5)
       length = min-max(4.9, 5.1)

--- a/src/landpatterns/QFN.stanza
+++ b/src/landpatterns/QFN.stanza
@@ -80,7 +80,7 @@ public defstruct QFN <: Quad-Package :
   doc: \<DOC>
   Optional thermal lead for the package.
   <DOC>
-  thermal-lead?:False|Shape with:
+  thermal-lead?:False|Shape|ThermalPad with:
     as-method => true
 
   doc: \<DOC>
@@ -123,7 +123,7 @@ public defn QFN (
   --
   num-leads:Int,
   lead-profile:Quad-Lead-Profile,
-  thermal-lead?:False|Shape,
+  thermal-lead?:False|Shape|ThermalPad,
   package-body:PackageBody,
   pad-planner:PadPlanner = RectanglePadPlanner,
   lead-numbering:Numbering = select-quad-numbering(num-leads, lead-profile),

--- a/src/landpatterns/QFN.stanza
+++ b/src/landpatterns/QFN.stanza
@@ -15,18 +15,15 @@ doc: \<DOC>
 QFN Lead Type
 <DOC>
 public defstruct QFN-Lead <: SMT-Lead:
-  lead-type:LeadProtrusion with: (
-      as-method => true,
-      default => QuadFlatNoLeads(),
-    )
-  length:Toleranced with: (
-    as-method => true,
+  lead-type:LeadProtrusion with:
+      as-method => true
+      default => QuadFlatNoLeads()
+  length:Toleranced with:
+    as-method => true
     ensure => ensure-positive!
-    )
-  width:Toleranced with: (
-    as-method => true,
+  width:Toleranced with:
+    as-method => true
     ensure => ensure-positive!
-    )
 with:
   equalable => true
   hashable => true
@@ -68,7 +65,9 @@ public defstruct QFN <: Quad-Package :
   doc: \<DOC>
   Number of leads ignoring any depopulated leads and thermal leads
   <DOC>
-  num-leads:Int with: (ensure => ensure-even-positive!, as-method => true)
+  num-leads:Int with:
+    ensure => ensure-even-positive!
+    as-method => true
 
   doc: \<DOC>
   Lead Profiles for all of the QFN's edges
@@ -76,16 +75,19 @@ public defstruct QFN <: Quad-Package :
   By default the QFN uses the {@link QuadFlatNoLeads} protrusion
   type by default.
   <DOC>
-  lead-profile:Quad-Lead-Profile with: (as-method => true)
+  lead-profile:Quad-Lead-Profile with:
+    as-method => true
   doc: \<DOC>
   Optional thermal lead for the package.
   <DOC>
-  thermal-lead?:False|Shape with: (as-method => true)
+  thermal-lead?:False|Shape with:
+    as-method => true
 
   doc: \<DOC>
   Package Body for the Quad-based Package.
   <DOC>
-  package-body:PackageBody with: (as-method => true)
+  package-body:PackageBody with:
+    as-method => true
 
   doc: \<DOC>
   Pad Planner for the Quad package
@@ -95,7 +97,8 @@ public defstruct QFN <: Quad-Package :
   all positions. The user can override this with their preferred
   shape as desired.
   <DOC>
-  pad-planner:PadPlanner with: (as-method => true)
+  pad-planner:PadPlanner with:
+    as-method => true
 
   doc: \<DOC>
   Lead Numbering Scheme for the Quad Package
@@ -103,12 +106,14 @@ public defstruct QFN <: Quad-Package :
   This provides a numbering scheme for the leads of the Quad
   package. By default, it uses {@link Column-Major-Numbering}.
   <DOC>
-  lead-numbering:Numbering with: (as-method => true)
+  lead-numbering:Numbering with:
+    as-method => true
 
   doc: \<DOC>
   Density Level for the Generated Package
   <DOC>
-  density-level:DensityLevel with: (as-method => true)
+  density-level:DensityLevel with:
+    as-method => true
 
 with:
   printer => true

--- a/src/landpatterns/QFP.stanza
+++ b/src/landpatterns/QFP.stanza
@@ -118,7 +118,7 @@ public defstruct QFP <: Quad-Package :
   doc: \<DOC>
   Optional thermal lead for the package.
   <DOC>
-  thermal-lead?:False|Shape with:
+  thermal-lead?:False|Shape|ThermalPad with:
     as-method => true
 
   doc: \<DOC>
@@ -167,7 +167,7 @@ public defn QFP (
   --
   num-leads:Int,
   lead-profile:Quad-Lead-Profile,
-  thermal-lead?:False|Shape,
+  thermal-lead?:False|Shape|ThermalPad,
   package-body:PackageBody,
   pad-planner:PadPlanner = RectanglePadPlanner,
   lead-numbering:Numbering = select-quad-numbering(num-leads, lead-profile),

--- a/src/landpatterns/QFP.stanza
+++ b/src/landpatterns/QFP.stanza
@@ -24,18 +24,15 @@ public defstruct QFP-Lead <: SMT-Lead:
   the lead-type {@link SmallGullWingLeads} should be
   considered.
   <DOC>
-  lead-type:LeadProtrusion with: (
-      as-method => true,
-      default => BigGullWingLeads(),
-    )
-  length:Toleranced with: (
-    as-method => true,
+  lead-type:LeadProtrusion with:
+      as-method => true
+      default => BigGullWingLeads()
+  length:Toleranced with:
+    as-method => true
     ensure => ensure-positive!
-    )
-  width:Toleranced with: (
-    as-method => true,
+  width:Toleranced with:
+    as-method => true
     ensure => ensure-positive!
-    )
 with:
   equalable => true
   hashable => true

--- a/src/landpatterns/SOIC.stanza
+++ b/src/landpatterns/SOIC.stanza
@@ -52,20 +52,17 @@ public defstruct SOIC-Lead <: SMT-Lead:
   the lead-type {@link SmallGullWingLeads} should be
   considered.
   <DOC>
-  lead-type:LeadProtrusion with: (
-      as-method => true,
-      default => BigGullWingLeads(),
-    )
-  length:Toleranced with: (
-    as-method => true,
-    default => min-max(0.4, 1.27),
+  lead-type:LeadProtrusion with:
+      as-method => true
+      default => BigGullWingLeads()
+  length:Toleranced with:
+    as-method => true
+    default => min-max(0.4, 1.27)
     ensure => ensure-positive!
-    )
-  width:Toleranced with: (
-    as-method => true,
-    default => min-max(0.31, 0.51),
+  width:Toleranced with:
+    as-method => true
+    default => min-max(0.31, 0.51)
     ensure => ensure-positive!
-    )
 with:
   equalable => true
   hashable => true
@@ -125,28 +122,31 @@ public defstruct SOIC <: Dual-Package :
   doc: \<DOC>
   Total Number of Leads - excluding the thermal pad.
   <DOC>
-  num-leads: Int with: (
-    ensure => ensure-even-positive!,
+  num-leads: Int with:
+    ensure => ensure-even-positive!
     as-method => true
-  )
+
   doc: \<DOC>
   Lead Profile for the pins on the opposing edges of the SOIC package.
   By default the {@link SOIC-Lead} type is used for the `lead` and
   `protrusion` definitions.
   <DOC>
-  lead-profile:Lead-Profile with: (as-method => true)
+  lead-profile:Lead-Profile with:
+    as-method => true
 
   doc: \<DOC>
   Specify the presence and shape of the exposed thermal lead (pad)
   on the bottom side of the package body.
   If `false` - then no thermal pad is created.
   <DOC>
-  thermal-lead?:False|Shape with: (as-method => true)
+  thermal-lead?:False|Shape with:
+    as-method => true
 
   doc: \<DOC>
   Package Body for the SOIC.
   <DOC>
-  package-body:PackageBody with: (as-method => true)
+  package-body:PackageBody with:
+    as-method => true
 
   doc: \<DOC>
   Pad Planner for the SOIC package
@@ -156,7 +156,8 @@ public defstruct SOIC <: Dual-Package :
   all positions. The user can override this with their preferred
   shape as desired.
   <DOC>
-  pad-planner:PadPlanner with: (as-method => true)
+  pad-planner:PadPlanner with:
+    as-method => true
 
   doc: \<DOC>
   Lead Numbering Scheme for the SOIC Package
@@ -164,12 +165,14 @@ public defstruct SOIC <: Dual-Package :
   This provides a numbering scheme for the leads of the SOIC
   package. By default, it uses {@link Std-IC-Numbering}.
   <DOC>
-  lead-numbering:Numbering with: (as-method => true)
+  lead-numbering:Numbering with:
+    as-method => true
 
   doc: \<DOC>
   Density Level for the Generated Package
   <DOC>
-  density-level:DensityLevel with: (as-method => true)
+  density-level:DensityLevel with:
+    as-method => true
 with:
   hashable => true
   printer => true

--- a/src/landpatterns/SOIC.stanza
+++ b/src/landpatterns/SOIC.stanza
@@ -139,7 +139,7 @@ public defstruct SOIC <: Dual-Package :
   on the bottom side of the package body.
   If `false` - then no thermal pad is created.
   <DOC>
-  thermal-lead?:False|Shape with:
+  thermal-lead?:False|Shape|ThermalPad with:
     as-method => true
 
   doc: \<DOC>
@@ -192,7 +192,7 @@ public defn SOIC (
   package-body:PackageBody,
   pitch:Double                   = SOIC-DEF-PITCH,
   lead:SMT-Lead,                 = SOIC-Lead(),
-  thermal-lead?:False|Shape      = false,
+  thermal-lead?:False|Shape|ThermalPad = false,
   pad-planner:PadPlanner         = SOIC-DEF-PAD-PLANNER,
   num-scheme:Numbering           = SOIC-DEF-NUM-SCHEME(num-leads),
   density-level:DensityLevel     = DENSITY-LEVEL
@@ -219,7 +219,7 @@ public defn SOIC-N (
   package-body:PackageBody       = make-SOIC-narrow-body(package-length),
   pitch:Double                   = SOIC-DEF-PITCH,
   lead:SOIC-Lead                 = SOIC-Lead(),
-  thermal-lead?:False|Shape      = false,
+  thermal-lead?:False|Shape|ThermalPad = false,
   pad-planner:PadPlanner         = SOIC-DEF-PAD-PLANNER,
   num-scheme:Numbering           = SOIC-DEF-NUM-SCHEME(num-leads),
   density-level:DensityLevel     = DENSITY-LEVEL
@@ -246,7 +246,7 @@ public defn SOIC-W (
   package-body:PackageBody       = make-SOIC-wide-body(package-length)
   pitch:Double                   = SOIC-DEF-PITCH,
   lead:SOIC-Lead                 = SOIC-Lead(),
-  thermal-lead?:False|Shape      = false,
+  thermal-lead?:False|Shape|ThermalPad = false,
   pad-planner:PadPlanner         = SOIC-DEF-PAD-PLANNER,
   num-scheme:Numbering           = SOIC-DEF-NUM-SCHEME(num-leads),
   density-level:DensityLevel     = DENSITY-LEVEL

--- a/src/landpatterns/SON.stanza
+++ b/src/landpatterns/SON.stanza
@@ -91,7 +91,7 @@ public defstruct SON <: Dual-Package :
   on the bottom side of the package body.
   If `false` - then no thermal pad is created.
   <DOC>
-  thermal-lead?:False|Shape with:
+  thermal-lead?:False|Shape|ThermalPad with:
     as-method => true
   doc: \<DOC>
   Package Body for the SON.
@@ -148,7 +148,7 @@ public defn SON (
   --
   num-leads:Int,
   lead-profile:Lead-Profile,
-  thermal-lead?:False|Shape      = false,
+  thermal-lead?:False|Shape|ThermalPad = false,
   package-body:PackageBody,
   pad-planner:PadPlanner         = SON-DEF-PAD-PLANNER,
   num-scheme:Numbering           = SON-DEF-NUM-SCHEME(num-leads),

--- a/src/landpatterns/SOP.stanza
+++ b/src/landpatterns/SOP.stanza
@@ -76,7 +76,7 @@ public defstruct SOP <: Dual-Package :
   on the bottom side of the package body.
   If `false` - then no thermal pad is created.
   <DOC>
-  thermal-lead?:False|Shape with:
+  thermal-lead?:False|Shape|ThermalPad with:
     as-method => true
   doc: \<DOC>
   Package Body for the SOP.
@@ -133,7 +133,7 @@ public defn SOP (
   --
   num-leads:Int,
   lead-profile:Lead-Profile,
-  thermal-lead?:False|Shape      = false,
+  thermal-lead?:False|Shape|ThermalPad = false,
   package-body:PackageBody,
   pad-planner:PadPlanner         = SOP-DEF-PAD-PLANNER,
   num-scheme:Numbering           = SOP-DEF-NUM-SCHEME(num-leads),

--- a/src/landpatterns/SOT.stanza
+++ b/src/landpatterns/SOT.stanza
@@ -45,18 +45,15 @@ This type defines the parameters of each of the individual leads
 of the IC package. It is typically used with {@link Lead-Profile}
 <DOC>
 public defstruct SOT-Lead <: SMT-Lead:
-  lead-type:LeadProtrusion with: (
-      as-method => true,
-      default => SmallGullWingLeads(),
-    )
-  length:Toleranced with: (
-    as-method => true,
+  lead-type:LeadProtrusion with:
+      as-method => true
+      default => SmallGullWingLeads()
+  length:Toleranced with:
+    as-method => true
     ensure => ensure-positive!
-    )
-  width:Toleranced with: (
-    as-method => true,
+  width:Toleranced with:
+    as-method => true
     ensure => ensure-positive!
-    )
 with:
   equalable => true
   hashable => true
@@ -75,18 +72,15 @@ This supports packages like `SOT-23F` or `SOT538` which use a
 flat lead style instead of the Gull-Wing Lead style.
 <DOC>
 public defstruct SOTFL-Lead <: SMT-Lead:
-  lead-type:LeadProtrusion with: (
+  lead-type:LeadProtrusion with:
       as-method => true,
-      default => SmallOutlineFlatLeads(),
-    )
-  length:Toleranced with: (
-    as-method => true,
+      default => SmallOutlineFlatLeads()
+  length:Toleranced with:
+    as-method => true
     ensure => ensure-positive!
-    )
-  width:Toleranced with: (
-    as-method => true,
+  width:Toleranced with:
+    as-method => true
     ensure => ensure-positive!
-    )
 with:
   equalable => true
   hashable => true
@@ -113,7 +107,7 @@ public defstruct SOT <: Dual-Package :
   Total Number of Leads - excluding the thermal pad.
   <DOC>
   num-leads: Int with:
-    ensure => ensure-even-positive!,
+    ensure => ensure-even-positive!
     as-method => true
 
   doc: \<DOC>

--- a/src/landpatterns/SOT.stanza
+++ b/src/landpatterns/SOT.stanza
@@ -123,7 +123,7 @@ public defstruct SOT <: Dual-Package :
   Thisi lead is generally on the bottom side of the package body.
   The default value for SOT is false as it isn't common in most packages.
   <DOC>
-  thermal-lead?:False|Shape with:
+  thermal-lead?:False|Shape|ThermalPad with:
     as-method => true
     default => false
 
@@ -169,7 +169,7 @@ public defn SOT (
   --
   num-leads:Int,
   lead-profile:Lead-Profile,
-  thermal-lead?:False|Shape      = false,
+  thermal-lead?:False|Shape|ThermalPad = false,
   package-body:PackageBody,
   pad-planner:PadPlanner         = SOT-DEF-PAD-PLANNER,
   num-scheme:Numbering           = SOT-DEF-NUM-SCHEME(num-leads),
@@ -270,7 +270,7 @@ public defstruct SOT-23-3 <: SOT :
   Thisi lead is generally on the bottom side of the package body.
   The default value for SOT is false as it isn't common in most packages.
   <DOC>
-  thermal-lead?:False|Shape with:
+  thermal-lead?:False|Shape|ThermalPad with:
     as-method => true
     default => false
 

--- a/src/landpatterns/VirtualLP.stanza
+++ b/src/landpatterns/VirtualLP.stanza
@@ -9,6 +9,7 @@ defpackage jsl/landpatterns/VirtualLP:
   import jsl/design/Classable
   import jsl/geometry/box
   import jsl/landpatterns/courtyard
+  import jsl/landpatterns/thermal-pads
 
 doc: \<DOC>
 Base Type for the Elements of the Virtual Landpattern Tree
@@ -75,6 +76,7 @@ public defn build-vpad-classes (r:Int, c:Int) -> Tuple<String> :
     to-string("col-%_" % [c]),
     to-string("row-%_" % [r])
   ]
+
 
 
 public defn print-pads (o:OutputStream, pds:Seqable<VirtualPad> ) :
@@ -483,6 +485,38 @@ public defn add-keepout (
     for s in shapes seq :
       VirtualArtwork(ForbidCopper(start, end), s, name? = name, class = class)
   append-all(vp, new-kos)
+
+
+doc: \<DOC>
+Add a Thermal Pad to the Virtual LandPattern Scene Graph
+
+@param vp Scene Graph
+@param pad-id Pad Id for this thermal pad - this is used in the
+`pin-properties` mapping of the `pcb-component` to map symbol pin
+to landpattern pad.
+@param thermal-lead? Thermal Lead Object Definition.
+If `False` - this function does nothing.
+If `Shape` - then we construct a `ThermalPad` with no special
+handling.
+Otherwise, we use the `ThermalPad` to construct a large thermal
+pad with optional paste subdivision etc. and add it to the
+passed scenegraph.
+<DOC>
+public defn add-thermal-pad (
+  vp:VirtualLP, pad-id:Int|Ref, thermal-lead?:False|Shape|ThermalPad,
+  --
+  pose:Pose = loc(0.0, 0.0)
+  ):
+  if thermal-lead? is-not False:
+    val tp = match(thermal-lead?):
+      (lead-shape:Shape):
+        ThermalPad(shape = lead-shape)
+      (tp-obj:ThermalPad): tp-obj
+
+    val cls = ["pad", "thermal"]
+    val pd-def = smd-thermal-pad(tp)
+    append(vp, VirtualPad(pad-id, pd-def, pose, class = cls))
+
 
 doc: \<DOC>
 Create a reference designator in the current virtual landpattern

--- a/src/landpatterns/dual-row.stanza
+++ b/src/landpatterns/dual-row.stanza
@@ -39,7 +39,9 @@ provide the remaining methods to construct
 the landpattern, like `build-silkscreen`.
 <DOC>
 public defstruct Dual-Package <: Package :
-  num-leads:Int with: (ensure => ensure-even-positive!, as-method => true)
+  num-leads:Int with:
+    ensure => ensure-even-positive!
+    as-method => true
 
   doc: \<DOC>
   Lead Profile Defines the Configuration of leads on each edge
@@ -53,7 +55,8 @@ public defstruct Dual-Package <: Package :
   doc: \<DOC>
   Package Body for the Quad-based Package.
   <DOC>
-  package-body:PackageBody with: (as-method => true)
+  package-body:PackageBody with:
+    as-method => true
 
   doc: \<DOC>
   Pad Planner for the Quad package
@@ -63,7 +66,8 @@ public defstruct Dual-Package <: Package :
   all positions. The user can override this with their preferred
   shape as desired.
   <DOC>
-  pad-planner:PadPlanner with: (as-method => true)
+  pad-planner:PadPlanner with:
+    as-method => true
 
   doc: \<DOC>
   Lead Numbering Scheme for the Quad Package
@@ -71,12 +75,14 @@ public defstruct Dual-Package <: Package :
   This provides a numbering scheme for the leads of the Dual
   package. By default, it uses {@link Column-Major-Numbering}.
   <DOC>
-  lead-numbering:Numbering with: (as-method => true)
+  lead-numbering:Numbering with:
+    as-method => true
 
   doc: \<DOC>
   Density Level for the Generated Package
   <DOC>
-  density-level:DensityLevel with: (as-method => true)
+  density-level:DensityLevel with:
+    as-method => true
 
 with:
   printer => true

--- a/src/landpatterns/dual-row.stanza
+++ b/src/landpatterns/dual-row.stanza
@@ -23,6 +23,7 @@ defpackage jsl/landpatterns/dual-row:
   import jsl/landpatterns/VirtualLP
   import jsl/landpatterns/grid-planner
   import jsl/landpatterns/pad-grid
+  import jsl/landpatterns/thermal-pads
 
 public val DUAL-ROW-COLS = 2
 
@@ -50,7 +51,7 @@ public defstruct Dual-Package <: Package :
   doc: \<DOC>
   Optional thermal lead for the package.
   <DOC>
-  thermal-lead?:False|Shape
+  thermal-lead?:False|Shape|ThermalPad
 
   doc: \<DOC>
   Package Body for the Quad-based Package.
@@ -109,11 +110,9 @@ public defmethod build-pads (
 
   append-all(vp, pad-seq)
 
-  match(thermal-lead?(pkg)):
-    (lead-shape:Shape):
-      val cls = ["pad", "thermal"]
-      append(vp, VirtualPad(num-leads(pkg) + 1, smd-pad(lead-shape), loc(0.0, 0.0), class = cls))
-    (x:False): false
+  if thermal-lead?(pkg) is-not False:
+    add-thermal-pad(vp, num-leads(pkg) + 1, thermal-lead?(pkg))
+
 
 doc: \<DOC>
 Dual-Row Grid Planner

--- a/src/landpatterns/framework.stanza
+++ b/src/landpatterns/framework.stanza
@@ -24,3 +24,4 @@ defpackage jsl/landpatterns/framework:
   forward jsl/landpatterns/courtyard
   forward jsl/landpatterns/introspection
   forward jsl/landpatterns/pad-grid
+  forward jsl/landpatterns/thermal-pads

--- a/src/landpatterns/pads.stanza
+++ b/src/landpatterns/pads.stanza
@@ -118,7 +118,7 @@ public defn make-soldermask (mask-shape:Shape) :
     if pad-type(self) == TH:
       layer(SolderMask(Bottom)) = mask-shape
 
-defn get-default-soldermask-amount () -> Double :
+public defn get-default-soldermask-amount () -> Double :
   clearance(current-rules(), SolderMaskRegistration)
 
 doc: \<DOC>
@@ -627,14 +627,6 @@ public defn circle-smd-pad (
       to-shape-func(mask, pad-r, m, anchor),
       to-shape-func(paste, pad-r, m, anchor),
     )
-
-
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-; TODO - Add paste mask subdivision to
-;   keep paste mask coverage below some threshold.
-
 
 doc: \<DOC>
 Generate a Thermal Pad for a Package

--- a/src/landpatterns/quad.stanza
+++ b/src/landpatterns/quad.stanza
@@ -31,6 +31,7 @@ defpackage jsl/landpatterns/quad:
   import jsl/landpatterns/numbering
   import jsl/landpatterns/pad-planner
   import jsl/landpatterns/grid-planner
+  import jsl/landpatterns/thermal-pads
 
 public val QUAD-NUM-COLUMNS = 4
 
@@ -213,7 +214,7 @@ public defstruct Quad-Package <: Package :
   doc: \<DOC>
   Optional thermal lead for the package.
   <DOC>
-  thermal-lead?:False|Shape
+  thermal-lead?:False|Shape|ThermalPad
 
   doc: \<DOC>
   Package Body for the Quad-based Package.
@@ -255,7 +256,7 @@ public defn Quad-Package (
   --
   num-leads:Int,
   lead-profile:Quad-Lead-Profile,
-  thermal-lead?:False|Shape,
+  thermal-lead?:False|Shape|ThermalPad,
   package-body:PackageBody,
   pad-planner:PadPlanner = RectanglePadPlanner,
   lead-numbering:Numbering = select-quad-numbering(num-leads, lead-profile),
@@ -323,11 +324,9 @@ public defmethod build-pads (
 
   append-all(vp, gen-pad-info())
 
-  match(thermal-lead?(pkg)):
-    (lead-shape:Shape):
-      val cls = ["pad", "thermal"]
-      append(vp, VirtualPad(num-leads(pkg) + 1, smd-pad(lead-shape), loc(0.0, 0.0), class = cls))
-    (x:False): false
+  if thermal-lead?(pkg) is-not False:
+      add-thermal-pad(vp, num-leads(pkg) + 1, thermal-lead?(pkg))
+
 
 
 doc: \<DOC>

--- a/src/landpatterns/quad.stanza
+++ b/src/landpatterns/quad.stanza
@@ -51,9 +51,11 @@ See {@link select-quad-numbering} for more information.
 <DOC>
 public defstruct Quad-Lead-Profile <: Equalable & Hashable:
   x-leads : Lead-Profile
-  x-count : Maybe<Int> with: (ensure => ensure-positive!)
+  x-count : Maybe<Int> with:
+    ensure => ensure-positive!
   y-leads : Lead-Profile
-  y-count : Maybe<Int> with: (ensure => ensure-positive!)
+  y-count : Maybe<Int> with:
+    ensure => ensure-positive!
 with:
   equalable => true
   printer => true
@@ -200,7 +202,9 @@ public defstruct Quad-Package <: Package :
   doc: \<DOC>
   Number of leads ignoring any depopulated leads and thermal leads
   <DOC>
-  num-leads:Int with: (ensure => ensure-even-positive!, as-method => true)
+  num-leads:Int with:
+    ensure => ensure-even-positive!
+    as-method => true
 
   doc: \<DOC>
   Lead Profiles for All Edges of the Quad Package
@@ -214,7 +218,8 @@ public defstruct Quad-Package <: Package :
   doc: \<DOC>
   Package Body for the Quad-based Package.
   <DOC>
-  package-body:PackageBody with: (as-method => true)
+  package-body:PackageBody with:
+    as-method => true
 
   doc: \<DOC>
   Pad Planner for the Quad package
@@ -224,7 +229,8 @@ public defstruct Quad-Package <: Package :
   all positions. The user can override this with their preferred
   shape as desired.
   <DOC>
-  pad-planner:PadPlanner with: (as-method => true)
+  pad-planner:PadPlanner with:
+    as-method => true
 
   doc: \<DOC>
   Lead Numbering Scheme for the Quad Package
@@ -232,12 +238,14 @@ public defstruct Quad-Package <: Package :
   This provides a numbering scheme for the leads of the Quad
   package. By default, it uses {@link Column-Major-Numbering}.
   <DOC>
-  lead-numbering:Numbering with: (as-method => true)
+  lead-numbering:Numbering with:
+    as-method => true
 
   doc: \<DOC>
   Density Level for the Generated Package
   <DOC>
-  density-level:DensityLevel with: (as-method => true)
+  density-level:DensityLevel with:
+    as-method => true
 
 with:
   printer => true

--- a/src/landpatterns/thermal-pads.stanza
+++ b/src/landpatterns/thermal-pads.stanza
@@ -1,0 +1,198 @@
+#use-added-syntax(jitx)
+defpackage jsl/landpatterns/thermal-pads:
+  import core
+  import jitx
+  import jitx/commands
+
+  import maybe-utils
+
+  import jsl/errors
+  import jsl/landpatterns/pad-planner
+  import jsl/landpatterns/grid-planner
+  import jsl/landpatterns/pads
+
+doc: \<DOC>
+Paste Subdivision Generator
+
+This type is used to construct a grid of paste applications.
+This is typically used for large thermal pads associated with
+QFNs, QFPs, SOIC, TSSOP, etc for high power applications.
+
+The idea is to provide empty space for the excess
+solder paste to flow into during the phase transition
+of the solder material. This reduces short circuits
+and other assembly attrition.
+
+<DOC>
+public defstruct PasteSubdivision :
+  doc: \<DOC>
+  Paste Element Dimensions
+  This parameter determines the shape of the paste opening
+  elements in the grid. The user can either:
+  1.  Provide a static `Dims` object that is applied to all openings. This
+  is the most typical case.
+  2.  A function that converts the `GridPosition` to `Dims`. This allows for
+  variable sized openings in teh grid. (This is less common).
+  The `Dims` must be in units of mm.
+  <DOC>
+  elem-dims:Dims|(GridPosition -> Dims)
+  doc: \<DOC>
+  Paste Application Element Planner
+
+  This planner coordinates the shape and population
+  of paste elements in the grid.
+
+  By default this uses `RectanglePadPlanner`
+  <DOC>
+  elem-planner:PadPlanner with:
+    default => RectanglePadPlanner
+  doc: \<DOC>
+  Grid Structure for the Paste Elements
+  <DOC>
+  paste-grid:GridPlanner
+
+  ; TODO - I want to add a 'strict-no-overlap'
+  ;  flag that will cause this generator to check
+  ;  for any paste elements are overlapping/touching.
+  ;  We currently don't expose the intersection
+  ;  algorithms so we will have to wait for that.
+  ; doc: \<DOC>
+  ; Enable for the Strict No Overlap Detection Check
+
+  ; If this value is true - then the paste sub divider
+  ; will check that each paste element does not overlap
+  ; with any other element in the grid.
+
+  ; If an overlap is detected - then an exception is thrown.
+  ; <DOC>
+  ; strict-no-overlap:True|False with:
+  ;   default => true
+with:
+  printer => true
+  keyword-constructor => true
+
+
+doc: \<DOC>
+Create the paste application shape for the thermal pad
+
+@param p Parameters for the paste subdivider
+@return A `Union` shape of multiple elements. It is possible
+that these elements overlap.
+<DOC>
+public defn create-paste-subdivision (p:PasteSubdivision) -> Shape :
+  val ep = elem-planner(p)
+  val G = paste-grid(p)
+  val elem-gen = match(elem-dims(p)):
+    (elem:Dims): fn (x): elem
+    (elem-func): elem-func
+
+  Union $ for pos in grid(G) seq?:
+    val shaper? = shape-generator(ep, row(pos), column(pos))
+    match(shaper?):
+      (_:False): None()
+      (shaper):
+        val sh = shaper $ elem-gen(pos)
+        One $ (pose(pos) * sh)
+
+
+
+doc: \<DOC>
+Thermal Pad Generator
+This type is used to construct large thermal
+pads for land patterns like QFNs, TSSOPs, etc.
+<DOC>
+public defstruct ThermalPad :
+  doc: \<DOC>
+  Copper Shape for the Thermal Lead
+  Dimensions of this shape are in mm
+  <DOC>
+  shape:Shape
+
+  doc: \<DOC>
+  Optional override of the default soldermask expansion
+  This value is in mm and increases the soldermask opening
+  by `sm-expand` mm on each side of `shape`. For example,
+  the width of the soldermask opening will be `2 * sm-expand`
+  larger than the originating `shape`.
+  This value is allowed to be negative - but it is on the user to
+  make sure the generated opening is compatible with the package.
+  <DOC>
+  sm-expand:Maybe<Double> with:
+    default => None()
+
+  doc: \<DOC>
+  Optional Paste Subdivider
+
+  This object provides the information necessary to
+  subdivide the paste application into a grid of elements.
+
+  By default, this value is `None()`.
+  <DOC>
+  paste-subdiv:Maybe<PasteSubdivision> with:
+    default => None()
+with:
+  printer => true
+  keyword-constructor => true
+
+doc: \<DOC>
+Construct a thermal SMD `pcb-pad` definition
+@param tp Thermal Pad Specification
+@return The constructed `pcb-pad` definition we can use
+in our landpatterns.
+<DOC>
+public defn smd-thermal-pad (tp:ThermalPad) -> Pad:
+  val sm = value-or-else(sm-expand(tp), get-default-soldermask-amount)
+  val sh = shape(tp)
+  val paste = match(paste-subdiv(tp)):
+    (_:None): sh ; Replicate the copper shape
+    (given:One<PasteSubdivision>):
+      create-paste-subdivision $ value(given)
+  smd-pad(sh, expand(sh, sm), paste)
+
+
+doc: \<DOC>
+Create a thermal pad with a simple paste subdivision pattern.
+
+This is a helper routine for constructing the paste subdivision
+more easily.
+
+@param shape Rectangular shape for the thermal pad. General purpose
+shapes aren't allowed here so that we can make the math easier.
+@param padding Spacing in mm between paste openings and between the
+edge of the copper pad and the paste opening. The default
+value is 0.2mm.
+@param grid-size This function assumes a square grid and this value
+determines how many openings on each side of this grid. So a value
+of `3` would indicate a 3x3 grid with 9 openings. The default value
+is `2`.
+<DOC>
+public defn ThermalPad (shape:Rectangle -- padding:Double = 0.2, grid-size:Int = 2) -> ThermalPad:
+
+  val num-paddings = grid-size + 1
+  val padding-space = to-double(num-paddings) * padding
+
+  val elem-x = (width(shape) - padding-space) / to-double(grid-size)
+  val elem-y = (height(shape) - padding-space) / to-double(grid-size)
+
+  if (elem-x < 0.0) or (elem-y < 0.0):
+    throw $ ValueError("Invalid Thermal Pad Configuration - Padding Causes a Negative Opening Size")
+
+  val elem-pitch = Dims(
+    elem-x + padding,
+    elem-y + padding
+  )
+
+  ThermalPad(
+    shape = shape,
+    paste-subdiv = One $ PasteSubdivision(
+      elem-dims = Dims(elem-x, elem-y),
+      paste-grid = GridPlanner(
+        pitch = elem-pitch,
+        columns = grid-size,
+        rows = grid-size,
+        anchor = C
+      )
+    )
+  )
+
+  ;

--- a/src/landpatterns/thermal-pads.stanza
+++ b/src/landpatterns/thermal-pads.stanza
@@ -71,15 +71,38 @@ with:
   printer => true
   keyword-constructor => true
 
+doc: \<DOC>
+Create Paste SubDivision Shape
+
+This is the interface definition for the PasteSubdivision types.
+The user can override the default behavior of the subdivision
+generator by overriding this method in a derived class.
+
+@param p The `PasteSubdivision` object
+@return A Shape that will be applied to the thermal pad at the origin
+of the thermal pad. To create multiple non-contiguous shapes, use the
+`Union` shape type.
+<DOC>
+public defmulti create-paste-subdivision (p:PasteSubdivision) -> Shape
 
 doc: \<DOC>
-Create the paste application shape for the thermal pad
+Default paste application shape for the thermal pad
+
+The default implementation constructs a grid of elements
+based on the `PasteSubdivision` parameters.
+
+The `GridPlanner` is used to construct the grid shape.
+This implementation uses a limited subset of `PadPlanner` to
+provide:
+
+1.  Which grid locations are active.
+2.  The shape at each of those grid locations.
 
 @param p Parameters for the paste subdivider
 @return A `Union` shape of multiple elements. It is possible
 that these elements overlap.
 <DOC>
-public defn create-paste-subdivision (p:PasteSubdivision) -> Shape :
+public defmethod create-paste-subdivision (p:PasteSubdivision) -> Shape :
   val ep = elem-planner(p)
   val G = paste-grid(p)
   val elem-gen = match(elem-dims(p)):


### PR DESCRIPTION
This adds a new generator implementation allows for the paste application to be subdivided: 

![Screenshot 2024-09-19 111708](https://github.com/user-attachments/assets/8ea720a0-68b0-49a7-856d-57324c0f5c72)
![Screenshot 2024-09-19 115148](https://github.com/user-attachments/assets/ac70223f-8aaa-42b1-99fb-85473d38b324)

It is a little hard to see - but the faint white squares in the thermal pad are where I'm subdividing the paste mask.

The generator is fully generalized and uses the same `PadPlanner` and `GridPlanner` implementations for the pad construction. 

This is also the place where we can add custom soldermask pattern handling in the future.