### PR TITLE
Simplify top level

### DIFF
--- a/examples/components/QuadAND.stanza
+++ b/examples/components/QuadAND.stanza
@@ -4,11 +4,7 @@ defpackage jsl/examples/components/QuadAND:
   import jitx
   import jitx/commands
 
-  import jsl/bundles
-  import jsl/design/settings
-  import jsl/symbols
-  import jsl/landpatterns
-
+  import jsl
   import jsl/examples/landpatterns/board
 
 pcb-component QuadAND:

--- a/examples/landpatterns/BGA-Stagger.stanza
+++ b/examples/landpatterns/BGA-Stagger.stanza
@@ -4,9 +4,7 @@ defpackage jsl/examples/landpatterns/BGA-stagger:
   import jitx
   import jitx/commands
 
-  import jsl/design/settings
-  import jsl/landpatterns
-  import jsl/symbols
+  import jsl
   import jsl/examples/landpatterns/board
 
 val board-shape = RoundedRectangle(50.0, 50.0, 0.25)

--- a/examples/landpatterns/BGA-complex.stanza
+++ b/examples/landpatterns/BGA-complex.stanza
@@ -4,9 +4,7 @@ defpackage jsl/examples/landpatterns/BGA-complex:
   import jitx
   import jitx/commands
 
-  import jsl/design/settings
-  import jsl/landpatterns
-
+  import jsl
   import jsl/examples/landpatterns/board
 
 val board-shape = RoundedRectangle(50.0, 50.0, 0.25)

--- a/examples/landpatterns/BGA-simple.stanza
+++ b/examples/landpatterns/BGA-simple.stanza
@@ -4,10 +4,7 @@ defpackage jsl/examples/landpatterns/BGA-simple:
   import jitx
   import jitx/commands
 
-  import jsl/design/settings
-  import jsl/symbols
-  import jsl/landpatterns
-
+  import jsl
   import jsl/examples/landpatterns/board
 
 val board-shape = RoundedRectangle(50.0, 50.0, 0.25)

--- a/examples/landpatterns/BGA-thermal-enhanced.stanza
+++ b/examples/landpatterns/BGA-thermal-enhanced.stanza
@@ -4,10 +4,7 @@ defpackage jsl/examples/landpatterns/BGA-thermal-enhanced:
   import jitx
   import jitx/commands
 
-  import jsl/design/settings
-  import jsl/landpatterns
-  import jsl/symbols
-
+  import jsl
   import jsl/examples/landpatterns/board
 
 

--- a/examples/landpatterns/Molded-2pin.stanza
+++ b/examples/landpatterns/Molded-2pin.stanza
@@ -4,9 +4,7 @@ defpackage jsl/examples/landpatterns/Molded-2pin:
   import jitx
   import jitx/commands
 
-  import jsl/symbols
-  import jsl/landpatterns
-
+  import jsl
   import jsl/examples/landpatterns/board
 
 pcb-component test-inductor :

--- a/examples/landpatterns/QFN.stanza
+++ b/examples/landpatterns/QFN.stanza
@@ -5,9 +5,7 @@ defpackage jsl/examples/landpatterns/QFN:
   import jitx
   import jitx/commands
 
-  import jsl/design/settings
-  import jsl/landpatterns
-
+  import jsl
   import jsl/examples/landpatterns/board
 
 val board-shape = RoundedRectangle(50.0, 50.0, 0.25)

--- a/examples/landpatterns/QFP.stanza
+++ b/examples/landpatterns/QFP.stanza
@@ -5,10 +5,7 @@ defpackage jsl/examples/landpatterns/QFP:
   import jitx
   import jitx/commands
 
-  import jsl/design/settings
-  import jsl/landpatterns
-  import jsl/symbols
-
+  import jsl
   import jsl/examples/landpatterns/board
 
 val board-shape = RoundedRectangle(50.0, 50.0, 0.25)

--- a/examples/landpatterns/Radial.stanza
+++ b/examples/landpatterns/Radial.stanza
@@ -5,9 +5,7 @@ defpackage jsl/examples/landpatterns/Radial-polarized:
   import jitx
   import jitx/commands
 
-  import jsl/design/settings
-  import jsl/landpatterns
-
+  import jsl
   import jsl/examples/landpatterns/board
 
 val board-shape = RoundedRectangle(50.0, 50.0, 0.25)

