### PR TITLE
Add Keepout Generators for SMT Components

### DIFF
--- a/examples/landpatterns/SMT.stanza
+++ b/examples/landpatterns/SMT.stanza
@@ -46,7 +46,7 @@ pcb-component test-SMT (case:String):
     [p[2] | p[2] | Down | 0]
 
   assign-symbol(test-sym)
-  val pkg = get-resistor-pkg(case, DensityLevelC)
+  val pkg = get-resistor-pkg(case, density-level = DensityLevelC)
 
   val lp = create-landpattern(pkg)
   assign-landpattern(lp)

--- a/src/ensure.stanza
+++ b/src/ensure.stanza
@@ -134,3 +134,7 @@ public defn ensure-in-set! (accepted:Tuple<Int>):
     if not contains?(accepted, value):
       throw $ ValueError("Value '%_' not in Accepted Value Set: [%,]" % [value, accepted])
   ensure-func
+
+public defn ensure-not-empty! (field:String, value:Collection) :
+  if count(value) == 0:
+    throw $ ValueError("Expected Non-Empty Collection - Found: %_" % [value])

--- a/src/landpatterns/VirtualLP.stanza
+++ b/src/landpatterns/VirtualLP.stanza
@@ -848,6 +848,67 @@ public defn get-first-pad (vp:VirtualLP) -> VirtualPad :
     throw(Exception("Virtual landpattern has no pads"))
   reduce(earlier-pad, pads)
 
+doc: \<DOC>
+Construct the interior bounds for the pads of a component
+
+This function only makes sense for things like QFPs, SOICs,
+SSOPs, or 2-pin components.
+
+This function assumes that you have used the function
+{@link build-vpad-classes} when constructing the rows and
+columns of pads for your footprint.
+
+This function attempts to extract out the pads by row
+or column and then use the bounding box of the soldermask
+to determine the interior bounds between the pads.
+
+Note - there is another way to do this that I decided against
+which was to try and find lines and intersections of those lines.
+This seemed like it might be a bit more robust but at the cost
+of being more complex code wise.
+
+@throws ValueError if it encounter a number of columns that it can't
+handle. Specifically, this function can handle [1, 2, 4] columns of pads.
+This corresponds to 2-pin, dual-row, and quad land patterns, respectively.
+<DOC>
+public defn pad-interior-bounds (vp:VirtualLP, side:Side) -> Box:
+
+  val get-bounds = bounds{_, layer-spec = SolderMask(side)}
+  val cols = identify-pad-columns(vp)
+  val num-cols = length(cols)
+  if num-cols == 1:
+    ; This is a 2-pin component - ie a SMT, Radial or Axial
+    val row0 = get-bounds $ get-pads-by-row(vp, 0)
+    val row1 = get-bounds $ get-pads-by-row(vp, 1)
+
+    Box(
+      Point(left(row1), up(row1))
+      Point(right(row0), down(row0))
+    )
+
+  else if num-cols == 2 :
+    val col0 = get-bounds $ get-pads-by-column(vp, 0)
+    val col1 = get-bounds $ get-pads-by-column(vp, 1)
+
+    Box(
+      Point(right(col0), down(col0))
+      Point(left(col1), up(col1))
+      )
+  else if num-cols == 4 :
+
+    val col-W = get-bounds $ get-pads-by-column(vp, 0)
+    val col-S = get-bounds $ get-pads-by-column(vp, 1)
+    val col-E = get-bounds $ get-pads-by-column(vp, 2)
+    val col-N = get-bounds $ get-pads-by-column(vp, 3)
+
+    Box(
+      Point(right(col-W), up(col-S)),
+      Point(left(col-E), down(col-N))
+    )
+  else:
+    throw $ ValueError("Unhandled Number of Columns '%_' - Expected 1, 2, or 4" % [num-cols])
+
+
 ; Converters
 #for (vType in [VirtualPad, VirtualArtwork, VirtualCopper, VirtualLP]
   funcName in [as-VirtualPad, as-VirtualArtwork, as-VirtualCopper ,as-VirtualLP]) :

