### PR TITLE
Add App Specific Keepout Generator

### DIFF
--- a/examples/landpatterns/app-specific-keepout.stanza
+++ b/examples/landpatterns/app-specific-keepout.stanza
@@ -1,0 +1,65 @@
+#use-added-syntax(jitx)
+defpackage jsl/examples/landpatterns/app-specific-keepout:
+  import core
+  import jitx
+  import jitx/commands
+
+  import jsl/design/settings
+  import jsl/symbols
+  import jsl/landpatterns
+
+  import jsl/examples/landpatterns/board
+
+val board-shape = RoundedRectangle(50.0, 50.0, 0.25)
+
+pcb-component test-SOIC:
+
+  pin-properties :
+    [pin:Ref | pads:Ref ... | side:Dir ]
+    [VDD | p[5] | Up ]
+    [VIN+ | p[3] | Left ]
+    [VIN- | p[4] | Left ]
+    [VSS | p[2] | Down ]
+    [VOUT | p[1] | Right ]
+
+  val box = BoxSymbol(self)
+  assign-symbol $ create-symbol(box)
+
+  val pkg = SOIC-N(
+    num-leads = 8,
+    lead-span = min-max(5.8, 6.2),
+    package-length = 4.5 +/- 0.10,
+    density-level = DensityLevelC
+  )
+
+  val lp = create-landpattern(pkg)
+  assign-landpattern(lp)
+
+doc: \<DOC>
+Application Specific Keepout Overlay Example
+
+This circuit creates two component instances and
+applies an application specific keepout to one of them
+This keepout is on the top layer by default and will
+track the instance as it moves in the layout.
+<DOC>
+pcb-module test-design:
+  inst non-keepout : test-SOIC
+
+  inst app-keepout : test-SOIC
+  val KO = KeepoutOverlay(Rectangle(4.0, 6.0))
+  make-keepout-overlay(KO, app-keepout, name = "D-Overlay")
+
+
+; Set the top level module (the module to be compile into a schematic and PCB)
+set-current-design("APP-Specific-Keepout-TEST")
+set-rules(default-rules)
+set-board(default-board(board-shape))
+
+set-main-module(test-design)
+
+; Use any helper function from helpers.stanza here. For example:
+; run-check-on-design(my-design)
+
+; View the results
+view-board()

--- a/src/landpatterns/keep-outs.stanza
+++ b/src/landpatterns/keep-outs.stanza
@@ -5,6 +5,7 @@ defpackage jsl/landpatterns/keep-outs:
   import jitx/commands
 
   import jsl/ensure
+  import jsl/utils
   import jsl/geometry/box
   import jsl/landpatterns/VirtualLP
   import jsl/landpatterns/silkscreen
@@ -24,6 +25,8 @@ This function will generate the necessary keep-out artwork
 in the virtual LP scene graph.
 <DOC>
 public defmulti build-keep-out (kc:KeepoutCreator, vp:VirtualLP -- side:Side = Top) -> False
+
+public val DEF_KEEPOUT_LAYER_SET = [LayerIndex(0)]
 
 doc: \<DOC>
 Keepout Creator for Intra-pad Keepouts
@@ -50,7 +53,7 @@ public defstruct IntraPadKeepOut <: KeepoutCreator :
   <DOC>
   layer-set:Tuple<LayerIndex> with:
     ensure => ensure-not-empty!
-    default => [LayerIndex(0)]
+    default => DEF_KEEPOUT_LAYER_SET
 
   doc: \<DOC>
   Shrink the created keepout
