### PR TITLE
Updates to the Silkscreen Generation

### DIFF
--- a/examples/landpatterns/SMT.stanza
+++ b/examples/landpatterns/SMT.stanza
@@ -77,7 +77,16 @@ pcb-module test-design:
   place(C2) at loc(2.5, 0.0) on Top
 
   inst C3 : test-SMT("0402")
+  ; place(C3) at loc(0.0, 0.0) on Top
   inst C4 : test-SMT-pol("0402")
+
+  inst C5 : test-SMT("0603")
+  inst C6 : test-SMT-pol("0603")
+
+  inst C7 : test-SMT("0805")
+  inst C8 : test-SMT-pol("0805")
+
+
 
 ; Set the top level module (the module to be compile into a schematic and PCB)
 set-current-design("SMT-TEST")

--- a/examples/landpatterns/SMT.stanza
+++ b/examples/landpatterns/SMT.stanza
@@ -25,7 +25,20 @@ pcb-symbol test-sym:
     number-size = 0.762
     name-size = 0.762
 
-pcb-component test-SMT:
+pcb-symbol test-sym-pol:
+  pin a at Point(-2.54, 2.54) with :
+    direction = Left
+    length = 2.54
+    number-size = 0.762
+    name-size = 0.762
+
+  pin c at Point(-2.54, 0.0) with :
+    direction = Left
+    length = 2.54
+    number-size = 0.762
+    name-size = 0.762
+
+pcb-component test-SMT (case:String):
 
   pin-properties :
     [pin:Ref | pads:Ref ... | side:Dir | bank:Int]
@@ -33,21 +46,38 @@ pcb-component test-SMT:
     [p[2] | p[2] | Down | 0]
 
   assign-symbol(test-sym)
-  val chip-def = chips["1206"]
-  val pkg = SMT-Chip(
-    chip-def,
-    density-level = DensityLevelC
-  )
-
-  ; val pkg = get-chip-pkg("1210", DensityLevelB)
+  val pkg = get-resistor-pkg(case, DensityLevelC)
 
   val lp = create-landpattern(pkg)
   assign-landpattern(lp)
 
-pcb-module test-design:
-  inst c : test-SMT
-  place(c) at loc(0.0, 0.0) on Top
+pcb-component test-SMT-pol (case:String):
+  pin-properties :
+    [pin:Ref | pads:Ref ... | side:Dir | bank:Int]
+    [a | a | Up |  0]
+    [c | c | Down | 0]
 
+  assign-symbol(test-sym-pol)
+
+  val chip-def = get-chip-def(case)
+  val pkg = SMT-Capacitor(
+    chip-def,
+    polarized? = true
+    density-level = DensityLevelC
+  )
+  val lp = create-landpattern(pkg)
+  assign-landpattern(lp)
+
+
+pcb-module test-design:
+  inst C1 : test-SMT("1206")
+  place(C1) at loc(0.0, 0.0) on Top
+
+  inst C2 : test-SMT-pol("1206")
+  place(C2) at loc(2.5, 0.0) on Top
+
+  inst C3 : test-SMT("0402")
+  inst C4 : test-SMT-pol("0402")
 
 ; Set the top level module (the module to be compile into a schematic and PCB)
 set-current-design("SMT-TEST")