--- a/src/landpatterns/VirtualLP.stanza
+++ b/src/landpatterns/VirtualLP.stanza
@@ -10,6 +10,7 @@ defpackage jsl/landpatterns/VirtualLP:
   import jsl/design/Classable
   import jsl/geometry/box
   import jsl/landpatterns/courtyard
+  import jsl/landpatterns/leads
   import jsl/landpatterns/thermal-pads
 
 doc: \<DOC>

--- a/src/landpatterns/framework.stanza
+++ b/src/landpatterns/framework.stanza
@@ -22,6 +22,7 @@ defpackage jsl/landpatterns/framework:
   forward jsl/landpatterns/helpers
   forward jsl/landpatterns/silkscreen
   forward jsl/landpatterns/courtyard
+  forward jsl/landpatterns/keep-outs
   forward jsl/landpatterns/introspection
   forward jsl/landpatterns/pad-grid
   forward jsl/landpatterns/thermal-pads

--- a/src/landpatterns/keep-outs.stanza
+++ b/src/landpatterns/keep-outs.stanza
@@ -1,0 +1,84 @@
+#use-added-syntax(jitx)
+defpackage jsl/landpatterns/keep-outs:
+  import core
+  import jitx
+  import jitx/commands
+
+  import jsl/ensure
+  import jsl/geometry/box
+  import jsl/landpatterns/VirtualLP
+  import jsl/landpatterns/silkscreen
+
+doc: \<DOC>
+Interface Type for Keepout Creation
+
+Custom keepout generators can be built by inheriting
+from this type and then implementing the interface
+<DOC>
+public deftype KeepoutCreator
+
+doc: \<DOC>
+Build the keep-out layer geometry in the Virtual LP Scene Graph
+
+This function will generate the necessary keep-out artwork
+in the virtual LP scene graph.
+<DOC>
+public defmulti build-keep-out (kc:KeepoutCreator, vp:VirtualLP -- side:Side = Top) -> False
+
+
+
+doc: \<DOC>
+Keepout Creator for Intra-pad Keepouts
+
+For SMT chip components like resistors and capacitors,
+we often want to restrict copper underneath the component.
+This can be for SI reasons, manufacturing reasons, etc.
+
+Sometimes we want to restrict the ground plane on an internal
+layer underneath these components.
+
+This type is used to contruct these keepouts on any layer
+of the board design.
+<DOC>
+public defstruct IntraPadKeepOut <: KeepoutCreator :
+  layer-set:Tuple<LayerIndex> with:
+    ensure => ensure-not-empty!
+
+  doc: \<DOC>
+  Shrink the created keepout
+  By default, this type will create a keepout that is
+  the same size as the interstitual region between the
+  pads of the SMT component.
+  This parameter can be used to make this keepout region
+  smaller (or larger if negative).
+  By default this value is 0.0.
+  <DOC>
+  shrink-by:Double|Percentage|Dims with:
+    default => 0.0
+with:
+  printer => true
+  keyword-constructor => true
+
+
+public defmethod build-keep-out (k:IntraPadKeepOut, vp:VirtualLP -- side:Side = Top) :
+
+  val b = pad-interior-bounds(vp, side)
+  val sh-by = match(shrink-by(k)):
+    (s:Double): Point(s, s)
+    (s:Dims): Point(x(s), y(s))
+    (p:Percentage):
+      val s = dims(b)
+      Point(x(s) * p, y(s) * p)
+
+  val b* = shrink(sh-by, b)
+  val sh = to-Rectangle(b*)
+
+  val cls = ["keepout"]
+  for ly in layer-set(k) do:
+    val fb = ForbidCopper(ly)
+    add-artwork(vp, fb, sh, class = cls)
+
+
+
+
+

--- a/src/landpatterns/keep-outs.stanza
+++ b/src/landpatterns/keep-outs.stanza
@@ -25,8 +25,6 @@ in the virtual LP scene graph.
 <DOC>
 public defmulti build-keep-out (kc:KeepoutCreator, vp:VirtualLP -- side:Side = Top) -> False
 
-
-
 doc: \<DOC>
 Keepout Creator for Intra-pad Keepouts
 