--- a/examples/landpatterns/SMT-polarized.stanza
+++ b/examples/landpatterns/SMT-polarized.stanza
@@ -5,9 +5,7 @@ defpackage jsl/examples/landpatterns/SMT-polarized:
   import jitx
   import jitx/commands
 
-  import jsl/design/settings
-  import jsl/landpatterns
-
+  import jsl
   import jsl/examples/landpatterns/board
 
 val board-shape = RoundedRectangle(50.0, 50.0, 0.25)

--- a/examples/landpatterns/SMT.stanza
+++ b/examples/landpatterns/SMT.stanza
@@ -5,9 +5,7 @@ defpackage jsl/examples/landpatterns/SMT:
   import jitx
   import jitx/commands
 
-  import jsl/design/settings
-  import jsl/landpatterns
-
+  import jsl
   import jsl/examples/landpatterns/board
 
 val board-shape = RoundedRectangle(50.0, 50.0, 0.25)

--- a/examples/landpatterns/SOIC32W.stanza
+++ b/examples/landpatterns/SOIC32W.stanza
@@ -4,9 +4,7 @@ defpackage jsl/examples/landpatterns/SOIC32W:
   import jitx
   import jitx/commands
 
-  import jsl/design/settings
-  import jsl/landpatterns
-
+  import jsl
   import jsl/examples/landpatterns/board
 
 val board-shape = RoundedRectangle(50.0, 50.0, 0.25)

--- a/examples/landpatterns/SOIC8N.stanza
+++ b/examples/landpatterns/SOIC8N.stanza
@@ -4,9 +4,7 @@ defpackage jsl/examples/landpatterns/SOIC8N:
   import jitx
   import jitx/commands
 
-  import jsl/design/settings
-  import jsl/landpatterns
-
+  import jsl
   import jsl/examples/landpatterns/board
 
 val board-shape = RoundedRectangle(50.0, 50.0, 0.25)

--- a/examples/landpatterns/SON.stanza
+++ b/examples/landpatterns/SON.stanza
@@ -4,9 +4,7 @@ defpackage jsl/examples/landpatterns/SON:
   import jitx
   import jitx/commands
 
-  import jsl/landpatterns
-  import jsl/symbols
-
+  import jsl
   import jsl/examples/landpatterns/board
 
 

--- a/examples/landpatterns/SOP.stanza
+++ b/examples/landpatterns/SOP.stanza
@@ -4,10 +4,7 @@ defpackage jsl/examples/landpatterns/SOP:
   import jitx
   import jitx/commands
 
-  import jsl/design/settings
-  import jsl/landpatterns
-  import jsl/symbols
-
+  import jsl
   import jsl/examples/landpatterns/board
 
 

--- a/examples/landpatterns/SOT.stanza
+++ b/examples/landpatterns/SOT.stanza
@@ -4,10 +4,7 @@ defpackage jsl/examples/landpatterns/SOT:
   import jitx
   import jitx/commands
 
-  import jsl/landpatterns
-  import jsl/symbols
-  import jsl/design/settings
-
+  import jsl
   import jsl/examples/landpatterns/board
 
 

--- a/examples/landpatterns/Uneven-QFN.stanza
+++ b/examples/landpatterns/Uneven-QFN.stanza
@@ -5,9 +5,7 @@ defpackage jsl/examples/landpatterns/Uneven-QFN:
   import jitx
   import jitx/commands
 
-  import jsl/design/settings
-  import jsl/landpatterns
-
+  import jsl
   import jsl/examples/landpatterns/board
 
 val board-shape = RoundedRectangle(50.0, 50.0, 0.25)

--- a/examples/landpatterns/app-specific-keepout.stanza
+++ b/examples/landpatterns/app-specific-keepout.stanza
@@ -4,10 +4,7 @@ defpackage jsl/examples/landpatterns/app-specific-keepout:
   import jitx
   import jitx/commands
 
-  import jsl/design/settings
-  import jsl/symbols
-  import jsl/landpatterns
-
+  import jsl
   import jsl/examples/landpatterns/board
 
 val board-shape = RoundedRectangle(50.0, 50.0, 0.25)

--- a/examples/landpatterns/headers.stanza
+++ b/examples/landpatterns/headers.stanza
@@ -4,9 +4,7 @@ defpackage jsl/examples/landpatterns/headers:
   import jitx
   import jitx/commands
 