@@ -87,6 +90,104 @@ public defmethod build-keep-out (k:IntraPadKeepOut, vp:VirtualLP -- side:Side = 
     add-artwork(vp, fb, sh, class = cls)
 
 
+doc: \<DOC>
+Application Layer Keepout Generator Interface
+
+This type defines an interface for application layer keepout generators.
+The idea is that sometimes, you will want to have a keepout placed over
+a component - but you don't want to change the `pcb-component` definition
+to introduce this keepout there.
+
+For example - if your application requires
+a 32 layer board and you want keepouts on layers 16 and 19 - it may not make
+sense to encode this in the `pcb-component`.
+<DOC>
+public deftype IKeepoutOverlay
+
+doc: \<DOC>
+Retrieve the Keepout Shape for a particular Copper Layer
+@param k KeepoutOverlay object
+@param lyId Optionally create custom shapes based on the desired layer.
+See {@link KeepoutOverlay} for a constant shape variant.
+@return geometry for the constructed keepout region. This shape
+can be offset with a {@link Pose} for offset keepouts.
+<DOC>
+public defmulti shape (k:IKeepoutOverlay, lyId:LayerIndex) -> Shape
+
+doc: \<DOC>
+Keepout Overlay Generator
+
+This method must be called from a `pcb-module` context.
+This method will construct a Keepout object and then place it in the
+current `pcb-module` context relative to the passed `other` instance.
+The Keepout object is basically a `pcb-module` that only contains
+`layer` statements.
+
+@param k KeepoutOverlay object
+@param other Component or Module Instance which the constructed keepout object will
+track.
+@param layer-set Set of copper layers that keepouts will be drawn on. By default this
+is only the top layer.
+@param side Which side of the board to work from
+@param name Optional name to apply to the keepout object. This is useful for
+differentiating multiple keepout objects in a board.
+
+<DOC>
+public defmulti make-keepout-overlay (k:IKeepoutOverlay, other:JITXObject -- layer-set:Tuple<LayerIndex> = DEF_KEEPOUT_LAYER_SET, side:Side = Top, name:String = ?) -> False
+
+doc: \<DOC>
+Default Implementation
+<DOC>
+public defmethod make-keepout-overlay (k:IKeepoutOverlay, other:JITXObject -- layer-set:Tuple<LayerIndex> = DEF_KEEPOUT_LAYER_SET, side:Side = Top, name:String = ?) :
+  val lySh-set = to-tuple $ for lyId in layer-set seq:
+    lyId => shape(k, lyId)
+
+  inside pcb-module:
+    inst ko : keepout-overlay(lySh-set, name? = name)
+    place(ko) at loc(0.0, 0.0) on side (relative-to other)
+
+doc: \<DOC>
+Keepout Overlay Object Definition
+
+This module is used to construct the `keepout-overlay` instance in `make-keepout-overlay`
+It primarily consists of layer statements on `ForbidCopper(layerId)`.
+
+@param layer-set Set of `copper => Shape` mappings that will be constructed as keepouts
+@param name? Optional Name for the module.
+<DOC>
+public pcb-module keepout-overlay (layer-set:Tuple<KeyValue<LayerIndex, Shape>> -- name?:Maybe<String> = None()):
+  match(name?):
+    (_:None):
+      false
+    (given:One<String>):
+      name = value(given)
+
+  for kvp in layer-set do:
+    val [lyId, sh] = unpack(kvp)
+    layer(ForbidCopper(lyId)) = sh
+
+
+doc: \<DOC>
+Constant Shape Keepout Overlay Generator
+
+This generator implements the IKeepoutOverlay interface
+and constructs keepouts of the same shape on all
+requested copper layers.
+<DOC>
+public deftype KeepoutOverlay <: IKeepoutOverlay
+
+doc: \<DOC>
+Constructor for KeepoutOverlay
+@param const-shape Constant Geometry that will be applied on all copper layers
+requested.
+<DOC>
+public defn KeepoutOverlay (const-shape:Shape) -> KeepoutOverlay:
+  val sh = const-shape
+  new KeepoutOverlay:
+    defmethod shape (this, lyId:LayerIndex) -> Shape:
+      sh
+    defmethod print (o:OutputStream, this) :
+      print(o, "KeepoutOverlay(%_)" % [sh])
 
 
 


### PR DESCRIPTION
This allows us to create keepouts outside of `pcb-component` definitions but have them track a particular instance in the layout. 

![Screenshot 2024-09-30 145802](https://github.com/user-attachments/assets/12a48ae2-285e-4108-add2-4e26a2cfab53)

Example:
```
  inst USBC : connectors/components/USB/USBTypeC/device

  ; Construct Pour Keepouts on applicable layers
  val KO = KeepoutOverlay(Rectangle(3.0, 4.0))
  make-keepout-overlay(
    KO, USBC.J,
    layer-set = [LayerIndex(0), LayerIndex(2), LayerIndex(3)]
    name = "USBC-Keepout"
    )

```