@@ -41,8 +39,18 @@ This type is used to contruct these keepouts on any layer
 of the board design.
 <DOC>
 public defstruct IntraPadKeepOut <: KeepoutCreator :
+  doc: \<DOC>
+  Set of copper layers where the keepout will be placed.
+  The most obvious layer would be the top layer underneath
+  the component. But for some applications, we might want
+  to add keepouts in the reference plane underneath the
+  component as well.
+
+  The default value is the top layer `LayerIndex(0)`
+  <DOC>
   layer-set:Tuple<LayerIndex> with:
     ensure => ensure-not-empty!
+    default => [LayerIndex(0)]
 
   doc: \<DOC>
   Shrink the created keepout

--- a/src/landpatterns/silkscreen.stanza
+++ b/src/landpatterns/silkscreen.stanza
@@ -11,7 +11,10 @@ defpackage jsl/landpatterns/silkscreen:
   import jsl/errors
   import jsl/geometry/box
   import jsl/geometry/LineRectangle
-  import jsl/landpatterns/framework
+  import jsl/landpatterns/VirtualLP
+  import jsl/landpatterns/helpers
+  import jsl/landpatterns/leads
+  import jsl/landpatterns/package-body
 
 public defn default-silk-width () -> Double :
   clearance(current-rules(), MinSilkscreenWidth)

--- a/src/landpatterns/silkscreen.stanza
+++ b/src/landpatterns/silkscreen.stanza
@@ -211,66 +211,6 @@ with:
   printer => true
   keyword-constructor => true
 
-doc: \<DOC>
-Construct the interior bounds for the pads of a component
-
-This function only makes sense for things like QFPs, SOICs,
-SSOPs, or 2-pin components.
-
-This function assumes that you have used the function
-{@link build-vpad-classes} when constructing the rows and
-columns of pads for your footprint.
-
-This function attempts to extract out the pads by row
-or column and then use the bounding box of the soldermask
-to determine the interior bounds between the pads.
-
-Note - there is another way to do this that I decided against
-which was to try and find lines and intersections of those lines.
-This seemed like it might be a bit more robust but at the cost
-of being more complex code wise.
-
-@throws ValueError if it encounter a number of columns that it can't
-handle. Specifically, this function can handle [1, 2, 4] columns of pads.
-This corresponds to 2-pin, dual-row, and quad land patterns, respectively.
-<DOC>
-defn pad-interior-bounds (vp:VirtualLP, side:Side) -> Box:
-
-  val get-bounds = bounds{_, layer-spec = SolderMask(side)}
-  val cols = identify-pad-columns(vp)
-  val num-cols = length(cols)
-  if num-cols == 1:
-    ; This is a 2-pin component - ie a SMT, Radial or Axial
-    val row0 = get-bounds $ get-pads-by-row(vp, 0)
-    val row1 = get-bounds $ get-pads-by-row(vp, 1)
-
-    Box(
-      Point(left(row1), up(row1))
-      Point(right(row0), down(row0))
-    )
-
-  else if num-cols == 2 :
-    val col0 = get-bounds $ get-pads-by-column(vp, 0)
-    val col1 = get-bounds $ get-pads-by-column(vp, 1)
-
-    Box(
-      Point(right(col0), down(col0))
-      Point(left(col1), up(col1))
-      )
-  else if num-cols == 4 :
-
-    val col-W = get-bounds $ get-pads-by-column(vp, 0)
-    val col-S = get-bounds $ get-pads-by-column(vp, 1)
-    val col-E = get-bounds $ get-pads-by-column(vp, 2)
-    val col-N = get-bounds $ get-pads-by-column(vp, 3)
-
-    Box(
-      Point(right(col-W), up(col-S)),
-      Point(left(col-E), down(col-N))
-    )
-  else:
-    throw $ ValueError("Unhandled Number of Columns '%_' - Expected 1, 2, or 4" % [num-cols])
-
 
 public defmethod build-shape (s:InterstitialOutline, vp:VirtualLP -- side:Side = Top) -> Shape :
   ; Package bounding box

