### PR TITLE
Keepout Box Bugfix

### DIFF
--- a/src/geometry/box.stanza
+++ b/src/geometry/box.stanza
@@ -8,19 +8,42 @@ defpackage jsl/geometry/box :
 
   import jsl/errors
 
+public defstruct NegativeBoxError <: Exception :
+  lo:Point
+  hi:Point
+
+defmethod print (o:OutputStream, e:NegativeBoxError):
+  print(o, "Negative Box: lo=%_ hi=%_" % [lo(e), hi(e)])
+
 ;============================================================
 ;========================== Box =============================
 ;============================================================
 
+doc: \<DOC>
+Axis-Aligned Box
+<DOC>
 public defstruct Box <: Equalable :
   lo: Point
   hi: Point
 with :
   constructor => #Box
+  printer => true
 
+doc: \<DOC>
+Constructor for Box Type
+
+The `lo` point must be less than or equal to the `hi`
+point for both X and Y axises.
+
+@param lo Point for the down/left position
+@param hi Point for the up/right position
+
+@throws NegativeBoxError If the `hi` point is
+not greater than or equal to the `lo` point.
+<DOC>
 public defn Box (lo:Point, hi:Point) :
   if x(hi) < x(lo) or y(hi) < y(lo) :
-    throw $ ValueError("Negative Box: lo=%_ hi=%_" % [lo, hi])
+    throw $ NegativeBoxError(lo, hi)
   #Box(lo, hi)
 
 public defn up (b:Box) : y(hi(b))

--- a/src/landpatterns/VirtualLP.stanza
+++ b/src/landpatterns/VirtualLP.stanza
@@ -888,10 +888,22 @@ public defn pad-interior-bounds (vp:VirtualLP, side:Side -- layer-spec:LayerSpec
     val row0 = get-bounds $ get-pads-by-row(vp, 0)
     val row1 = get-bounds $ get-pads-by-row(vp, 1)
 
-    Box(
-      Point(left(row1), up(row1))
-      Point(right(row0), down(row0))
-    )
+    try:
+      Box(
+        Point(left(row1), up(row1))
+        Point(right(row0), down(row0))
+      )
+    catch (e:NegativeBoxError):
+      println("Failed to determine the pad interior bounds.")
+      match(layer-spec):
+        (_:SolderMask):
+          println("This might mean that the soldermask openings of the two pads overlap resulting in a negative area box.")
+        (f:False):
+          println("This suggests that the copper pads for the component overlap.")
+        (f):
+          println("LayerSpec: %_" % [layer-spec])
+      throw $ ValueError("Invalid Pad Interior: %_" % [e])
+      ; throw(e)
 
   else if num-cols == 2 :
     val col0 = get-bounds $ get-pads-by-column(vp, 0)

--- a/src/landpatterns/VirtualLP.stanza
+++ b/src/landpatterns/VirtualLP.stanza
@@ -868,13 +868,19 @@ which was to try and find lines and intersections of those lines.
 This seemed like it might be a bit more robust but at the cost
 of being more complex code wise.
 
+@param vp VirtualLP Scene Graph - we will search for pads here.
+@param side Board side to collect pads from.
+@param layer-spec Specify which layer is used to collect the shapes.
+By default, this function uses the `SolderMask(side)` layer.
+To select the copper on this side - use `false`. See {@link bounds}
+
 @throws ValueError if it encounter a number of columns that it can't
 handle. Specifically, this function can handle [1, 2, 4] columns of pads.
 This corresponds to 2-pin, dual-row, and quad land patterns, respectively.
 <DOC>
-public defn pad-interior-bounds (vp:VirtualLP, side:Side) -> Box:
+public defn pad-interior-bounds (vp:VirtualLP, side:Side -- layer-spec:LayerSpecifier|False = SolderMask(side)) -> Box:
 
-  val get-bounds = bounds{_, layer-spec = SolderMask(side)}
+  val get-bounds = bounds{_, layer-spec = layer-spec}
   val cols = identify-pad-columns(vp)
   val num-cols = length(cols)
   if num-cols == 1:

--- a/src/landpatterns/keep-outs.stanza
+++ b/src/landpatterns/keep-outs.stanza
@@ -73,7 +73,7 @@ with:
 
 public defmethod build-keep-out (k:IntraPadKeepOut, vp:VirtualLP -- side:Side = Top) :
 
-  val b = pad-interior-bounds(vp, side)
+  val b = pad-interior-bounds(vp, side, layer-spec = false)
   val sh-by = match(shrink-by(k)):
     (s:Double): Point(s, s)
     (s:Dims): Point(x(s), y(s))

--- a/src/landpatterns/silkscreen.stanza
+++ b/src/landpatterns/silkscreen.stanza
@@ -382,7 +382,7 @@ public defn has-enough-interior-space? (s:InteriorEdgesOutline, vp:VirtualLP -- 
   try:
     compute-interior-pad-space(s, vp, side = side)
     true
-  catch (e:ValueError):
+  catch (e:NegativeBoxError):
     false
 
 public defstruct SingleLineOutline <: SilkscreenOutline :


### PR DESCRIPTION
A query error was selecting for super small components and resulted in exposing an error in the keepout logic - especially for components where the landpattern soldermask openings overlap. I've updated the logic to better handle that case as well as change the keepout interior pad boundary to use the copper shape instead of the soldermask.