### PR TITLE
[Refactor] Removed constant name statements on bundles

### DIFF
--- a/src/bundles/comms.stanza
+++ b/src/bundles/comms.stanza
@@ -15,7 +15,6 @@ protocol
 @member scl Synchronous Clock Line
 <DOC>
 public pcb-bundle i2c:
-  name = "I2C"
   description = "Inter-Integrated Circuit (I2C) - Serial Communication Protocol"
   port sda
   port scl
@@ -31,7 +30,6 @@ public pcb-enum jsl/bundles/comms/SMBUSPins :
   SMBSUS#
 
 pcb-bundle smbus-b (pins:Collection<SMBUSPins>):
-  name = "SMBus"
   description = "System Management Bus (SMBus) - Serial Communication Protocol"
   port smbclk
   port smbdat
@@ -88,7 +86,6 @@ which consists of a differential pair `H` / `L`
 
 <DOC>
 public pcb-bundle can-phy :
-  name = "CAN Physical Interface"
   port H
   port L
 
@@ -124,7 +121,6 @@ public pcb-enum jsl/bundles/comms/SPIPins :
   SPI-CIPO
 
 pcb-bundle spi-b (pins:Collection<SPIPins>):
-  name = "SPI"
   port sck
   for p in pins do :
     switch(p) :
@@ -267,7 +263,6 @@ public pcb-enum jsl/bundles/comms/UARTPins :
   UART-TX
 
 pcb-bundle uart-b (pins:Collection<UARTPins>):
-  name = "UART"
   for p in pins do :
     switch(p) :
       UART-DTR : make-port(`dtr)

--- a/src/bundles/debug.stanza
+++ b/src/bundles/debug.stanza
@@ -19,7 +19,6 @@ or microcontroller.
 @member tms State Select Line
 <DOC>
 public pcb-bundle jtag :
-  name = "JTAG"
   port tck
   port tdi
   port tdo
@@ -29,7 +28,6 @@ public pcb-enum jsl/bundles/debug/SWDPins :
   SWD-SWO ; Trace Output for Serial Wire Debug
 
 pcb-bundle swd-b (pins:Collection<SWDPins>):
-  name = "SWD"
   port swdio
   port swdclk
   for p in pins do:

--- a/src/bundles/general.stanza
+++ b/src/bundles/general.stanza
@@ -23,7 +23,6 @@ ports/bundles.
 @member N Negative side of the differential pair
 <DOC>
 public pcb-bundle diff-pair :
-  name = "Differential Signal Pair"
   port N
   port P
 
@@ -40,7 +39,6 @@ No directionality is implied by this bundle.
 
 <DOC>
 public pcb-bundle dual-pair :
-  name = "Dual Pair Bundle"
   port A : diff-pair
   port B : diff-pair
 
@@ -55,7 +53,6 @@ The lane pair is a directed differential pair lane
 @member RX Receive Pair
 <DOC>
 public pcb-bundle lane-pair :
-  name = "Lane Pair Bundle"
   port TX : diff-pair
   port RX : diff-pair
 
@@ -89,7 +86,6 @@ of a DC power source.
 @member V- Negative Voltage of the Power Bundle
 <DOC>
 public pcb-bundle power :
-  name = "DC Power"
   port V+
   port V-
 
@@ -128,7 +124,6 @@ Differential Pair ADC Interface Bundle
 @member N Negative side of the ADC differential pair
 <DOC>
 public pcb-bundle adc-diff-pair :
-  name = "ADC Differential Signal Pair"
   port P
   port N
 
@@ -147,7 +142,6 @@ Differential Pair DAC Interface Bundle
 @member N Negative side of the DAC differential pair
 <DOC>
 public pcb-bundle dac-diff-pair :
-  name = "DAC Differential Signal Pair"
   port P
   port N
 
@@ -166,7 +160,6 @@ Clock Differential Pair
 @member N Negative side of the clock differential pair
 <DOC>
 public pcb-bundle clk-diff-pair :
-  name = "Clock Differential Signal Pair"
   port P
   port N
 
@@ -177,7 +170,6 @@ High-Speed Differential Pair
 @member N Negative side of the high-speed differential pair
 <DOC>
 public pcb-bundle hs-diff-pair :
-  name = "High-Speed Differential Signal Pair"
   port P
   port N
 


### PR DESCRIPTION
Current hypothesis is that this was causing confusion when debugging bundles because the bundle definition name was overriden with the `name` statement string.

I haven't changed the `protocols` bundles yet.

@bhusang  -  This might address the issues that we were encountering when debugging OCDB and JSL mixed definitions.