--- a/src/landpatterns/two-pin/SMT.stanza
+++ b/src/landpatterns/two-pin/SMT.stanza
@@ -8,8 +8,6 @@ defpackage jsl/landpatterns/two-pin/SMT:
   import jsl/ensure
   import jsl/design/settings
   import jsl/design/Classable
-  import jsl/geometry/box
-  import jsl/geometry/LineRectangle
 
   import jsl/landpatterns/two-pin/SMT-table with:
     prefix => #SMT-
@@ -21,7 +19,7 @@ defpackage jsl/landpatterns/two-pin/SMT:
   import jsl/landpatterns/pad-planner
   import jsl/landpatterns/numbering
   import jsl/landpatterns/VirtualLP
-
+  import jsl/landpatterns/keep-outs
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -125,18 +123,28 @@ Create a Resistor SMT Chip Package of a given size
 @param k Standard Package size (eg "0805") or Metric Alias (eg, "2012m")
 @return Package with all default configurations
 <DOC>
-public defn get-resistor-pkg (k:String, density-level:DensityLevel = DENSITY-LEVEL) -> SMT-Resistor :
+public defn get-resistor-pkg (
+  k:String
+  --
+  keep-out:KeepoutCreator|False = false,
+  density-level:DensityLevel = DENSITY-LEVEL
+  ) -> SMT-Resistor :
   val chip-def = chips[k]
-  SMT-Resistor(chip-def, density-level = density-level)
+  SMT-Resistor(chip-def, keep-out = keep-out, density-level = density-level)
 
 doc: \<DOC>
 Create a Capacitor SMT Chip Package of a given size
 @param k Standard Package size (eg "0805") or Metric Alias (eg, "2012m")
 @return Package with all default configurations
 <DOC>
-public defn get-capacitor-pkg (k:String, density-level:DensityLevel = DENSITY-LEVEL) -> SMT-Capacitor :
+public defn get-capacitor-pkg (
+  k:String
+  --
+  polarized?:True|False = false,
+  keep-out:KeepoutCreator|False = false,
+  density-level:DensityLevel = DENSITY-LEVEL) -> SMT-Capacitor :
   val chip-def = chips[k]
-  SMT-Capacitor(chip-def, density-level = density-level)
+  SMT-Capacitor(chip-def, polarized? = polarized?, keep-out = keep-out, density-level = density-level)
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -175,6 +183,13 @@ public defstruct SMT-Chip <: Package :
   <DOC>
   height:Toleranced with:
     ensure => ensure-positive!
+
+  doc: \<DOC>
+  Construct a Keepout underneath the component.
+  Default is `false` indicating no keepout is created.
+  <DOC>
+  keep-out:KeepoutCreator|False with:
+    default => false
   doc: \<DOC>
   Protrusion Type
   <DOC>
@@ -235,13 +250,14 @@ public defn SMT-Chip (
   side-fillet:Double|False = false,
   ; TODO - this is still broken.
   height:Toleranced = 0.4 +/- 0.1,
+  keep-out:KeepoutCreator|False = false
   ; TODO - refactor for `LeadProtrusion` type
   protrusion:LeadProtrusion = select-protrusion(chip-def),
   pad-planner:PadPlanner = RectanglePadPlanner,
   lead-numbering:Numbering = select-numbering(polarized?),
   density-level:DensityLevel = DENSITY-LEVEL
   ):