--- a/src/landpatterns/BGA/package.stanza
+++ b/src/landpatterns/BGA/package.stanza
@@ -198,7 +198,8 @@ public defn compute-overall-outline (
 
   val pkg-outline = bounds $ envelope(body, density-level = density-level)
   val lp-pads = get-pads(vp)
-  val pad-outline = bounds(lp-pads, layer-spec = SolderMask(Top))
+  val pad-outline* = bounds(lp-pads, layer-spec = SolderMask(Top))
+  val pad-outline = fatten(mask-clearance + (line-width / 2.0), pad-outline*)
   val overall = union(pkg-outline, pad-outline)
   LineRectangle(overall, line-width = line-width)
 

--- a/src/landpatterns/QFP.stanza
+++ b/src/landpatterns/QFP.stanza
@@ -202,62 +202,15 @@ public defmethod courtyard-excess (pkg:QFP) -> Double :
   val fillets = lead-fillets(protrusion, density-level = density-level(pkg))
   courtyard-excess(fillets)
 
-; Compute the Box bounding the _interior_ of the pads
-; Only works on rectangular landpatterns
-; Is there a less ugly way to do this?
-defn pad-interior-bounds (vp:VirtualLP, side:Side) :
-  val xset = HashSet<Double>()
-  val yset = HashSet<Double>()
-  ; Collect all x- and y-coordinates from pads
-  for p in get-pads(vp) :
-    val bx = bounds([p], layer-spec = SolderMask(side))
-    add(xset, x(lo(bx)))
-    add(xset, x(hi(bx)))
-    add(yset, y(lo(bx)))
-    add(yset, y(hi(bx)))
-  val xs = qsort $ to-tuple(xset)
-  val ys = qsort $ to-tuple(yset)
-  val lo = Point(xs[1], ys[1])
-  val hi = Point(xs[length(xs) - 2], ys[length(ys) - 2])
-  Box(lo, hi)
-
-public defn QFP-pkg-outline (
-  pkg:QFP,
-  vp:VirtualLP
-  --
-  line-width:Double,
-  mask-clearance:Double,
-  side:Side = Top
-  ):
-  val pkg-body = package-body(pkg)
-  ; Package bounding box
-  val pkg-outline = bounds $ envelope(pkg-body, density-level = density-level(pkg))
-  ; Interior outline of pads; shrunk by soldermask-clearance
-  val pad-interior = shrink(mask-clearance + line-width / 2.0, pad-interior-bounds(vp, side))
-  ; Select smaller box
-  val pkg-outline* =
-    if area(pkg-outline) < area(pad-interior) : pkg-outline
-    else : pad-interior
-  LineRectangle(pkg-outline*, line-width = line-width)
-
-public defn QFP-outline (
-  pkg:QFP,
-  vp:VirtualLP
-  --
-  line-width:Double = default-silk-width(),
-  mask-clearance:Double = default-mask-clearance(),
-  side:Side = Top
-  ):
-  val outline-geom =
-    QFP-pkg-outline(pkg, vp, line-width = line-width, mask-clearance = mask-clearance, side = side)
-
-  add-artwork(vp, Silkscreen("outline", side), outline-geom, class = "outline")
-
 public defmethod build-silkscreen (
   pkg:QFP,
   vp:VirtualLP
   ) -> False:
-  QFP-outline(pkg, vp)
+
+  val outline = InterstitialOutline(
+    pkg-body = package-body(pkg)
+  )
+  build-outline(outline, vp)
 
   build-smd-pin-1-dot(
       vp,

--- a/src/landpatterns/SOIC.stanza
+++ b/src/landpatterns/SOIC.stanza
@@ -282,9 +282,10 @@ public defmethod build-silkscreen (
   pkg:SOIC,
   vp:VirtualLP,
   ) -> False :
-  create-silkscreen-pkg-extrema-outline(
-    vp, package-body(pkg),
+  val eo = EdgesOutline(
+    pkg-body = package-body(pkg),
     density-level = density-level(pkg)
   )
+  build-outline(eo, vp)
   build-smd-pin-1-dot(vp, dir = Left)
   add-reference-designator(vp)

--- a/src/landpatterns/SON.stanza
+++ b/src/landpatterns/SON.stanza
@@ -188,10 +188,11 @@ public defmethod build-silkscreen (
   pkg:SON,
   vp:VirtualLP
   ) -> False:
-  create-silkscreen-pkg-extrema-outline(
-    vp, package-body(pkg),
+  val eo = EdgesOutline(
+    pkg-body = package-body(pkg),
     density-level = density-level(pkg)
   )
+  build-outline(eo, vp)
   build-smd-pin-1-dot(
     vp,
     dir = Left,

--- a/src/landpatterns/SOP.stanza
+++ b/src/landpatterns/SOP.stanza
@@ -173,10 +173,11 @@ public defmethod build-silkscreen (
   pkg:SOP,
   vp:VirtualLP
   ) -> False:
-  create-silkscreen-pkg-extrema-outline(
-    vp, package-body(pkg),
+  val eo = EdgesOutline(
+    pkg-body = package-body(pkg),
     density-level = density-level(pkg)
   )
+  build-outline(eo, vp)
   build-smd-pin-1-dot(
     vp,
     dir = Left,

--- a/src/landpatterns/SOT.stanza
+++ b/src/landpatterns/SOT.stanza
@@ -207,10 +207,11 @@ public defmethod build-silkscreen (
   pkg:SOT,
   vp:VirtualLP
   ) -> False:
-  create-silkscreen-pkg-extrema-outline(
-    vp, package-body(pkg),
+  val eo = EdgesOutline(
+    pkg-body = package-body(pkg),
     density-level = density-level(pkg)
   )
+  build-outline(eo, vp)
   build-smd-pin-1-dot(
     vp,
     dir = Left,

--- a/src/landpatterns/VirtualLP.stanza
+++ b/src/landpatterns/VirtualLP.stanza
@@ -413,6 +413,25 @@ public defn get-silkscreen-outline! (vp:VirtualLP) -> VirtualArtwork :
 
   outlines[0]
 
+doc: \<DOC>
+Retrieve the Silkscreen outline if present
+
+This function looks for a `VirtualArtwork` object with class `outline`.
+
+@param vp Virtual Landpattern SceneGraph
+@return  If no `outline` present, then this function returns `None()`
+If an artwork of class `outline` is present, we return one.
+@throws ValueError if multiple `outline` elements are found.
+<DOC>
+public defn get-silkscreen-outline (vp:VirtualLP) -> Maybe<VirtualArtwork> :
+  val outlines = to-tuple $ seq{as-VirtualArtwork, _} $ find-by-class(vp, "outline")
+  if length(outlines) == 0:
+    None()
+  else if length(outlines) > 1:
+    throw $ ValueError("Expected only one element in class 'outline': %," % [outlines])
+  else:
+    One $ outlines[0]
+
 public defn add-artwork (
   vp:VirtualLP,
   ls:LayerSpecifier,

--- a/src/landpatterns/VirtualLP.stanza
+++ b/src/landpatterns/VirtualLP.stanza
@@ -6,6 +6,7 @@ defpackage jsl/landpatterns/VirtualLP:
   import jitx/commands
 
   import jsl/errors
+  import jsl/ensure
   import jsl/design/Classable
   import jsl/geometry/box
   import jsl/landpatterns/courtyard
@@ -735,6 +736,68 @@ public defn find-by-class (vp:VirtualLP, cls:String) -> Seqable<VirtualElement> 
   val kid-elems = for child in children(vp) seq-cat:
     find-by-class(child, cls)
   cat(local-elems, kid-elems)
+
+defn identify-pad-row-col (vp:VirtualLP, prefix:String) -> Tuple<Int> :
+  val pad-elems = find-by-class(vp, "pad")
+  val found-indices = for pad-elem in pad-elems seq?:
+    val row-cls = for cls in class(pad-elem) first:
+      if prefix?(cls, prefix):
+        One(cls)
+      else:
+        None()
+    match(row-cls):
+      (_:None):
+        throw $ ValueError("Pad '%_' does not have a '%_*' class" % [pad-elem, prefix])
+        None()
+      (given:One<String>):
+        val index = last $ to-list $ split(value(given), "-")
+        match(to-int(index)):
+          (_:False): None()
+          (x:Int): One(x)
+
+  to-tuple $ unique(found-indices)
+
+doc: \<DOC>
+Identify the unique rows of pads in this land pattern
+@param vp VirtualLP SceneGraph
+@return Tuple of row indices. For example, a dual
+with 16 pins (2 x 8) will have 8 rows and 2 columns. This
+function will return 8.
+<DOC>
+public defn identify-pad-rows (vp:VirtualLP) -> Tuple<Int> :
+  identify-pad-row-col(vp, "row-")
+
+doc: \<DOC>
+Identify the unique columns of pads in this land pattern
+@param vp VirtualLP SceneGraph
+@return Tuple of row indices. For example, a square quad
+with 8 x 8 will have 8 rows and 4 columns. This function
+will return 4.
+<DOC>
+public defn identify-pad-columns (vp:VirtualLP) -> Tuple<Int> :
+  identify-pad-row-col(vp, "col-")
+
+doc: \<DOC>
+Retrieve the pads in the specified row
+@param vp VirtualLP SceneGraph
+@param row Identifies the row of pads to retrieve. Must be >= 0.
+@return Sequence of `VirtualPad` objects. If no row with
+index `row` is present, then an empty sequence will be provided.
+<DOC>
+public defn get-pads-by-row (vp:VirtualLP, row:Int) -> Seq<VirtualPad> :
+  ensure-non-negative!("row", row)
+  seq{as-VirtualPad, _} $ find-by-class(vp, to-string $ "row-%_" % [row])
+
+doc: \<DOC>
+Retrieve the pads in the specified column
+@param vp VirtualLP SceneGraph
+@param row Identifies the column of pads to retrieve. Must be >= 0.
+@return Sequence of `VirtualPad` objects. If no column with
+index `column` is present, then an empty sequence will be provided.
+<DOC>
+public defn get-pads-by-column (vp:VirtualLP, column:Int) -> Seq<VirtualPad> :
+  ensure-non-negative!("column", column)
+  seq{as-VirtualPad, _} $ find-by-class(vp, to-string $ "col-%_" % [column])
 
 doc: \<DOC>
 Find a virtual pad with the given reference

--- a/src/landpatterns/quad.stanza
+++ b/src/landpatterns/quad.stanza
@@ -315,11 +315,7 @@ public defmethod build-pads (
       match(pad-gen?):
         (_:False): None()
         (pad-gen):
-          val cls = [
-            "pad",
-            to-string("col-%_" % [c]),
-            to-string("row-%_" % [r])
-          ]
+          val cls = build-vpad-classes(r, c)
           One $ VirtualPad(pad-id, pad-gen(pad-size), pose(pos), class = cls)
 
   append-all(vp, gen-pad-info())

--- a/src/landpatterns/silkscreen.stanza
+++ b/src/landpatterns/silkscreen.stanza
@@ -606,8 +606,10 @@ public defn build-outline-pin-1-triangle (
 doc: \<DOC>
 Create a Pin 1 indicator as a round dot next to the pad
 
-This creates a small circle in the silkscreen directly
-above (+Y) the "pin 1" pad of a land pattern.
+By default This creates a small circle in the silkscreen directly
+above (+Y) the "pin 1" pad of a land pattern. You can use the
+`dir` option to place the marker in a different cardinal
+direction.
 
 This function assumes that the space directly above the
 pin 1 pad is available to place this circle.

--- a/src/landpatterns/silkscreen.stanza
+++ b/src/landpatterns/silkscreen.stanza
@@ -404,16 +404,16 @@ public defmethod build-shape (s:InteriorEdgesOutline, vp:VirtualLP -- side:Side 
   val pkg-outline = bounds $ envelope(pkg-body(s), density-level = density-level(s))
   ; Interior outline of pads; shrunk by soldermask-clearance
   val lw = line-width(s)
-  val pad-interior = pad-interior-bounds(vp, side)
-  val pad-interior* = try:
-     shrink(mask-clearance(s) + lw / 2.0, pad-interior)
+  val pad-interior = try:
+    compute-interior-pad-space(s, vp, side = side)
   catch (e:ValueError):
-    pad-interior
+    println("Not enough interior space for Edge Outline - Try SingleLineOutline")
+    throw(e)
 
   ; Select smaller box
   val pkg-outline* =
     if area(pkg-outline) < area(pad-interior) : pkg-outline
-    else : pad-interior*
+    else : pad-interior
 
   val [sw, se, ne, nw] = corners(pkg-outline*)
 
@@ -427,6 +427,67 @@ public defmethod build-shape (s:InteriorEdgesOutline, vp:VirtualLP -- side:Side 
 
   Union $ to-tuple $ for line-ep in line-eps seq:
     Line(lw, line-ep)
+
+defn compute-interior-pad-space (s:InteriorEdgesOutline, vp:VirtualLP -- side:Side = Top) -> Box :
+  val lw = line-width(s)
+  val pad-interior = pad-interior-bounds(vp, side)
+  shrink(mask-clearance(s) + lw / 2.0, pad-interior)
+
+public defn has-enough-interior-space? (s:InteriorEdgesOutline, vp:VirtualLP -- side:Side = Top) -> True|False:
+  try:
+    compute-interior-pad-space(s, vp, side = side)
+    true
+  catch (e:ValueError):
+    false
+
+public defstruct SingleLineOutline <: SilkscreenOutline :
+  doc: \<DOC>
+  Package Body Dimensions
+  These dimensions will be projected on to the board
+  to construct the outline.
+  <DOC>
+  pkg-body:PackageBody
+  edge:SilkscreenEdge with:
+    default => EW-Edge
+  doc: \<DOC>
+  Line Width for the constructed silkscreen outline
+  By default we use the `MinSilkscreenWidth` from the design rules.
+  <DOC>
+  line-width:Double with:
+    ensure => ensure-positive!
+    default => default-silk-width()
+  doc: \<DOC>
+  Clearance from silkscreen to the soldermask
+  By default we use the `MinSilkSolderMaskSpace` from the
+  design rules.
+  <DOC>
+  mask-clearance:Double with:
+    ensure => ensure-non-negative!
+    default => default-mask-clearance()
+  doc: \<DOC>
+  Density Level Specification
+  This determines whether we use:
+  *  Maximum Material Condition
+  *  Nominal Material Condition
+  *  Least Material Condition
+
+  of the package body to construct the outline.
+  <DOC>
+  density-level:DensityLevel with:
+    default => DENSITY-LEVEL
+with:
+  printer => true
+  keyword-constructor => true
+
+
+public defmethod build-shape (s:SingleLineOutline, vp:VirtualLP -- side:Side = Top) -> Shape :
+  val pkg-outline = bounds $ envelope(pkg-body(s), density-level = density-level(s))
+
+  switch(edge(s)):
+    NS-Edge:
+      Line(line-width(s), [Point(0.0, up(pkg-outline)), Point(0.0, down(pkg-outline))])
+    EW-Edge:
+      Line(line-width(s), [Point(left(pkg-outline), 0.0), Point(right(pkg-outline), 0.0)])
 
 doc: \<DOC>
 Compute the closest corner of the passed Box to the Pin1 position.

--- a/src/landpatterns/silkscreen.stanza
+++ b/src/landpatterns/silkscreen.stanza
@@ -952,4 +952,4 @@ public defn create-silkscreen-pkg-extrema-outline (
     mask-clearance = mask-clearance
     density-level = density-level
   )
-  build-outline(eo, vp, side = side)
+  build-shape(eo, vp, side = side)

--- a/src/landpatterns/silkscreen.stanza
+++ b/src/landpatterns/silkscreen.stanza
@@ -1,11 +1,13 @@
 #use-added-syntax(jitx)
 defpackage jsl/landpatterns/silkscreen:
   import core
+  import collections
   import math
   import jitx
   import jitx/commands
 
   import jsl/design/settings
+  import jsl/ensure
   import jsl/errors
   import jsl/geometry/box
   import jsl/geometry/LineRectangle
@@ -16,6 +18,415 @@ public defn default-silk-width () -> Double :
 
 public defn default-mask-clearance () -> Double :
   clearance(current-rules(), MinSilkSolderMaskSpace)
+
+doc: \<DOC>
+Base Type for Silkscreen Outline Generators
+
+The user should derive from this type and implement
+its interface to construct the silkscreen outline
+for a component.
+<DOC>
+public deftype SilkscreenOutline
+
+public defmulti build-shape (s:SilkscreenOutline, vp:VirtualLP -- side:Side = Top) -> Shape
+
+doc: \<DOC>
+Build Component Outline Silkscreen Content in VirtualLP
+
+This is the interface for the silkscreen outline generator
+function that will construct the silkscreen geometry in
+the `VirtualLP` scene graph.
+
+@param s Silkscreen Outline Object
+@param vp Virtual LandPattern Scene Graph. User can introspect
+the scene graph through this object then construct the
+appropriate new geometry.
+
+<DOC>
+public defmulti build-outline (s:SilkscreenOutline, vp:VirtualLP -- side:Side = Top)
+
+doc: \<DOC>
+Default Implementation for Build Component Outline
+
+This method uses the `build-shape` method to contruct the
+silkscreen content and then applies it to the VirtaulLP scene graph.
+<DOC>
+public defmethod build-outline (s:SilkscreenOutline, vp:VirtualLP -- side:Side = Top) :
+  val sh = build-shape(s, vp, side = side)
+  add-silkscreen-outline(vp, sh, side = side)
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Package Body Outline
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+doc: \<DOC>
+Silkscreen Outline Generator that follows the Package Body
+<DOC>
+public defstruct PackageOutline <: SilkscreenOutline :
+  doc: \<DOC>
+  Package Body Dimensions
+  These dimensions will be projected on to the board
+  to construct the outline.
+  <DOC>
+  pkg-body:PackageBody
+  doc: \<DOC>
+  Line Width for the constructed silkscreen outline
+  By default we use the `MinSilkscreenWidth` from the design rules.
+  <DOC>
+  line-width:Double with:
+    ensure => ensure-positive!
+    default => default-silk-width()
+  doc: \<DOC>
+  Clearance from silkscreen to the soldermask
+  By default we use the `MinSilkSolderMaskSpace` from the
+  design rules.
+  <DOC>
+  mask-clearance:Double with:
+    ensure => ensure-non-negative!
+    default => default-mask-clearance()
+  doc: \<DOC>
+  Density Level Specification
+  This determines whether we use:
+  *  Maximum Material Condition
+  *  Nominal Material Condition
+  *  Least Material Condition
+
+  of the package body to construct the outline.
+  <DOC>
+  density-level:DensityLevel with:
+    default => DENSITY-LEVEL
+with:
+  printer => true
+  keyword-constructor => true
+
+public defmethod build-shape (s:PackageOutline, vp:VirtualLP -- side:Side = Top) -> Shape :
+  val pkg-outline = bounds $ envelope(pkg-body(s), density-level = density-level(s))
+  val lw = line-width(s)
+  val pkg-outline* = fatten(lw / 2.0, pkg-outline)
+
+  ; TODO - I want to use `Difference` here will all of the soldermask openings
+  ;  defined by the pads.
+
+  LineRectangle(pkg-outline*, line-width = lw)
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Overall Outline
+
+public defstruct OverallOutline <: SilkscreenOutline :
+  doc: \<DOC>
+  Package Body Dimensions
+  These dimensions will be projected on to the board
+  to construct the outline.
+  <DOC>
+  pkg-body:PackageBody
+  doc: \<DOC>
+  Line Width for the constructed silkscreen outline
+  By default we use the `MinSilkscreenWidth` from the design rules.
+  <DOC>
+  line-width:Double with:
+    ensure => ensure-positive!
+    default => default-silk-width()
+  doc: \<DOC>
+  Clearance from silkscreen to the soldermask
+  By default we use the `MinSilkSolderMaskSpace` from the
+  design rules.
+  <DOC>
+  mask-clearance:Double with:
+    ensure => ensure-non-negative!
+    default => default-mask-clearance()
+  doc: \<DOC>
+  Density Level Specification
+  This determines whether we use:
+  *  Maximum Material Condition
+  *  Nominal Material Condition
+  *  Least Material Condition
+
+  of the package body to construct the outline.
+  <DOC>
+  density-level:DensityLevel with:
+    default => DENSITY-LEVEL
+with:
+  printer => true
+  keyword-constructor => true
+
+public defmethod build-shape (s:OverallOutline, vp:VirtualLP -- side:Side = Top ) -> Shape :
+  val pkg-outline = bounds $ envelope(pkg-body(s), density-level = density-level(s))
+  val pad-outline* = bounds(get-pads(vp), layer-spec = SolderMask(side))
+  val pad-outline = fatten(mask-clearance(s), pad-outline*)
+  val overall = union(pkg-outline, pad-outline)
+  val lw = line-width(s)
+  val overall* = fatten(lw / 2.0, overall)
+  LineRectangle(overall*, line-width = lw)
+
+
+doc: \<DOC>
+Create an interstitial silkscreen outline.
+
+The interstitial outline is formed between the
+pads, typically underneath the component package body.
+It may or may not be seen after the component has been
+installed.
+
+This is most useful for packages like QFP, SOIC, SSOP,
+and similar packages. It also works for 2-pin SMT
+and through-hole components.
+<DOC>
+public defstruct InterstitialOutline <: SilkscreenOutline :
+  doc: \<DOC>
+  Package Body Dimensions
+  These dimensions will be projected on to the board
+  to construct the outline.
+  <DOC>
+  pkg-body:PackageBody
+  doc: \<DOC>
+  Line Width for the constructed silkscreen outline
+  By default we use the `MinSilkscreenWidth` from the design rules.
+  <DOC>
+  line-width:Double with:
+    ensure => ensure-positive!
+    default => default-silk-width()
+  doc: \<DOC>
+  Clearance from silkscreen to the soldermask
+  By default we use the `MinSilkSolderMaskSpace` from the
+  design rules.
+  <DOC>
+  mask-clearance:Double with:
+    ensure => ensure-non-negative!
+    default => default-mask-clearance()
+
+  doc: \<DOC>
+  Density Level Specification
+  This determines whether we use:
+  *  Maximum Material Condition
+  *  Nominal Material Condition
+  *  Least Material Condition
+
+  of the package body to construct the outline.
+  <DOC>
+  density-level:DensityLevel with:
+    default => DENSITY-LEVEL
+with:
+  printer => true
+  keyword-constructor => true
+
+doc: \<DOC>
+Construct the interior bounds for the pads of a component
+
+This function only makes sense for things like QFPs, SOICs,
+SSOPs, or 2-pin components.
+
+This function assumes that you have used the function
+{@link build-vpad-classes} when constructing the rows and
+columns of pads for your footprint.
+
+This function attempts to extract out the pads by row
+or column and then use the bounding box of the soldermask
+to determine the interior bounds between the pads.
+
+Note - there is another way to do this that I decided against
+which was to try and find lines and intersections of those lines.
+This seemed like it might be a bit more robust but at the cost
+of being more complex code wise.
+
+@throws ValueError if it encounter a number of columns that it can't
+handle. Specifically, this function can handle [1, 2, 4] columns of pads.
+This corresponds to 2-pin, dual-row, and quad land patterns, respectively.
+<DOC>
+defn pad-interior-bounds (vp:VirtualLP, side:Side) -> Box:
+
+  val get-bounds = bounds{_, layer-spec = SolderMask(side)}
+  val cols = identify-pad-columns(vp)
+  val num-cols = length(cols)
+  if num-cols == 1:
+    ; This is a 2-pin component - ie a SMT, Radial or Axial
+    val row0 = get-bounds $ get-pads-by-row(vp, 0)
+    val row1 = get-bounds $ get-pads-by-row(vp, 1)
+
+    Box(
+      Point(left(row1), up(row1))
+      Point(right(row0), down(row0))
+    )
+
+  else if num-cols == 2 :
+    val col0 = get-bounds $ get-pads-by-column(vp, 0)
+    val col1 = get-bounds $ get-pads-by-column(vp, 1)
+
+    Box(
+      Point(right(col0), down(col0))
+      Point(left(col1), up(col1))
+      )
+  else if num-cols == 4 :
+
+    val col-W = get-bounds $ get-pads-by-column(vp, 0)
+    val col-S = get-bounds $ get-pads-by-column(vp, 1)
+    val col-E = get-bounds $ get-pads-by-column(vp, 2)
+    val col-N = get-bounds $ get-pads-by-column(vp, 3)
+
+    Box(
+      Point(right(col-W), up(col-S)),
+      Point(left(col-E), down(col-N))
+    )
+  else:
+    throw $ ValueError("Unhandled Number of Columns '%_' - Expected 1, 2, or 4" % [num-cols])
+
+
+public defmethod build-shape (s:InterstitialOutline, vp:VirtualLP -- side:Side = Top) -> Shape :
+  ; Package bounding box
+  val pkg-outline = bounds $ envelope(pkg-body(s), density-level = density-level(s))
+  ; Interior outline of pads; shrunk by soldermask-clearance
+  val lw = line-width(s)
+  val pad-interior = pad-interior-bounds(vp, side)
+  val pad-interior* = shrink(mask-clearance(s) + lw / 2.0, pad-interior)
+  ; Select smaller box
+  val pkg-outline* =
+    if area(pkg-outline) < area(pad-interior) : pkg-outline
+    else : pad-interior*
+  LineRectangle(pkg-outline*, line-width = lw)
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Extrema Outlines
+;
+
+doc: \<DOC>
+Selector for whether the edge lines are
+drawn on the Top / Bottom sides (N/S) or the Left/Right sides (E/W)
+<DOC>
+public defenum SilkscreenEdge :
+  NS-Edge
+  EW-Edge
+
+public defstruct EdgesOutline <: SilkscreenOutline :
+  doc: \<DOC>
+  Package Body Dimensions
+  These dimensions will be projected on to the board
+  to construct the outline.
+  <DOC>
+  pkg-body:PackageBody
+  edge:SilkscreenEdge with:
+    default => NS-Edge
+  doc: \<DOC>
+  Line Width for the constructed silkscreen outline
+  By default we use the `MinSilkscreenWidth` from the design rules.
+  <DOC>
+  line-width:Double with:
+    ensure => ensure-positive!
+    default => default-silk-width()
+  doc: \<DOC>
+  Clearance from silkscreen to the soldermask
+  By default we use the `MinSilkSolderMaskSpace` from the
+  design rules.
+  <DOC>
+  mask-clearance:Double with:
+    ensure => ensure-non-negative!
+    default => default-mask-clearance()
+  doc: \<DOC>
+  Density Level Specification
+  This determines whether we use:
+  *  Maximum Material Condition
+  *  Nominal Material Condition
+  *  Least Material Condition
+
+  of the package body to construct the outline.
+  <DOC>
+  density-level:DensityLevel with:
+    default => DENSITY-LEVEL
+with:
+  printer => true
+  keyword-constructor => true
+
+public defmethod build-shape (s:EdgesOutline, vp:VirtualLP -- side:Side = Top) -> Shape :
+
+  val outline = get-extended-pkg-outline(
+    vp,
+    pkg-body(s)
+    density-level(s)
+    line-width(s)
+    mask-clearance(s)
+    side
+    edge(s)
+  )
+
+  construct-pkg-extrema-lines(
+    vp, pkg-body(s),
+    density-level = density-level(s)
+    line-width = line-width(s)
+    mask-clearance = mask-clearance(s)
+    side = side
+    edge = edge(s)
+  )
+
+
+public defstruct InteriorEdgesOutline <: SilkscreenOutline :
+  doc: \<DOC>
+  Package Body Dimensions
+  These dimensions will be projected on to the board
+  to construct the outline.
+  <DOC>
+  pkg-body:PackageBody
+  edge:SilkscreenEdge with:
+    default => NS-Edge
+  doc: \<DOC>
+  Line Width for the constructed silkscreen outline
+  By default we use the `MinSilkscreenWidth` from the design rules.
+  <DOC>
+  line-width:Double with:
+    ensure => ensure-positive!
+    default => default-silk-width()
+  doc: \<DOC>
+  Clearance from silkscreen to the soldermask
+  By default we use the `MinSilkSolderMaskSpace` from the
+  design rules.
+  <DOC>
+  mask-clearance:Double with:
+    ensure => ensure-non-negative!
+    default => default-mask-clearance()
+  doc: \<DOC>
+  Density Level Specification
+  This determines whether we use:
+  *  Maximum Material Condition
+  *  Nominal Material Condition
+  *  Least Material Condition
+
+  of the package body to construct the outline.
+  <DOC>
+  density-level:DensityLevel with:
+    default => DENSITY-LEVEL
+with:
+  printer => true
+  keyword-constructor => true
+
+
+public defmethod build-shape (s:InteriorEdgesOutline, vp:VirtualLP -- side:Side = Top) -> Shape :
+  ; Package bounding box
+  val pkg-outline = bounds $ envelope(pkg-body(s), density-level = density-level(s))
+  ; Interior outline of pads; shrunk by soldermask-clearance
+  val lw = line-width(s)
+  val pad-interior = pad-interior-bounds(vp, side)
+  val pad-interior* = try:
+     shrink(mask-clearance(s) + lw / 2.0, pad-interior)
+  catch (e:ValueError):
+    pad-interior
+
+  ; Select smaller box
+  val pkg-outline* =
+    if area(pkg-outline) < area(pad-interior) : pkg-outline
+    else : pad-interior*
+
+  val [sw, se, ne, nw] = corners(pkg-outline*)
+
+  val line-eps = switch(edge(s)):
+    NS-Edge:
+      [[nw, ne], [sw, se]]
+    EW-Edge:
+      [[nw, sw], [ne, se]]
+
+  ; Want to difference with the soldermask openings
+
+  Union $ to-tuple $ for line-ep in line-eps seq:
+    Line(lw, line-ep)
 
 doc: \<DOC>
 Compute the closest corner of the passed Box to the Pin1 position.
@@ -292,6 +703,8 @@ public defn add-pin-1-dot (
 doc: \<DOC>
 Construct the projected shape of the package body on the board.
 
+Legacy - Use {@link PackageOutline}
+
 @param vp Virtual LP scene graph node - outline will be created here.
 @param pkg-body 3D body model for the component
 @param density-level Indicates whether we will use MMC, NMC, or LMC
@@ -305,12 +718,18 @@ public defn construct-pkg-outline (
   line-width:Double = default-silk-width(),
   mask-clearance:Double = default-mask-clearance()
   ) -> Shape:
-  val pkg-outline = bounds $ envelope(pkg-body, density-level = density-level)
-  val pkg-outline* = fatten(line-width / 2.0, pkg-outline)
-  LineRectangle(pkg-outline*, line-width = line-width)
+  val po = PackageOutline(
+    pkg-body = pkg-body,
+    line-width = line-width,
+    mask-clearance = mask-clearance
+    density-level = density-level
+  )
+  build-shape(po, vp)
 
 doc: \<DOC>
 Construct a silkscreen outline of a component based on the Package Body
+
+To be replaced by the {@link PackageOutline} type
 
 @param vp Virtual LP scene graph node - outline will be created here.
 @param pkg-body 3D body model for the component
@@ -328,20 +747,18 @@ public defn create-silkscreen-outline (
   side:Side = Top
   ) -> False :
 
-  val outline-geom = construct-pkg-outline(
-    vp, pkg-body,
-    density-level = density-level
-    line-width = line-width
+  val po = PackageOutline(
+    pkg-body = pkg-body,
+    line-width = line-width,
     mask-clearance = mask-clearance
+    density-level = density-level
   )
-  ; TODO - I want to use `Difference` here will all of the soldermask openings
-  ;  defined by the pads.
-
-  add-silkscreen-outline(vp, outline-geom, side = side)
-
+  build-outline(po, vp, side = side)
 
 doc: \<DOC>
 Construct the projected shape of the Package Body and Soldermask Pad Openings
+
+Legacy - Use {@link OverallOutline}
 
 The user must create all of the pads associated with this landpattern before
 invoking this function.
@@ -366,17 +783,19 @@ public defn construct-overall-outline (
   mask-clearance:Double = default-mask-clearance()
   side:Side = Top
   ) -> Shape:
-  val pkg-outline = bounds $ envelope(pkg-body, density-level = density-level)
-  val pad-outline = bounds(get-pads(vp), layer-spec = SolderMask(side))
 
-  val overall = union(pkg-outline, pad-outline)
-  val overall* = fatten(mask-clearance + (line-width / 2.0), overall)
-
-  LineRectangle(overall*, line-width = line-width)
-
+  val oo = OverallOutline(
+    pkg-body = pkg-body,
+    line-width = line-width,
+    mask-clearance = mask-clearance
+    density-level = density-level
+  )
+  build-shape(oo, vp, side = side)
 
 doc: \<DOC>
 Construct a silkscreen outline based on the Package Body and Soldermask Pad Openings
+
+Legacy - To be replaced with {@link OverallOutline}
 
 The user must create all of the pads associated with this landpattern before
 invoking this function.
@@ -396,23 +815,13 @@ public defn create-silkscreen-overall-outline (
   side:Side = Top
   ) -> False :
 
-  val outline-geom = construct-overall-outline(
-    vp, pkg-body,
-    density-level = density-level
-    line-width = line-width
+  val oo = OverallOutline(
+    pkg-body = pkg-body,
+    line-width = line-width,
     mask-clearance = mask-clearance
-    side = side
-    )
-
-  add-silkscreen-outline(vp, outline-geom, side = side)
-
-doc: \<DOC>
-Selector for whether the edge lines are
-drawn on the Top / Bottom sides (N/S) or the Left/Right sides (E/W)
-<DOC>
-public defenum SilkscreenEdge :
-  NS-Edge
-  EW-Edge
+    density-level = density-level
+  )
+  build-outline(oo, vp, side = side)
 
 doc: \<DOC>
 Determine the dimensions of the package body with Y extension
@@ -509,6 +918,8 @@ public defn construct-pkg-extrema-lines (
 doc: \<DOC>
 Construct and instantiate the package extrema lines in the scene graph
 
+Legacy - To be replaced by {@link EdgesOutline}
+
 @param vp Virtual Land Pattern Scene Graph node
 @param pkg-body Package dimensional body for sizing the lines.
 @param density-level Package density level. Default is `DENSITY-LEVEL`
@@ -531,80 +942,12 @@ public defn create-silkscreen-pkg-extrema-outline (
   mask-clearance:Double = default-mask-clearance()
   side:Side = Top
   ) -> Shape :
-  val outline-geom = construct-pkg-extrema-lines(
-    vp, pkg-body,
-    density-level = density-level
-    line-width = line-width
-    mask-clearance = mask-clearance
-    side = side,
+
+  val eo = EdgesOutline(
+    pkg-body = pkg-body,
     edge = edge
-    )
-  add-silkscreen-outline(vp, outline-geom, side = side)
-  outline-geom
-
-
-doc: \<DOC>
-Construct an outline shape of the package body by avoiding overlaps with pads
-
-This function takes an outline (like the outline of the package body)
-and computes the set of shapes that can maximally fill that outline
-but not overlap with any of the pads in a package.
-
-This function will also obey clearance requirements to prevent DRC
-issues.
-
-This function is primarily for supporting dual-row land patterns
-like SON, SOP, etc.
-
-@param vp Virtual Land Pattern Scene Graph
-@param pkg-body Package Body for the IC
-@param density-level Density Level for the Package
-@param line-width Silkscreen min line width as defined by pcb-rules.
-@param mask-clearance Minimum soldermask clearance to silkscreen as defined
-by the pcb-rules.
-@param side Which side of the board this outline will be created on. It
-filters for which pads of the landpattern to inspect.
-@return LineRectangle shape that could be drawn in the silkscreen.
-<DOC>
-public defn compute-pkg-internal-box (
-  vp:VirtualLP,
-  pkg-body:PackageBody,
-  --
-  density-level:DensityLevel = DENSITY-LEVEL
-  line-width:Double = default-silk-width(),
-  mask-clearance:Double = default-mask-clearance(),
-  side:Side = Top
-  ) -> Shape :
-
-  val pkg-outline = bounds $ envelope(pkg-body, density-level = density-level)
-  val courtyard? = get-courtyard-boundary(vp, side = side)
-
-  ; Check for overlap between the pad soldermask and the
-  ;  current proposed outline. We will then shrink the
-  ;  proposed outline until there is at least `mask-clearance`
-  ;  on either side.
-  val h-shrink = let:
-    val col-0-pads = seq{as-VirtualPad, _} $ find-by-class(vp, "col-0")
-    val col-1-pads = seq{as-VirtualPad, _} $ find-by-class(vp, "col-1")
-
-    val col-0-outline = bounds(col-0-pads, layer-spec = SolderMask(side))
-    val col-1-outline = bounds(col-1-pads, layer-spec = SolderMask(side))
-
-    val interstitial = Box(
-      Point(right(col-0-outline), down(col-0-outline)),
-      Point(left(col-1-outline), up(col-1-outline))
-    )
-
-    val iW = x(dims(interstitial)) - ((2.0 * mask-clearance) + line-width)
-    val iP = x(dims(pkg-outline))
-
-    ; Compute the shrinkage that will be applid to
-    ;   both sides (if any)
-    val diff = (iW - iP) / 2.0
-    if diff < 0.0 :
-      ; We need to shrink the package outline
-      fatten(Point(diff, 0.0), pkg-outline)
-    else:
-      pkg-outline
-
-  LineRectangle(h-shrink, line-width = line-width)
+    line-width = line-width,
+    mask-clearance = mask-clearance
+    density-level = density-level
+  )
+  build-outline(eo, vp, side = side)

--- a/src/landpatterns/two-pin/SMT.stanza
+++ b/src/landpatterns/two-pin/SMT.stanza
@@ -36,18 +36,14 @@ public defstruct SMT-Chip-Def :
   name: String
   aliases: Tuple<String>
 
-  length:Toleranced with: (
+  length:Toleranced with:
     ensure => ensure-positive!
-  )
-  width:Toleranced with: (
+  width:Toleranced with:
     ensure => ensure-positive!
-  )
-  lead-length:Toleranced with: (
+  lead-length:Toleranced with:
     ensure => ensure-positive!
-  )
-  lead-width:Toleranced with: (
+  lead-width:Toleranced with:
     ensure => ensure-positive!
-  )
 
 doc: \<DOC>
 Internal Constructor to create Definitions from Tuples
@@ -161,17 +157,21 @@ public defstruct SMT-Chip <: Package :
   doc: \<DOC>
   Z-dimension Height of the Chip Package.
   <DOC>
-  height:Toleranced with: (ensure => ensure-positive! )
+  height:Toleranced with:
+    ensure => ensure-positive!
   doc: \<DOC>
   Protrusion Type
   <DOC>
   protrusion:LeadProtrusion
-  pad-planner:PadPlanner with: (as-method => true)
-  lead-numbering:Numbering with: (as-method => true)
+  pad-planner:PadPlanner with:
+    as-method => true
+  lead-numbering:Numbering with:
+    as-method => true
   doc: \<DOC>
   Density Level for the Generated Package
   <DOC>
-  density-level:DensityLevel with: (as-method => true)
+  density-level:DensityLevel with:
+    as-method => true
 with:
   constructor => #SMT-Chip
 

--- a/src/landpatterns/two-pin/SMT.stanza
+++ b/src/landpatterns/two-pin/SMT.stanza
@@ -23,6 +23,7 @@ defpackage jsl/landpatterns/two-pin/SMT:
   import jsl/landpatterns/VirtualLP
 
 
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;          SMT Size Table
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -95,13 +96,28 @@ Check if the passed string is a known chip size - like "0603", "0805", etc
 public defn is-known-chip-pkg (k:String) -> True|False :
   key?(chips, k)
 
+
+val UnknownCaseSizeError = ValueError{"Unknown Case Size '%_'" % [_]}
+
+doc: \<DOC>
+Get the SMT Chip definition from a case size
+@param k Standard Package size (eg "0805") or Metric Alias (eg, "2012m")
+@return SMT Chip Definition for this chip size if it exists.
+@throws ValueError if no chip definition with that name can be found.
+<DOC>
+public defn get-chip-def (k:String) -> SMT-Chip-Def :
+  if not is-known-chip-pkg(k):
+    throw $ UnknownCaseSizeError(k)
+  chips[k]
+
 doc: \<DOC>
 Create a SMT-Chip Package given a chip size string.
 @param k Standard Package size (eg "0805") or Metric Alias (eg, "2012m")
 @return SMT Chip Package with all default configurations
+@throws ValueError if no chip definition with that name can be found.
 <DOC>
 public defn get-chip-pkg (k:String, density-level:DensityLevel = DENSITY-LEVEL) -> SMT-Chip :
-  val chip-def = chips[k]
+  val chip-def = get-chip-def(k)
   SMT-Chip(chip-def, density-level = density-level)
 
 doc: \<DOC>
@@ -273,77 +289,20 @@ public defmethod build-pads (
 
   append-all(vp, gen-pad-info())
 
-public defn build-SMT-outline (
-  pkg:SMT-Chip,
-  vp:VirtualLP
-  --
-  line-width:Double = default-silk-width(),
-  mask-clearance:Double = default-mask-clearance(),
-  side:Side = Top
-  ):
-
-  val [p1, p2] = get-two-pin-pads(vp)
-  val s1 = bounds([p1], layer-spec = SolderMask(side))
-  val s2 = bounds([p2], layer-spec = SolderMask(side))
-
-  ; I'm assuming that the pads in this LP container
-  ;  are oriented with the length in the Y axis.
-  val interstitial = Box(
-    Point(left(s2), up(s2)),
-    Point(right(s1), down(s1))
-  )
-  val h = y(dims(interstitial))
-  ; Minimum box height is mask clearance and  linewidth on either side
-  ;  and then I'm arbitrarily requiring at least mask-clearance between
-  ;  the top and bottom lines for them to be visible. For polarized chips
-  ;  I need an additional line width
-  val add-clearance = if polarized?(pkg):
-    mask-clearance + line-width
-  else:
-    mask-clearance
-  val free-space = h - ((2.0 * (mask-clearance + line-width)) + add-clearance)
-
-  defn create-line (v:Double, width:Double = line-width) -> Line :
-    val shrink = (width / 2.0)
-    Line(width, [
-      Point(left(interstitial) + shrink , v),
-      Point(right(interstitial) - shrink, v)
-      ])
-
-  val outline = if free-space < 0.0 :
-    ; We will draw a Line instead of a LineRectangle because there is
-    ;  not enough space.
-    val c = center(interstitial)
-    create-line(y(c))
-  else:
-    val shrink = Point((- line-width / 2.0), (- ((line-width / 2.0) + mask-clearance)))
-    val o-box = fatten(shrink, interstitial)
-    LineRectangle(o-box, line-width = line-width),
-
-  add-artwork(vp, Silkscreen("outline", side), outline, class = "outline")
-
-  ; Add Polarized Marker
-  if polarized?(pkg):
-    val pol-line = if free-space < 0.0 :
-      ; We will put an additional line on the other side of the 'c' pad
-      val v = up(s1) + mask-clearance + (line-width / 2.0)
-      create-line(v)
-    else:
-      ; We will put an additional line inside the rect on the 'c' side.
-      val pol-size = (15 %)
-      val pol-h = h * pol-size
-      val pol-width = max(pol-h, line-width)
-
-      val v = up(interstitial) - (mask-clearance) - line-width - (0.5 * pol-width)
-
-      create-line(v, pol-width)
-    add-artwork(vp, Silkscreen("polarized", side), pol-line, class = "pol-marker")
 
 public defmethod build-silkscreen (
   pkg:SMT-Chip,
   vp:VirtualLP
   ):
-  build-SMT-outline(pkg, vp)
+  val outline = InteriorEdgesOutline(
+    pkg-body = package-body(pkg),
+    edge = EW-Edge
+  )
+  build-outline(outline, vp)
+
+  if polarized?(pkg):
+    build-smd-pin-1-dot(vp, pin-1-id = #R(c), dir = Down)
+
   add-reference-designator(vp)
 
 

--- a/src/landpatterns/two-pin/SMT.stanza
+++ b/src/landpatterns/two-pin/SMT.stanza
@@ -294,11 +294,19 @@ public defmethod build-silkscreen (
   pkg:SMT-Chip,
   vp:VirtualLP
   ):
+
   val outline = InteriorEdgesOutline(
     pkg-body = package-body(pkg),
     edge = EW-Edge
   )
-  build-outline(outline, vp)
+  if has-enough-interior-space?(outline, vp):
+    build-outline(outline, vp)
+  else:
+    val sl = SingleLineOutline(
+      pkg-body = package-body(pkg),
+      edge = EW-Edge
+    )
+    build-outline(sl, vp)
 
   if polarized?(pkg):
     build-smd-pin-1-dot(vp, pin-1-id = #R(c), dir = Down)

--- a/src/landpatterns/two-pin/SMT.stanza
+++ b/src/landpatterns/two-pin/SMT.stanza
@@ -268,7 +268,7 @@ public defmethod build-pads (
       match(pad-gen?):
         (_:False): None()
         (pad-gen):
-          val cls = ["pad"]
+          val cls = build-vpad-classes(r, 0)
           One $ VirtualPad(pad-id, pad-gen(pad-sz), pos, class = cls)
 
   append-all(vp, gen-pad-info())

--- a/src/landpatterns/two-pin/axial.stanza
+++ b/src/landpatterns/two-pin/axial.stanza
@@ -226,6 +226,7 @@ public defmethod build-pads (
         (_:False): None()
         (th-pad-gen:((Dims, Dims) -> Pad)):
           val pad-def = make-pad-def(lead(pkg), th-pad-gen, density-level(pkg))
-          One $ VirtualPad(pad-id, pad-def, pos)
+          val cls = build-vpad-classes(r, 0)
+          One $ VirtualPad(pad-id, pad-def, pos, class = cls)
 
   append-all(vp, gen-pad-info())

--- a/src/landpatterns/two-pin/molded.stanza
+++ b/src/landpatterns/two-pin/molded.stanza
@@ -135,7 +135,15 @@ public defmethod build-silkscreen (
   pkg:Molded-2pin,
   vp:VirtualLP
   ):
-  val outline = create-silkscreen-pkg-extrema-outline(vp, package-body(pkg), edge = EW-Edge)
+  val eo = EdgesOutline(
+    pkg-body = package-body(pkg),
+    edge = EW-Edge
+    density-level = density-level(pkg)
+  )
+  build-outline(eo, vp)
+
+  val outline-art = get-silkscreen-outline!(vp)
+  val outline = shape(outline-art)
 
   match(pin-1-id?(pkg)):
     (_:None):false

--- a/src/landpatterns/two-pin/radial.stanza
+++ b/src/landpatterns/two-pin/radial.stanza
@@ -129,10 +129,8 @@ public defmethod build-pads (
       match(th-pad-gen?):
         (_:False): None()
         (th-pad-gen:((Dims, Dims) -> Pad)):
-          val cls = [
-            "pad",
-          ]
           val pad-def = make-pad-def(lead(pkg), th-pad-gen, density-level(pkg))
+          val cls = build-vpad-classes(r, 0)
           One $ VirtualPad(pad-id, pad-def, pos, class = cls)
 
   append-all(vp, gen-pad-info())


### PR DESCRIPTION
I'm trying to setup a framework by which we can allow customization of silkscreen content including the outline, pin1 markers, etc. 

This PR adds a interface type for silkscreen outlines and then converts existing code to create multiple different implementations of that interface.

This allows me to consolidate some code as well as set up a future where the silkscreen outline is an argument to the package. 

I've also added a better silkscreen for the SMTs that uses two lines instead of the full line rectangle:

![image](https://github.com/user-attachments/assets/1ac46878-8041-4c29-97fe-c150701782b5)

It doesn't look great for small case sizes like 0402 and 0201 - we will improve those. 