### PR TITLE
use min-col-width and min-row-width

### DIFF
--- a/examples/protocols/displayport/displayport-src.stanza
+++ b/examples/protocols/displayport/displayport-src.stanza
@@ -81,7 +81,7 @@ public pcb-component component :
 
   val box-params = BoxSymbolParams(
     show-grid = false
-    col-width = 1
+    min-col-width = 1
   )
 
   val box = BoxSymbol(self, params = box-params)

--- a/examples/protocols/pcie/pcie-src.stanza
+++ b/examples/protocols/pcie/pcie-src.stanza
@@ -97,7 +97,7 @@ public pcb-component component :
 
   val box-params = BoxSymbolParams(
     show-grid = false
-    col-width = 1
+    min-col-width = 1
   )
 
   val box = BoxSymbol(self, params = box-params)

--- a/examples/symbols/box-symbol.stanza
+++ b/examples/symbols/box-symbol.stanza
@@ -297,8 +297,8 @@ pcb-component test-default-align:
 
   val box = BoxSymbol(self, params = BoxSymbolParams(
     show-grid = true
-    col-width = 10
-    row-width = 5))
+    min-col-width = 10
+    min-row-width = 5))
   set-grid(box, [2,2])
   set-alignment(N, self.rail.V+)
   set-alignment(S, self.rail.V-)
@@ -332,8 +332,8 @@ pcb-component test-pad-ref:
     [ADDR[1] | p[4] | Right | 1 | "A1" ]
 
   val box = BoxSymbol(self, params = BoxSymbolParams(
-    col-width = 10
-    row-width = 5
+    min-col-width = 10
+    min-row-width = 5
     pad-ref-size = 2.0))
   set-grid(box, [2,2])
   set-alignment(N, self.rail.V+)
@@ -407,8 +407,8 @@ pcb-component test-pin-pitch:
 
   val box = BoxSymbol(self, params = BoxSymbolParams(
     show-grid = true
-    col-width = 10
-    row-width = 5
+    min-col-width = 10
+    min-row-width = 5
     pin-pitch = 5.0))
   set-grid(box, [2,2])
   set-alignment(N, self.rail.V+)
@@ -444,8 +444,8 @@ pcb-component test-up-column:
 
   val box = BoxSymbol(self, params = BoxSymbolParams(
     show-grid = true
-    col-width = 1
-    row-width = 5
+    min-col-width = 1
+    min-row-width = 5
   ))
   set-grid(box, [3,3], Ref("test"))
   set-alignment(N, self.rail.V+)
@@ -485,7 +485,7 @@ pcb-component test-even-row:
     ;col-width = 1
     ; line-width = 0.4
     ; pin-length = 4.4
-    row-width = 5
+    min-row-width = 5
   ))
   set-grid(box, [2, 1])
   set-alignment(N, self.rail.V+)
@@ -521,7 +521,7 @@ pcb-component test-group-margin:
 
   val box = BoxSymbol(self, params = BoxSymbolParams(
     show-grid = true
-    row-width = 5
+    min-row-width = 5
   ))
   set-grid(box, [2, 2])
 


### PR DESCRIPTION
* use `min-col-width` and `min-row-width` to make these examples runnable.