-  #SMT-Chip(chip-def, polarized?, side-fillet, height, protrusion, pad-planner, lead-numbering, density-level)
+  #SMT-Chip(chip-def, polarized?, side-fillet, height, keep-out, protrusion, pad-planner, lead-numbering, density-level)
 
 public defmethod build-pads (
   pkg:SMT-Chip,
@@ -289,7 +305,6 @@ public defmethod build-pads (
 
   append-all(vp, gen-pad-info())
 
-
 public defmethod build-silkscreen (
   pkg:SMT-Chip,
   vp:VirtualLP
@@ -313,6 +328,14 @@ public defmethod build-silkscreen (
 
   add-reference-designator(vp)
 
+public defmethod build-keep-out (
+  pkg:SMT-Chip,
+  vp:VirtualLP
+  ):
+  match(keep-out(pkg)):
+    (_:False): false
+    (x:KeepoutCreator):
+      build-keep-out(x, vp)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;   Resistor
@@ -320,18 +343,25 @@ public defmethod build-silkscreen (
 
 
 public defstruct SMT-Resistor <: SMT-Chip :
-  def:SMT-Chip-Def with: (as-method => true)
-  height:Toleranced with: (
+  def:SMT-Chip-Def with:
+    as-method => true
+  height:Toleranced with:
     as-method => true
     ensure => ensure-positive!
-    )
-  protrusion:LeadProtrusion with: ( as-method => true )
-  pad-planner:PadPlanner with: (as-method => true)
-  lead-numbering:Numbering with: (as-method => true)
+  keep-out:KeepoutCreator|False with:
+    as-method => true
+    default => false
+  protrusion:LeadProtrusion with:
+    as-method => true
+  pad-planner:PadPlanner with:
+    as-method => true
+  lead-numbering:Numbering with:
+    as-method => true
   doc: \<DOC>
   Density Level for the Generated Package
   <DOC>
-  density-level:DensityLevel with: (as-method => true)
+  density-level:DensityLevel with:
+    as-method => true
 with:
   constructor => #SMT-Resistor
 
@@ -343,13 +373,14 @@ public defn SMT-Resistor (
   --
   ; TODO - this is still broken.
   height:Toleranced = 0.4 +/- 0.1,
+  keep-out:KeepoutCreator|False = false,
   ; TODO - refactor for `LeadProtrusion` type
   protrusion:LeadProtrusion = select-protrusion(chip-def),
   pad-planner:PadPlanner = RectanglePadPlanner,
   lead-numbering:Numbering = STD-SMT-CHIP-NUMBERING,
   density-level:DensityLevel = DENSITY-LEVEL
   ):
-  #SMT-Resistor(chip-def, height, protrusion, pad-planner, lead-numbering, density-level)
+  #SMT-Resistor(chip-def, height, keep-out, protrusion, pad-planner, lead-numbering, density-level)
 
 public defmethod name (pkg:SMT-Resistor) -> String :
   defn to-deci (v:Double) -> String:
@@ -367,20 +398,29 @@ public defmethod name (pkg:SMT-Resistor) -> String :
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 public defstruct SMT-Capacitor <: SMT-Chip :
-  def:SMT-Chip-Def with: (as-method => true)
-  polarized?:True|False with: ( as-method => true)
-  side-fillet:Double|False with: ( as-method => true)
-  height:Toleranced with: (
+  def:SMT-Chip-Def with:
+    as-method => true
+  polarized?:True|False with:
+    as-method => true
+  side-fillet:Double|False with:
+    as-method => true
+  height:Toleranced with:
     as-method => true
     ensure => ensure-positive!
-    )
-  protrusion:LeadProtrusion with: ( as-method => true )
-  pad-planner:PadPlanner with: (as-method => true)
-  lead-numbering:Numbering with: (as-method => true)
+  keep-out:KeepoutCreator|False with:
+    as-method => true
+    default => false
+  protrusion:LeadProtrusion with:
+    as-method => true
+  pad-planner:PadPlanner with:
+    as-method => true
+  lead-numbering:Numbering with:
+    as-method => true
   doc: \<DOC>
   Density Level for the Generated Package
   <DOC>
-  density-level:DensityLevel with: (as-method => true)
+  density-level:DensityLevel with:
+    as-method => true
 with:
   constructor => #SMT-Capacitor
 
@@ -391,13 +431,14 @@ public defn SMT-Capacitor (
   side-fillet:Double|False = 0.04,
   ; TODO - this is still broken.
   height:Toleranced = 0.4 +/- 0.1,
+  keep-out:KeepoutCreator|False = false,
   ; TODO - refactor for `LeadProtrusion` type
   protrusion:LeadProtrusion = select-protrusion(chip-def),
   pad-planner:PadPlanner = RectanglePadPlanner,
   lead-numbering:Numbering = select-numbering(polarized?),
   density-level:DensityLevel = DENSITY-LEVEL
   ):
-  #SMT-Capacitor(chip-def, polarized?, side-fillet, height, protrusion, pad-planner, lead-numbering, density-level)
+  #SMT-Capacitor(chip-def, polarized?, side-fillet, height, keep-out, protrusion, pad-planner, lead-numbering, density-level)
 
 public defmethod name (pkg:SMT-Capacitor) -> String :
   defn to-deci (v:Double) -> String:

--- a/src/landpatterns/two-pin/molded.stanza
+++ b/src/landpatterns/two-pin/molded.stanza
@@ -47,6 +47,15 @@ public defstruct Molded-2pin <: Package :
   that the `anode` pin gets a pin-1 marker.
   <DOC>
   pin-1-id?:Maybe<Int|Ref>
+
+  doc: \<DOC>
+  Optional Keepout for the Molded Component Body
+  Typically, the user might use `IntraPadKeepOut` here.
+  Default is `None()`
+  <DOC>
+  keep-out:Maybe<KeepoutCreator> with:
+    default => None()
+
   doc: \<DOC>
   Package Body
   Typically a rectangular {@link PackageBody} but other
@@ -86,12 +95,13 @@ public defn Molded-2pin (
   package-body:PackageBody,
   polarized?:True|False = false,
   pin-1-id?:Maybe<Ref|Int> = default-molded-pin-1-id(polarized?),
+  keep-out:Maybe<KeepoutCreator> = None(),
   pad-planner:PadPlanner = RectanglePadPlanner
   lead-numbering:Numbering = select-numbering(polarized?)
   density-level:DensityLevel = DENSITY-LEVEL
   ) -> Molded-2pin :
   #Molded-2pin(
-    lead-span, lead, polarized?, pin-1-id?,
+    lead-span, lead, polarized?, pin-1-id?, keep-out,
     package-body, pad-planner, lead-numbering
     density-level
   )
@@ -160,3 +170,12 @@ public defmethod build-silkscreen (
       add-pin-1-dot(vp, marker-pt)
 
   add-reference-designator(vp)
+
+public defmethod build-keep-out (
+  pkg:Molded-2pin,
+  vp:VirtualLP
+  ):
+  match(keep-out(pkg)):
+    (_:None): false
+    (given:One<KeepoutCreator>):
+      build-keep-out(value(given), vp)

--- a/tests/landpatterns/two-pin/SMT.stanza
+++ b/tests/landpatterns/two-pin/SMT.stanza
@@ -168,7 +168,7 @@ deftest(two-pin) test-resistor-smt :
 
 deftest(two-pin) test-capacitor-smt :
 
-  val pkg = get-capacitor-pkg("1206", DensityLevelB)
+  val pkg = get-capacitor-pkg("1206", density-level = DensityLevelB)
 
   val lp = create-landpattern(pkg)
   val grid = PadGrid(lp)
@@ -189,7 +189,7 @@ deftest(two-pin) test-capacitor-smt :
 
 deftest(two-pin) test-capacitor-smt-with-pose:
 
-  val pkg = get-capacitor-pkg("1206", DensityLevelB)
+  val pkg = get-capacitor-pkg("1206", density-level = DensityLevelB)
 
   val lp = create-landpattern(pkg, pose = loc(-0.5, 0.0))
   val grid = PadGrid(lp)

--- a/tests/landpatterns/two-pin/SMT.stanza
+++ b/tests/landpatterns/two-pin/SMT.stanza
@@ -147,7 +147,7 @@ deftest(two-pin) test-chip-table :
 
 deftest(two-pin) test-resistor-smt :
 
-  val pkg = get-resistor-pkg("0402", DensityLevelC)
+  val pkg = get-resistor-pkg("0402", density-level = DensityLevelC)
 
   val lp = create-landpattern(pkg)
   val grid = PadGrid(lp)


### PR DESCRIPTION
This provides a mechanism for customizing the keep out generators for components, specifically SMT components: 
![image](https://github.com/user-attachments/assets/062a8c40-2640-442f-aba8-d63f95a5dc44)

Notice that this keepout currently works for planes but it is not yet working for traces.

Goal will be to expand this to support QFNs and other packages where we need to provide keepout functionality.