### PR TITLE
Pin Models for `topo-bus` instantiated components

### DIFF
--- a/src/landpatterns/leads.stanza
+++ b/src/landpatterns/leads.stanza
@@ -16,12 +16,15 @@ defpackage jsl/landpatterns/leads:
 doc: \<DOC>
 Generate the Bounding Dims of a sequence of pads
 @param lp-pads the pads that we want to create a bounding
-rectangle of.
+rectangle of. These pads should be in the same component for
+this function to make sense.
 @param layer-spec Optional layer specifier that will compute
   the bounds based on the geometry in a particular layer.
   If this value is false - we compute the boundary based on the
   copper pad geometry only.
 @param expand-by Amount to expand the created dimension by.
+@return Axis aligned box that contains the selected objects. Note
+that this box is in the frame of reference of the associated component.
 <DOC>
 public defn bounds (
   lp-pads:Seqable<LandPatternPad|VirtualPad>

--- a/src/si/bus.stanza
+++ b/src/si/bus.stanza
@@ -125,11 +125,23 @@ defn connect (lhs:Tuple, r:KeyValue|JITXObject|Tuple|Instantiable, acc:Vector, s
     (x:Instantiable) :
       connect-topo-bus(lhs, x, acc, short-trace?)
 
+defn add-pin-model (i:JITXObject, delay:Toleranced = typ(0.0), loss:Toleranced = typ(0.0)) :
+  inside pcb-module:
+    val [p1, p2] = get-element-ports(i)
+    pin-model(p1, p2) = PinModel(delay, loss)
+
 defn connect-topo-bus (lhs:Tuple, rhs:Instantiable, acc, short-trace?:True|False) -> Tuple :
   inside pcb-module :
     to-tuple $
       for l in lhs seq :
         inst i : rhs
+        ; TODO - This is a hack
+        ;  We need to add the ability to insert the pin model into the created
+        ;  component definition instead of into the instance. This requires a change
+        ;  to the query API. This is allows SI constrained topologies to work even
+        ;  without that feature present.
+        ;  Remove this when we have closed PROD-530
+        add-pin-model(i)
         add(acc, i)
         val [p1, p2] = get-element-ports(i)
         topo-net(l, p1)


### PR DESCRIPTION
This is a bit of a hack that is needed until we can address PROD-530
This allows SI topologies to properly construct constraints when using topo-bus.