-  import jsl/landpatterns
-  import jsl/symbols
-
+  import jsl
   import jsl/examples/landpatterns/board
 
 pcb-bundle header (w:Int):

--- a/examples/pin-assignment/circuit-pool.stanza
+++ b/examples/pin-assignment/circuit-pool.stanza
@@ -4,22 +4,8 @@ defpackage jsl/examples/pin-assignment/circuit-pool:
   import jitx
   import jitx/commands
 
-  import jsl/errors
-  import jsl/bundles
-
-  import jsl/design/settings
-  import jsl/symbols
-  import jsl/landpatterns
-
-  import jsl/si/pairs
-  import jsl/pin-assignment
-
-  import jsl/protocols/ethernet/MDI/MDI-1000Base-T
-  import jsl/protocols/ethernet/MII/RGMII
-
+  import jsl
   import jsl/examples/landpatterns/board
-
-
 
 pcb-component esd-protector (num-chs:Int = 4):
   if (num-chs % 2) != 0 :

--- a/examples/pin-assignment/swizzle.stanza
+++ b/examples/pin-assignment/swizzle.stanza
@@ -19,11 +19,7 @@ defpackage jsl/examples/pin-assignment/swizzle:
   import jitx
   import jitx/commands
 
-  import jsl/pin-assignment
-  import jsl/layerstack
-  import jsl/symbols
-  import jsl/landpatterns
-  import jsl/si/helpers
+  import jsl
 
 pcb-bundle header (w:Int):
   port D : pin[w]

--- a/examples/protocols/common/example-components.stanza
+++ b/examples/protocols/common/example-components.stanza
@@ -6,11 +6,7 @@ defpackage jsl/examples/protocols/common/example-components:
   import jitx/commands
   import jitx/emodels
 
-  import jsl/design/settings
-  import jsl/symbols
-  import jsl/landpatterns
-
-  import jsl/si/helpers
+  import jsl
 
 public pcb-component block-cap (value:Double):
   name = "block-cap"

--- a/examples/protocols/displayport/displayport-main.stanza
+++ b/examples/protocols/displayport/displayport-main.stanza
@@ -5,14 +5,7 @@ defpackage jsl/examples/protocols/displayport/main:
   import jitx
   import jitx/commands
 
-
-  import jsl/design/settings
-  import jsl/symbols/SymbolDefn
-
-  import jsl/protocols/displayport
-  import jsl/bundles
-  import jsl/si
-
+  import jsl
   import jsl/examples/protocols/common/example-board
   import jsl/examples/protocols/common/example-components
 

--- a/examples/protocols/displayport/displayport-src.stanza
+++ b/examples/protocols/displayport/displayport-src.stanza
@@ -4,14 +4,7 @@ defpackage jsl/examples/protocols/displayport/displayport-src :
   import jitx
   import jitx/commands
 
-  import jsl/symbols
-  import jsl/landpatterns
-
-  import jsl/design/settings
-  import jsl/si/helpers
-  import jsl/pin-assignment
-  import jsl/bundles
-  import jsl/protocols/displayport
+  import jsl
 
 doc: \<DOC>
 @brief DisplayPort dummy component

--- a/examples/protocols/ethernet/10GBASE-KR/e10GBASE-KR-main.stanza
+++ b/examples/protocols/ethernet/10GBASE-KR/e10GBASE-KR-main.stanza
@@ -6,18 +6,14 @@ defpackage jsl/examples/protocols/ethernet/10GBASE-KR/e10GBASE-KR-main:
   import jitx/commands
 
 
-  import jsl/design/settings
-
-  import jsl/protocols/ethernet/MDI/e10GBASE-KR
-  import jsl/si/helpers
-
+  import jsl
   import jsl/examples/protocols/common/example-board
   import jsl/examples/protocols/common/example-components
   import jsl/examples/protocols/ethernet/10GBASE-KR/e10GBASE-KR-src
 
 
 pcb-module e10GBASE-KR-example :
-  
+
   inst dut1  : jsl/examples/protocols/ethernet/10GBASE-KR/e10GBASE-KR-src/module(invert = false)
   inst dut2  : jsl/examples/protocols/ethernet/10GBASE-KR/e10GBASE-KR-src/module(invert = true)
   inst conn1 : jsl/examples/protocols/ethernet/10GBASE-KR/e10GBASE-KR-src/edge-connector

