### PR TITLE
[bugfix] Fixed missing query build inclusion

### DIFF
--- a/src/circuits/Pullups.stanza
+++ b/src/circuits/Pullups.stanza
@@ -102,7 +102,7 @@ public defn insert-pullup (
     val et = match(elem-type):
       (given:Instantiable): given
       (R-v:Double): ; Resistance Value
-        create-resistor(resistance = R-v, precision = (1 %))
+        create-resistor(qb, resistance = R-v)
 
     val elem = make-inst(to-symbol(inst-name), et, make-public)
     add-pullup(elem, sig, rail)


### PR DESCRIPTION
The `insert-pullup` function wasn't using the
passed query builder instance. `insert-pulldown`
was so no need to fix it.