### PR TITLE
Added a new tool for setting the config strap BOM status

### DIFF
--- a/src/circuits/ConfigStrap.stanza
+++ b/src/circuits/ConfigStrap.stanza
@@ -222,3 +222,33 @@ public defn ConfigStrap (
         pack-array(pack, hi-comps, lo-comps)
 
   config-strap
+
+doc: \<DOC>
+Configuration Strap BOM Configuration Setter
+
+This function is a generator and expects to be called
+from within a `pcb-module` context.
+
+@param straps ConfigStrap instance to configure.
+@param cfg Value to assign as binary to the configuration
+strap object. We will set the high/low components to
+`InBom` or `MarkedDNP` depending on the binary state of each bit.
+<DOC>
+public defn set-straps-config (straps:JITXObject, cfg:Int):
+  inside pcb-module:
+    val hw-rev-bits = length(straps.configs)
+    val bit-max = ceil-log2(hw-rev-bits)
+    if cfg > bit-max:
+      throw $ ValueError("Invalid HW Rev Bits Value '%_' - Greater than bitvector max: '%_'" % [cfg, bit-max])
+
+    for i in 0 to hw-rev-bits do:
+      val mask = (1 << i)
+      val b = (mask & cfg) > 0
+
+      instance-status(straps.hi-comps[i]):
+        bom-status =  MarkedDNP when not b else InBOM
+
+      instance-status(straps.lo-comps[i]):
+        bom-status =  MarkedDNP when b else InBOM
+
+


### PR DESCRIPTION
This is a function for setting the BOM status of the components in the ConfigStrap object.