--- a/examples/protocols/ethernet/10GBASE-KR/e10GBASE-KR-src.stanza
+++ b/examples/protocols/ethernet/10GBASE-KR/e10GBASE-KR-src.stanza
@@ -5,14 +5,7 @@ defpackage jsl/examples/protocols/ethernet/10GBASE-KR/e10GBASE-KR-src :
   import jitx/commands
   import math
 
-  import jsl/symbols
-  import jsl/landpatterns
-
-  import jsl/design/settings
-  import jsl/si/helpers
-  import jsl/pin-assignment
-  import jsl/bundles
-  import jsl/protocols/ethernet/MDI/e10GBASE-KR
+  import jsl
 
 doc: \<DOC>
 @brief e10GBASE-KR dummy component

--- a/examples/protocols/ethernet/RGMII_1000BaseT/main.stanza
+++ b/examples/protocols/ethernet/RGMII_1000BaseT/main.stanza
@@ -4,17 +4,7 @@ defpackage jsl/examples/ethernet/RGMII_1000BaseT/main:
   import jitx
   import jitx/commands
 
-  import jsl/design/settings
-  import jsl/symbols
-
-  import jsl/si
-  import jsl/bundles
-  import jsl/pin-assignment
-  import jsl/protocols/ethernet/MDI/MDI-1000Base-T
-  import jsl/protocols/ethernet/MII/RGMII
-
-  import jsl/landpatterns
-
+  import jsl
   import jsl/examples/protocols/common/example-board
 
 

--- a/examples/protocols/ethernet/RMII_100BaseTX/main.stanza
+++ b/examples/protocols/ethernet/RMII_100BaseTX/main.stanza
@@ -5,16 +5,7 @@ defpackage jsl/examples/protocols/ethernet/RMII_100BaseT:
   import jitx/commands
   import jitx/parts/query-api
 
-  import jsl/design/settings
-  import jsl/symbols
-  import jsl/landpatterns
-
-  import jsl/si
-  import jsl/bundles
-  import jsl/pin-assignment
-  import jsl/protocols/ethernet/MDI/MDI-100Base-TX
-  import jsl/protocols/ethernet/MII/RMII
-
+  import jsl
   import jsl/examples/protocols/common/example-board
 
 

--- a/examples/protocols/pcie/pcie-main.stanza
+++ b/examples/protocols/pcie/pcie-main.stanza
@@ -6,10 +6,7 @@ defpackage jsl/examples/protocols/pcie/main:
   import jitx/commands
 
 
-  import jsl/design/settings
-
-  import jsl/protocols/pcie
-  import jsl/si
+  import jsl
 
   import jsl/examples/protocols/common/example-board
   import jsl/examples/protocols/common/example-components

--- a/examples/protocols/pcie/pcie-src.stanza
+++ b/examples/protocols/pcie/pcie-src.stanza
@@ -4,15 +4,7 @@ defpackage jsl/examples/protocols/pcie/pcie-src :
   import jitx
   import jitx/commands
 
