### PR TITLE
Prod 598 remove get connected net

### DIFF
--- a/src/design/introspection.stanza
+++ b/src/design/introspection.stanza
@@ -449,55 +449,6 @@ public defn find-instance-by-ref (r:Ref, cxt:JITXObject = self) -> Maybe<JITXObj
     trail-comp?
 
 doc: \<DOC>
-Get the net associated with a module or component port
-
-This function must be called from within a `pcb-module` context.
-
-Note that this function will fail to find a net if the passed `pt`
-port is not part of a component or module in the local context.
-For example, if the design contains:
-
-```stanza
-pcb-module wrapper:
-  port GND
-  inst C : some-component
-
-  ; `INT` is defined only in the `wrapper`
-  ;   context.
-  net INT (C.internal-port, ...)
-
-pcb-module top-level:
-
-  inst W : wrapper
-  net GND (W.GND)
-
-  ; This will work
-  val n1 = get-connected-net!(W.GND)
-
-  ; This will not work
-  val n2 = get-connected-net!(W.C.internal-port)
-```
-
-The value for `n1` will be successfully found as the `GND`
-net because it is defined within the `pcb-module` context.
-
-The `n2` invocation will fail to find `INT` as the net
-for `W.C.internal-port` and return `None()`.
-
-@param pt Port of a component or module in this module context.
-@param cxt Optional context to search. The default value is `self`.
-@return If a connection is found - this function returns the Net as
-a JITXObject. If no connection is found - then None().
-<DOC>
-public defn get-connected-net (pt:JITXObject, cxt:JITXObject = self) -> Maybe<JITXObject>:
-  inside pcb-module:
-    for n in nets(cxt) first :
-      if connected?([pt, n]):
-        One(n)
-      else:
-        None()
-
-doc: \<DOC>
 Get all net statements associated with a module or component port
 
 This function must be called from within a `pcb-module` context.
@@ -548,31 +499,6 @@ public defn get-connected-nets (pt:JITXObject, cxt:JITXObject = self) -> Tuple<J
           One(n)
         else:
           None()
-
-doc: \<DOC>
-Get the net associated with a module or component port
-
-This function must be called from within a `pcb-module` context.
-
-This function has similar constraints to @{link get-connected-net}.
-
-@param pt Port of a component or module in this module context.
-@param cxt Optional context to search. The default value is `self`.
-@return A `Net` object as a JITXObject if the port is connected.
-@throws ValueError if no net connections are found or if more than one net
-connection is found.
-<DOC>
-public defn get-connected-net! (pt:JITXObject, cxt:JITXObject = self) -> JITXObject:
-  inside pcb-module:
-    val n-set = to-tuple $ for n in nets(cxt) filter :
-      connected?([pt, n])
-
-    if length(n-set) == 0:
-      throw $ ValueError("Invalid Port - No net connection found")
-    else if length(n-set) > 1 :
-      throw $ ValueError("Invalid Port - Multiple Nets Associated - Expected Singular Net")
-
-    n-set[0]
 
 doc: \<DOC>
 Port Info Object

--- a/src/landpatterns/thermal-vias.stanza
+++ b/src/landpatterns/thermal-vias.stanza
@@ -176,8 +176,8 @@ public defmethod make-thermal-vias (tv:GridThermalVias, pt:PortInfo -- via-net?:
     ;  arrangement so that the target pad is associated with a single port.
     val pd-info = get-largest-pad( pad-set(pt) )
     val pad-origin = pose(pd-info)
-
-    geom(n):
+    net via-net (n)
+    geom(via-net):
       for pos in grid(grid-def(tv)) do:
         val [r, c] = [row(pos), column(pos)]
         if active?(tv, r, c):


### PR DESCRIPTION
Remove get-connected-net
Also instantiate a new net in `make-thermal-vias` in order to eliminate any potential stabilization weirdness related to picking an arbitrary esir net.