### PR TITLE
Add new `Substrate` type and `Layerstack` functions

### DIFF
--- a/src/design.stanza
+++ b/src/design.stanza
@@ -5,3 +5,4 @@ defpackage jsl/design:
   forward jsl/design/introspection
   forward jsl/design/settings
   forward jsl/design/solvers
+  forward jsl/design/Substrate

--- a/src/design/Substrate.stanza
+++ b/src/design/Substrate.stanza
@@ -5,6 +5,8 @@ defpackage jsl/design/Substrate:
   import jitx
   import jitx/commands
 
+  import maybe-utils
+
   import jsl/ensure
   import jsl/errors
   import jsl/layerstack
@@ -255,7 +257,6 @@ public defn make-uncoupled-region (default:RoutingStructure, uncoupled?:Maybe<Ro
 
     uncoupled-region = uncoupled-spec
 
-
 doc: \<DOC>
 Convert a Substrate into a `pcb-board` definition
 @param f Substrate
@@ -283,3 +284,101 @@ public defn make-board-def (f:Substrate, outline:Shape -- signal-shrink:Maybe<Do
         signal-boundary = value(given)
     vias = vias(f)
   board-def-pcb
+
+defn check-layer (
+  f:Substrate,
+  v:Via,
+  start:Maybe<LayerIndex|Side>
+  stop:Maybe<LayerIndex|Side>
+  ) -> True|False:
+  val ls = stackup(f)
+  val sl? = map(start, to-layer-index)
+  val el? = map(stop, to-layer-index)
+  val s = via-start(v)
+  val e = via-stop(v)
+  match(sl?, el?):
+    (sl:None, el:None):
+      true
+    (sl:One<LayerIndex>, el:None):
+      in-range?(ls, value(sl), s, e)
+    (sl:None, el:One<LayerIndex>):
+      in-range?(ls, value(el), s, e)
+    (sl:One<LayerIndex>, el:One<LayerIndex>):
+      in-range?(ls, value(sl), s, e) and in-range?(ls, value(el), s, e)
+
+defn check-type (
+  v:Via,
+  type?:Maybe<MechanicalDrill|LaserDrill>
+  ) -> True|False :
+  match(type?):
+    (_:None): true
+    (given:One<MechanicalDrill|LaserDrill>):
+      value(given) == via-type(v)
+
+defn check-boolean (v:Via, spec?:Maybe<True|False>, func:(Via -> True|False)) -> True|False :
+ match(spec?):
+  (_:None): true
+  (given:One<True|False>):
+    value(given) == func(v)
+
+val check-filled = check-boolean{_0, _1, via-filled}
+val check-via-in-pad = check-boolean{_0, _1, via-in-pad}
+
+defn check-tented (v:Via, tented?:Maybe<True|False|Side>) -> True|False :
+  match(tented?):
+    (_:None): true
+    (given:One<True|False|Side>):
+      value(given) == via-tented(v)
+
+defn check-backdrill (f:Substrate, v:Via, backdrill?:Maybe<True|False>) -> True|False :
+  match(backdrill?):
+    (_:None): true
+    (given:One<True|False>):
+      value(given) == (via-backdrill(v) is-not False)
+
+doc: \<DOC>
+Query for a via defined in this substrate
+
+This allows the user to query for a via that
+matches some set of requirements from the substrate.
+This allows us to avoid using explicit via definitions
+in code for easier swapping of substrates.
+
+If a query parameter is not provided, then it defaults
+to `None()` and it will not affect the resulting via set.
+
+@param f Substrate to query
+@param start Copper layer for the start of the via
+@param stop Copper layer for the end of the via
+@param type Mechanical vs Laser Selector
+@param filled Selects for filled state
+@param tented Selects for tented state
+@param via-in-pad Selects for Via-in-Pad eligibility
+@param backdrill Selects for any via that is configured
+for a backdrill.
+<DOC>
+public defn query-via (
+  f:Substrate --
+  start:LayerIndex|Side = ?
+  stop:LayerIndex|Side = ?,
+  type:MechanicalDrill|LaserDrill = ?,
+  filled:True|False = ?,
+  tented:Side|True|False = ?,
+  via-in-pad:True|False = ?
+  backdrill:True|False = ?
+  ) -> Seq<Via> :
+
+  val vs = vias(f)
+  val checks = [
+    {check-layer(f, _0, start, stop)},
+    {check-type(_0, type)},
+    {check-filled(_0, filled)}
+    {check-tented(_0, tented)}
+    {check-via-in-pad(_0, via-in-pad)}
+    {check-backdrill(f, _0, backdrill)}
+  ]
+  for v in vs seq?:
+    val ret = for ch-func in checks all?:
+      ch-func(v)
+    if ret: One(v)
+    else: None()

--- a/src/design/Substrate.stanza
+++ b/src/design/Substrate.stanza
@@ -1,0 +1,285 @@
+#use-added-syntax(jitx)
+defpackage jsl/design/Substrate:
+  import core
+  import collections
+  import jitx
+  import jitx/commands
+
+  import jsl/ensure
+  import jsl/errors
+  import jsl/layerstack
+
+doc: \<DOC>
+Interface type for Substrate Definitions
+
+The idea behind this type is to provide a consistent
+interface that all fabricator specifc substrates can follow.
+This will allow a design to swap out the current substrate for
+a new substrate with minimal disruption to the design.
+<DOC>
+public deftype ISubstrate
+
+doc: \<DOC>
+Stackup Generator for this Substrate
+<DOC>
+public defmulti stackup (f:ISubstrate) -> LayerStack
+
+doc: \<DOC>
+Get the vias registered with this substrate.
+
+This method is useful for constructing a `pcb-board`
+definition from the substrate.
+<DOC>
+public defmulti vias (f:ISubstrate) -> Tuple<Via>
+
+doc: \<DOC>
+Create a Single-Ended Routing Structure for this Substrate
+
+This method returns a `pcb-routing-structure` instance for
+a given characteristic impedance.
+
+@param f Substrate object
+@param imped Characteristic impedance of desired routing structure
+@param neckdown Specify a custom neckdown property for this
+routing structure to override the default. For example, you
+might need smaller clearance near a component.
+<DOC>
+public defmulti se-routing-struct (
+  f:ISubstrate,
+  imped:Int
+  --
+  neckdown:NeckDown = ?
+  ) -> RoutingStructure
+
+doc: \<DOC>
+Create a Differential Routing Structure for this Substrate
+
+This method returns a `pcb-differential-routing-structure` instance for
+a given characteristic impedance.
+
+@param f Substrate object
+@param imped Characteristic impedance of desired routing structure
+@param uncoupled Specify an optional routing structure for the
+uncoupled region of a differential pair. By default, the uncoupled
+region keeps the same features as the diff-pair. User can override
+that behavior with this value.
+@param neckdown Specify an optional custom differential neckdown property
+for this routing structure to override the default. For example, you
+might need smaller clearance near a component.
+<DOC>
+public defmulti diff-routing-struct (
+  f:ISubstrate,
+  imped:Int
+  --
+  uncoupled:RoutingStructure = ?
+  neckdown:DifferentialNeckDown = ?
+  ) -> DifferentialRoutingStructure
+
+
+
+doc: \<DOC>
+Lookup-based Substrate Type
+
+This type is used to define board specific features that
+are unique to a particular manufacturer, process, etc.
+
+The idea is that some fabricators (like JLC-PCB) define
+standard features like via sizes, trace impedances,
+and stackups to make it easier for users to purchase
+inexpensive boards.
+
+<DOC>
+public defstruct Substrate <: ISubstrate :
+  doc: \<DOC>
+  Layer Stackup for the PCB
+
+  This defines the dielectric and copper stackup
+  for the PCB.
+  <DOC>
+  stackup:LayerStack with:
+    as-method => true
+
+  doc: \<DOC>
+  Via Set Available for this Substrate.
+  This collection contains the defined vias for
+  this design.
+
+  This collection is immutable because it must be
+  passed to the `pcb-board` creation via {@link make-board-def}
+  <DOC>
+  vias:Tuple<Via> with:
+    as-method => true
+  doc: \<DOC>
+  Single-Ended Routing Structure Generators
+  This object is not intended to be accessed directly.
+  User should access this type using {@link se-routing-struct}
+  <DOC>
+  se:HashTable<Int, (Maybe<NeckDown> -> RoutingStructure)>
+  doc: \<DOC>
+  Differential Routing Structure Generators
+  This object is not intended to be accessed directly.
+  User should access this type using {@link diff-routing-struct}
+  <DOC>
+  df:HashTable<Int, ((Maybe<RoutingStructure>, Maybe<DifferentialNeckDown>) -> DifferentialRoutingStructure)>
+with:
+  printer => true
+  keyword-constructor => true
+
+doc: \<DOC>
+Constructor for Substrate
+
+@param stackup PCB Stackup Construction Definition
+@param vias Collection of Vias for the design to use.
+@param single-ended Collection of generator functions categorized
+by characteristic impedance
+@param differential Collection of gneerator functions categorized
+by characteristic impedance
+<DOC>
+public defn Substrate (
+  --
+  stackup:LayerStack,
+  vias:Collection<Via>,
+  single-ended:Collection<KeyValue<Int, (Maybe<NeckDown> -> RoutingStructure)>>,
+  differential:Collection<KeyValue<Int, ((Maybe<RoutingStructure>, Maybe<DifferentialNeckDown>) -> DifferentialRoutingStructure)>>
+  ) -> Substrate:
+  Substrate(
+    stackup = stackup,
+    vias = to-tuple $ vias,
+    se = to-hashtable<Int, (Maybe<NeckDown> -> RoutingStructure)>(single-ended),
+    df = to-hashtable<Int, ((Maybe<RoutingStructure>, Maybe<DifferentialNeckDown>) -> DifferentialRoutingStructure)>(differential)
+  )
+
+doc: \<DOC>
+Single-Ended Routing Structure Creator
+
+User selects a routing structure by characteristic impedance
+that is supported by this substrate. The substrate must have
+been previously initialized with a substrate that supports
+this impedance.
+
+@param f Board Substrate
+@param imped Characteristic impedance in ohms.
+@param neckdown Optional neckdown feature for the
+created routing structure. This allows the user to
+customize the behavior of routes near their endpoints.
+@return Single-Ended Routing Structure for the passed
+characteristic impedance.
+@throws ValueError if no routing structure for that characteristic
+impedance exists.
+<DOC>
+public defmethod se-routing-struct (
+  f:Substrate,
+  imped:Int
+  --
+  neckdown:NeckDown = ?
+  ) -> RoutingStructure:
+  val func? = get?(se(f), imped)
+  val func = match(func?):
+    (_:False):
+      throw $ ValueError("No Single-Ended Impedance Registered for Characteristic Impedance '%_'" % [imped])
+    (x): x
+  func(neckdown)
+
+doc: \<DOC>
+Differential Routing Structure Creator
+
+User selects a differential routing structure
+by characteristic impedance.
+
+@param f Board Substrate
+@param imped Characteristic impedance in ohms.
+@param uncoupled Optional single-ended uncoupled region
+routing structure. Typically, the substrate has a
+sensible default, like the same width at the individual
+trace widths of the differential pair.
+@param neckdown Optional differential neckdown feature for the
+created routing structure. This allows the user to
+customize the behavior of routes near their endpoints.
+@return Differential Routing Structure for the passed
+characteristic impedance.
+@throws ValueError if no routing structure for that characteristic
+impedance exists.
+<DOC>
+public defmethod diff-routing-struct (
+  f:Substrate,
+  imped:Int
+  --
+  uncoupled:RoutingStructure = ?
+  neckdown:DifferentialNeckDown = ?
+  ) -> DifferentialRoutingStructure:
+  val func? = get?(df(f), imped)
+  val func = match(func?):
+    (_:False):
+      throw $ ValueError("No Differential Impedance Registered for Characteristic Impedance '%_'" % [imped])
+    (x): x
+  func(uncoupled, neckdown)
+
+
+doc: \<DOC>
+Retrieve a via from the substrate by name
+@param f Substrate
+@param name Name of the via
+@return Via matching the given name.
+@throws ValueError if no via by that name has been registered
+with the substrate.
+<DOC>
+public defn get-via (f:Substrate, n:String) -> Via :
+  val ret? = for v in vias(f) first:
+    if name(v) == n:
+      One(v)
+    else:
+      None()
+  match(ret?):
+    (_:None):
+      throw $ ValueError("No Via with name '%_' defined"  % [name])
+    (given:One<Via>): value(given)
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Utilities
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+doc: \<DOC>
+Generator for the `uncoupled` statement
+
+This function expects to be called from a `pcb-differential-routing-structure`
+context.
+@param default Default uncoupled region value is `uncoupled?` is `None()`
+@param uncoupled? Override for the default routing structure of the uncoupled region.
+<DOC>
+public defn make-uncoupled-region (default:RoutingStructure, uncoupled?:Maybe<RoutingStructure> = None()):
+  inside pcb-differential-routing-structure:
+    val uncoupled-spec = match(uncoupled?):
+      (_:None): default
+      (given:One<RoutingStructure>): value(given)
+
+    uncoupled-region = uncoupled-spec
+
+
+doc: \<DOC>
+Convert a Substrate into a `pcb-board` definition
+@param f Substrate
+@param outline Shape for the resulting `pcb-board`
+@param signal-shrink Optional parameter that defines the
+signal boundary in one of two ways:
+
+1. If a `Double` - then the `outline` parameter is shrunk by this amount in mm. This
+value must be positive.
+2. If a `Shape` - then this shape is applied to the `pcb-board` directly.
+
+@return `pcb-board` definition.
+<DOC>
+public defn make-board-def (f:Substrate, outline:Shape -- signal-shrink:Maybe<Double|Shape> = None()) -> Board:
+  pcb-board board-def-pcb:
+    stackup = create-pcb-stackup $ stackup(f)
+    boundary = outline
+    match(signal-shrink):
+      (_:None): false
+      (given:One<Double>):
+        val shrink = value(given)
+        ensure-positive!("signal-shrink", shrink)
+        signal-boundary = expand(outline, (- shrink))
+      (given:One<Shape>):
+        signal-boundary = value(given)
+    vias = vias(f)
+  board-def-pcb

--- a/src/layerstack.stanza
+++ b/src/layerstack.stanza
@@ -349,6 +349,43 @@ public defn conductors (ls:LayerStack) -> Tuple<LayerSpec> :
   to-tuple $ filter({material(_) is ConductorMaterial}, layers(ls))
 
 doc: \<DOC>
+Check if a layer id refers to a valid copper layer in this stackup
+
+@param ls PCB Stackup Generator
+@param l Index into the copper layers. If `Int`, this is a simple
+zero-based index starting from the `Top` layer and working to the
+`Bottom` layer.
+<DOC>
+public defn is-valid-copper-layer? (ls:LayerStack, l:Int|LayerIndex) -> True|False :
+  val ly-id = match(l):
+    (i:Int): i
+    (li:LayerIndex): layer-num(ls, li)
+  ly-id >= 0 and ly-id < get-conductor-count(ls)
+
+
+doc: \<DOC>
+Convert the copper layers into a tuple of `LayerIndex` objects
+@param ln Layer Stack Generator
+@param omits A collection of copper layers that we don't want to
+include in the generated output. Any value in this collection that matches a
+copper layer will cause that `LayerIndex` to be skipped.
+An `Int` value in this list indicates a simple zero-based index into the copper layers
+starting at `Top` and going to `Bottom`
+<DOC>
+public defn conductors-by-index (ls:LayerStack -- omits:Collection<Int|LayerIndex> = []) -> Tuple<LayerIndex> :
+  for o in omits do:
+    if not is-valid-copper-layer?(ls, o):
+      throw $ ValueError("Invalid Omit Layer '%_' - Not Valid in this Stackup: %_" % [o, ls])
+
+  to-tuple $ for (c in conductors(ls), i in 0 to false) seq?:
+    val skip = for o in omits any?:
+      layer-num(ls, o) == i
+    if not skip:
+      One $ LayerIndex(i, Top)
+    else:
+      None()
+
+doc: \<DOC>
 Add one or more layers to the top of the board stackup.
 
 When used on its own, this function is useful for creating asymmetric
@@ -516,6 +553,59 @@ public defn get-conductor (ls:LayerStack, index:Int) -> [Maybe<LayerSpec>, Layer
     (_:False): throw $ ValueError("No Copper Layer with Index: %_" % [index])
     (cu-index:Int):
       [get-pre-dielectric(cu-index), l-set[cu-index], get-post-dielectric(cu-index)]
+
+
+doc: \<DOC>
+Convert a LayerIndex to a Copper Layer Index
+
+@param ls PCB Stackup Generator - This provides the number
+of copper layers in the stackup.
+@param l Which layer in the stackup we are referring to.
+@return A zero-indexed value where `Top` is 0 and `Bottom`
+is `N-1` where `N` is the number of layers in the stackup.
+@throws ValueError If `l` is invalid for this stackup - ie, if the
+layer is outside of the available copper layers of the design.
+<DOC>
+public defn layer-num (ls:LayerStack, l:LayerIndex|Int) -> Int :
+  val cnt = get-conductor-count(ls)
+  is-valid-copper-layer?(ls, l)
+  match(l):
+    (i:Int): i
+    (li:LayerIndex): layer-num(li, cnt)
+
+doc: \<DOC>
+Compare Two LayerIndex given a PCB stackup
+
+@param ls PCB Stackup Generator - This provides the number
+of copper layers in the stackup.
+@return This function returns zero if the layer indices match
+This function returns a value < 0 if `a` is closer to the `Top` than `b`
+This function returns a value > 0 if `a` is closer to the `Bottom` than `b`
+<DOC>
+public defn compare-layer (ls:LayerStack, a:LayerIndex, b:LayerIndex) -> Int :
+  val a-num = layer-num(ls, a)
+  val b-num = layer-num(ls, b)
+  ; I'm mapping +1 to Lower in the stack (ie, Bottom)
+  ; I'm mapping -1 to Higher in the stack (ie, Top)
+  compare(a-num, b-num)
+
+doc: \<DOC>
+Check if a given copper layer is within a range of layers
+
+This is an inclusive check - so if `a` == `start` or `a` == `end` -
+then this check will return True.
+
+@param ls PCB Stackup Generator - This provides the number
+of copper layers in the stackup.
+@param a Copper Layer to compare against the `start` and `end` range.
+@param start Start of the copper layer range.
+@param end End of the copper layer range.
+@return True if `a` is on or between start & end. False if outside that range.
+<DOC>
+public defn in-range? (ls:LayerStack, a:LayerIndex, start:LayerIndex, end:LayerIndex) -> True|False :
+  val sc = compare-layer(ls, a, start)
+  val ec = compare-layer(ls, a, end)
+  sc >= 0 and ec <= 0
 
 defn make-name (x:LayerStack) :
   ; I can't use the `name` string in the pcb-stackup definition


### PR DESCRIPTION
This adds a type for defining the PCB substrate in a consistent way that allows us to swap in and out different substrates as well. 
I tested this with the JLC library by having 7628 and 1080 versions, and then swapping between them. 
