### PR TITLE
[Bugfix] Fixed check on config strap set value

### DIFF
--- a/slm.toml
+++ b/slm.toml
@@ -1,4 +1,4 @@
 name = "jsl"
-version = "0.8.0"
+version = "0.8.1"
 [dependencies]
 maybe-utils = { git = "StanzaOrg/maybe-utils", version = "0.1.6"}

--- a/src/circuits/ConfigStrap.stanza
+++ b/src/circuits/ConfigStrap.stanza
@@ -10,6 +10,7 @@ defpackage jsl/circuits/ConfigStrap:
 
   import core
   import collections
+  import math
   import jitx
   import jitx/commands
 
@@ -237,7 +238,7 @@ strap object. We will set the high/low components to
 public defn set-straps-config (straps:JITXObject, cfg:Int):
   inside pcb-module:
     val hw-rev-bits = length(straps.configs)
-    val bit-max = ceil-log2(hw-rev-bits)
+    val bit-max = to-int(pow(2.0, to-double(hw-rev-bits))) - 1
     if cfg > bit-max:
       throw $ ValueError("Invalid HW Rev Bits Value '%_' - Greater than bitvector max: '%_'" % [cfg, bit-max])
 


### PR DESCRIPTION
I had used log2 instead of pow2 to compute the
max resulting in false positives in the
check.