-  import jsl/symbols
-  import jsl/landpatterns
-
-  import jsl/design/settings
-  import jsl/si/helpers
-  import jsl/pin-assignment
-  import jsl/bundles
-  import jsl/protocols/pcie
-
+  import jsl
 
 val BGA-pkg = BGA(
   num-leads = 64,

--- a/examples/protocols/sata/SATA-main.stanza
+++ b/examples/protocols/sata/SATA-main.stanza
@@ -6,10 +6,7 @@ defpackage jsl/examples/protocols/sata/SATA-main:
   import jitx/commands
 
 
-  import jsl/design/settings
-
-  import jsl/protocols/sata
-  import jsl/si/helpers
+  import jsl
 
   import jsl/examples/protocols/common/example-board
   import jsl/examples/protocols/common/example-components

--- a/examples/protocols/sata/SATA-src.stanza
+++ b/examples/protocols/sata/SATA-src.stanza
@@ -5,14 +5,7 @@ defpackage jsl/examples/protocols/sata/SATA-src :
   import jitx/commands
   import math
 
-  import jsl/symbols
-  import jsl/landpatterns
-
-  import jsl/design/settings
-  import jsl/si/helpers
-  import jsl/pin-assignment
-  import jsl/bundles
-  import jsl/protocols/sata
+  import jsl
 
 doc: \<DOC>
 @brief SATA dummy component

--- a/examples/protocols/usb/usb-main.stanza
+++ b/examples/protocols/usb/usb-main.stanza
@@ -4,14 +4,7 @@ defpackage jsl/examples/usb/usb-main:
   import jitx
   import jitx/commands
 
-  import jsl/bundles
-  import jsl/protocols/usb
-  import jsl/si/constraints
-  import jsl/si/pairs
-  import jsl/si/helpers
-  import jsl/si/couplers
-  import jsl/symbols
-  import jsl/landpatterns
+  import jsl
 
   import jsl/examples/protocols/common/example-board
   import jsl/examples/protocols/common/example-components

--- a/examples/symbols/DIAC.stanza
+++ b/examples/symbols/DIAC.stanza
@@ -5,10 +5,7 @@ defpackage jsl/examples/symbols/DIAC:
   import jitx
   import jitx/commands
 
-  import jsl/design/settings
-  import jsl/landpatterns
-  import jsl/symbols
-
+  import jsl
   import jsl/examples/landpatterns/board
 
 val symb-defn = DiacSymbol()

--- a/examples/symbols/SCR.stanza
+++ b/examples/symbols/SCR.stanza
@@ -5,10 +5,7 @@ defpackage jsl/examples/symbols/SCR:
   import jitx
   import jitx/commands
 
-  import jsl/design/settings
-  import jsl/landpatterns
-  import jsl/symbols
-
+  import jsl
   import jsl/examples/landpatterns/board
 
 val symb-defn = SCRSymbol()

--- a/examples/symbols/TRIAC.stanza
+++ b/examples/symbols/TRIAC.stanza
@@ -5,10 +5,7 @@ defpackage jsl/examples/symbols/TRIAC:
   import jitx
   import jitx/commands
 
-  import jsl/design/settings
-  import jsl/landpatterns
-  import jsl/symbols
-
+  import jsl
   import jsl/examples/landpatterns/board
 
 val symb-defn = TriacSymbol()

--- a/examples/symbols/audio.stanza
+++ b/examples/symbols/audio.stanza
@@ -5,11 +5,7 @@ defpackage jsl/examples/symbols/audio:
   import jitx
   import jitx/commands
 
-  import jsl/design/settings
-  import jsl/landpatterns
-  import jsl/symbols
-
-
+  import jsl
   import jsl/examples/landpatterns/board
 
 val SOIC-pkg = SOIC-N(

--- a/examples/symbols/box-symbol.stanza
+++ b/examples/symbols/box-symbol.stanza
@@ -5,20 +5,8 @@ defpackage jsl/examples/smbols/box-symbol:
   import jitx
   import jitx/commands
 
-  import jsl/symbols/audio
-  import jsl/symbols/box-symbol
-  import jsl/design/settings
-  import jsl/landpatterns/two-pin/SMT
+  import jsl
   import jsl/examples/landpatterns/board
-  import jsl/landpatterns/packages
-  import jsl/landpatterns/pad-island
-  import jsl/landpatterns/SOIC
-  import jsl/landpatterns/numbering
-  import jsl/landpatterns/pad-planner
-  import jsl/symbols/SymbolDefn
-  import jsl/symbols/decorators
-  import jsl/bundles/comms
-  import jsl/bundles/general
 
 pcb-component basic:
   pin-properties:

--- a/examples/symbols/capacitor.stanza
+++ b/examples/symbols/capacitor.stanza
@@ -5,10 +5,7 @@ defpackage jsl/examples/symbols/capacitor:
   import jitx
   import jitx/commands
 
-  import jsl/design/settings
-  import jsl/landpatterns
-  import jsl/symbols
-
+  import jsl
   import jsl/examples/landpatterns/board
 
 

--- a/examples/symbols/crystal.stanza
+++ b/examples/symbols/crystal.stanza
@@ -4,9 +4,7 @@ defpackage jsl/examples/symbols/crystal:
   import jitx
   import jitx/commands
 
-  import jsl/symbols
-  import jsl/landpatterns
-  import jsl/design/settings
+  import jsl
   import jsl/examples/landpatterns/board
 
 

--- a/examples/symbols/diode-bridge.stanza
+++ b/examples/symbols/diode-bridge.stanza
@@ -5,10 +5,7 @@ defpackage jsl/examples/symbols/diode-bridge:
   import jitx
   import jitx/commands
 
-  import jsl/design/settings
-  import jsl/landpatterns
-  import jsl/symbols
-
+  import jsl
   import jsl/examples/landpatterns/board
 
 

--- a/examples/symbols/diode.stanza
+++ b/examples/symbols/diode.stanza
@@ -5,10 +5,7 @@ defpackage jsl/examples/symbols/diode:
   import jitx
   import jitx/commands
 
-  import jsl/design/settings
-  import jsl/landpatterns
-  import jsl/symbols
-
+  import jsl
   import jsl/examples/landpatterns/board
 
 

--- a/examples/symbols/ferrite.stanza
+++ b/examples/symbols/ferrite.stanza
@@ -4,8 +4,7 @@ defpackage jsl/examples/symbols/ferrite:
   import jitx
   import jitx/commands
 
-  import jsl/symbols
-  import jsl/landpatterns
+  import jsl
   import jsl/examples/landpatterns/board
 
 

--- a/examples/symbols/inductor.stanza
+++ b/examples/symbols/inductor.stanza
@@ -5,10 +5,7 @@ defpackage jsl/examples/symbols/inductor:
   import jitx
   import jitx/commands
 
-  import jsl/design/settings
-  import jsl/landpatterns
-  import jsl/symbols
-
+  import jsl
   import jsl/examples/landpatterns/board
 
 

--- a/examples/symbols/logic.stanza
+++ b/examples/symbols/logic.stanza
@@ -5,10 +5,7 @@ defpackage jsl/examples/symbols/logic:
   import jitx
   import jitx/commands
 
-  import jsl/design/settings
-  import jsl/landpatterns
-  import jsl/symbols
-
+  import jsl
   import jsl/examples/landpatterns/board
 
 val SOIC-pkg = SOIC-N(

--- a/examples/symbols/net-symbols.stanza
+++ b/examples/symbols/net-symbols.stanza
@@ -4,11 +4,7 @@ defpackage jsl/examples/symbols/net-symbols:
   import jitx
   import jitx/commands
 
-  import jsl/design/settings
-  import jsl/landpatterns
-  import jsl/symbols
-
-  import jsl/symbols/net-symbols
+  import jsl
   import jsl/examples/landpatterns/board
 
 

--- a/examples/symbols/opamp.stanza
+++ b/examples/symbols/opamp.stanza
@@ -5,10 +5,7 @@ defpackage jsl/examples/symbols/opamp:
   import jitx
   import jitx/commands
 
-  import jsl/design/settings
-  import jsl/landpatterns
-  import jsl/symbols
-
+  import jsl
   import jsl/examples/landpatterns/board
 
 val pkg = SOIC-N(

--- a/examples/symbols/potentiometer.stanza
+++ b/examples/symbols/potentiometer.stanza
@@ -5,7 +5,7 @@ defpackage jsl/examples/symbols/potentiometer:
   import jitx
   import jitx/commands
 
-  import jsl/symbols
+  import jsl
 
 val symb-defn = PotentiometerSymbol()
 val symb = create-symbol(symb-defn)

--- a/examples/symbols/resistor.stanza
+++ b/examples/symbols/resistor.stanza
@@ -5,9 +5,7 @@ defpackage jsl/examples/symbols/resistor:
   import jitx
   import jitx/commands
 
-  import jsl/design/settings
-  import jsl/landpatterns
-  import jsl/symbols
+  import jsl
 
   import jsl/examples/landpatterns/board
 

--- a/examples/symbols/switches.stanza
+++ b/examples/symbols/switches.stanza
@@ -5,11 +5,7 @@ defpackage jsl/examples/symbols/switches:
   import jitx
   import jitx/commands
 
-  import jsl/design/settings
-  import jsl/landpatterns
-  import jsl/symbols
-
-
+  import jsl
   import jsl/examples/landpatterns/board
 
 val SOIC-pkg = SOIC-N(

--- a/examples/symbols/transformer.stanza
+++ b/examples/symbols/transformer.stanza
@@ -5,10 +5,7 @@ defpackage jsl/examples/symbols/transformer:
   import jitx
   import jitx/commands
 
-  import jsl/design/settings
-  import jsl/landpatterns
-  import jsl/symbols
-
+  import jsl
   import jsl/examples/landpatterns/board
 
 

--- a/examples/symbols/transistors.stanza
+++ b/examples/symbols/transistors.stanza
@@ -5,10 +5,7 @@ defpackage jsl/examples/symbols/transistors:
   import jitx
   import jitx/commands
 
-  import jsl/design/settings
-  import jsl/landpatterns
-  import jsl/symbols
-
+  import jsl
   import jsl/examples/landpatterns/board
 
 defn setup-fet-params () :

--- a/examples/via-structures/diff-via-structure.stanza
+++ b/examples/via-structures/diff-via-structure.stanza
@@ -4,11 +4,7 @@ defpackage jsl/examples/via-structures/diff-via-structures:
   import jitx
   import jitx/commands
 
-  import jsl/via-structures
-  import jsl/si/helpers
-  import jsl/si/pairs
-  import jsl/si/couplers
-  import jsl/geometry/NotchedShapes
+  import jsl
   import jsl/examples/protocols/common/example-board
   import jsl/examples/protocols/common/example-components
 

--- a/examples/via-structures/se-via-structure.stanza
+++ b/examples/via-structures/se-via-structure.stanza
@@ -4,8 +4,7 @@ defpackage jsl/examples/via-structures/se-via-structures:
   import jitx
   import jitx/commands
 
-  import jsl/via-structures
-  import jsl/geometry/NotchedShapes
+  import jsl
   import jsl/examples/protocols/common/example-board
   import jsl/examples/protocols/common/example-components
 

--- a/jsl.stanza
+++ b/jsl.stanza
@@ -1,0 +1,16 @@
+defpackage jsl:
+  forward jsl/bundles
+  forward jsl/circuits
+  forward jsl/design
+  forward jsl/ensure
+  forward jsl/errors
+  forward jsl/geometry
+  forward jsl/landpatterns
+  forward jsl/layerstack
+  forward jsl/math
+  forward jsl/pin-assignment
+  forward jsl/protocols
+  forward jsl/si
+  forward jsl/symbols
+  forward jsl/symbols/net-symbols
+  forward jsl/via-structures

--- a/src/design.stanza
+++ b/src/design.stanza
@@ -1,0 +1,7 @@
+; Forwarding Package for the design sub-package
+defpackage jsl/design:
+  forward jsl/design/Classable
+  forward jsl/design/E-Series
+  forward jsl/design/introspection
+  forward jsl/design/settings
+  forward jsl/design/solvers

--- a/src/geometry.stanza
+++ b/src/geometry.stanza
@@ -1,0 +1,6 @@
+; Forwarding Package for JSL Geometry
+defpackage jsl/geometry:
+  forward jsl/geometry/basics
+  forward jsl/geometry/box
+  forward jsl/geometry/LineRectangle
+  forward jsl/geometry/NotchedShapes

--- a/src/protocols.stanza
+++ b/src/protocols.stanza
@@ -1,12 +1,9 @@
-#use-added-syntax(jitx)
+; Forwarding Package for the Protocol Constraint Definitions
 defpackage jsl/protocols:
-  import core
-  import jitx
-
   forward jsl/protocols/displayport
   forward jsl/protocols/ethernet
   forward jsl/protocols/pcie
   forward jsl/protocols/sata
   forward jsl/protocols/usb
-  forward jsl/protocols/memory/lpddr4
+  forward jsl/protocols/memory
 

--- a/src/protocols.stanza
+++ b/src/protocols.stanza
@@ -8,5 +8,5 @@ defpackage jsl/protocols:
   forward jsl/protocols/pcie
   forward jsl/protocols/sata
   forward jsl/protocols/usb
-  
-  
+  forward jsl/protocols/memory/lpddr4
+

--- a/src/protocols/memory.stanza
+++ b/src/protocols/memory.stanza
@@ -1,0 +1,2 @@
+defpackage jsl/protocols/memory:
+  forward jsl/protocols/memory/lpddr4

--- a/stanza.proj
+++ b/stanza.proj
@@ -1,6 +1,7 @@
 include? ".slm/stanza.proj"  ; Dependencies
 pkg-cache: ".slm/pkg-cache"
 
+package jsl defined-in "./jsl.stanza"
 packages jsl/* defined-in "./src/"
 
 packages jsl/tests/* defined-in "./tests/"


### PR DESCRIPTION
This adds the `import jsl` top level for making it easier to use this library in applications. 