### PR TITLE
Added new default query mechanism for caps/resistors.

### DIFF
--- a/src/circuits/Bypass.stanza
+++ b/src/circuits/Bypass.stanza
@@ -34,14 +34,13 @@ public defn bypass (elem:JITXObject, p1:JITXObject, p2:JITXObject):
     short-net(e-p1, p1)
     net (e-p2, p2)
 
-val BYPASS_DEF_QB = CapacitorQuery()
 val BYPASS_DEF_VAL = 0.1e-6 ; Farads
 
 
 defn insert-bypass (pos:JITXObject, neg:JITXObject -- elem-type?:Instantiable|Double, inst-name?:Maybe<String|Symbol> = None(), qb?:Maybe<CapacitorQuery> = None()) :
 
   val inst-name = to-string $ value-or(inst-name?, "%_-byp" % [get-ref-name $ ref(pos)])
-  val qb = value-or(qb?, BYPASS_DEF_QB)
+  val qb = value-or(qb?, get-default-capacitor-query())
 
   inside pcb-module:
     val elem-type = match(elem-type?):
@@ -72,8 +71,7 @@ can be used to control the other aspects of the query.
 given, then the Ref name of the `pos` signal will be used to create an instance name
 in the form `<NAME>-byp`.
 @param qb Optional capacitor query builder. This builder will extend the global defaults
-with any customization the user desires. The default value is `CapacitorQuery()` with no
-additional parameters.
+with any customization the user desires. The default value is `get-default-capacitor-query()`.
 @return Instance for this bypass component
 <DOC>
 public defn insert-bypass (pos:JITXObject, neg:JITXObject -- elem-type:Instantiable|Double = BYPASS_DEF_VAL, inst-name:String|Symbol = ?, qb:CapacitorQuery = ?) :
@@ -96,8 +94,7 @@ can be used to control the other aspects of the query.
 given, then the Ref name of the `pos` signal will be used to create an instance name
 in the form `<NAME>-byp`.
 @param qb Optional capacitor query builder. This builder will extend the global defaults
-with any customization the user desires. The default value is `CapacitorQuery()` with no
-additional parameters.
+with any customization the user desires. The default value is `get-default-capacitor-query()`.
 @return Instance for this bypass component
 <DOC>
 public defn insert-bypass (rail:JITXObject -- elem-type:Instantiable|Double = BYPASS_DEF_VAL, inst-name:String|Symbol = ?, qb:CapacitorQuery = ?) :

--- a/src/circuits/CrystalResonator.stanza
+++ b/src/circuits/CrystalResonator.stanza
@@ -17,13 +17,14 @@ Construct a Crystal Resonator Circuit
 that this circuit will attach to.
 @param V-rating Minimum voltage rating for the capacitors selected for this circuit. The
 user is assumed to have added the necessary voltage derating for their application.
+@param tc-code Default temperature rating to use for the load capacitors. This overides
+the default temperature coefficient code from the C-query. The default value is `C0G`
 @param prec Capacitor Value Precision Series that load capacitors will be selected from.
-@param query? Override-able base query for the capacitor selection. By default, this algorithm
-filters on:
+@param C-query Capacitor Query Object for customizing capacitor selection. Default is `get-default-capacitor-query()`.
+The following keys will be modified:
 
-*  Type = "ceramic"
-*  Temp Code = "C0G"
-*  Min Voltage = `V-rating`
+1.  `temperature-coefficient_code` - This function uses `C0G`
+2.  `rated-voltage` - This function overrides any voltage rating with the `V-rating` value. The results are sorted from lowest to highest.
 
 @return A `pcb-module` definition that can be instantiated to form the
 resonant tank for a crystal resonator. This module will have the following ports:
@@ -37,22 +38,20 @@ public defn create-crystal-resonator (
   C-load:Toleranced,
   C-stray:Toleranced,
   V-rating:Double,
+  tc-code:String = "C0G",
   prec:Percentage = (5 %),
-  query?:CapacitorQuery = ?
+  C-query:CapacitorQuery = get-default-capacitor-query()
   ) -> Instantiable:
 
   val cap-V = 2.0 * (C-load - C-stray)
   val c-bal = closest-std-val(typ(cap-V), prec)
 
-  val q = match(query?):
-    (_:None):
-      CapacitorQuery(
-        type = "ceramic",
-        temperature-coefficient_code = "C0G",
-        rated-voltage = AtLeast(V-rating),
-        sort! = SortKey(rated-voltage = Increasing)
-      )
-    (given:One<CapacitorQuery>): value(given)
+  val q = add(
+    C-query,
+    rated-voltage = AtLeast(V-rating),
+    sort! = SortKey(rated-voltage = Increasing),
+    temperature-coefficient_code = tc-code
+  )
 
   val cap-type = create-capacitor(
     q,

--- a/src/circuits/Termination.stanza
+++ b/src/circuits/Termination.stanza
@@ -17,19 +17,28 @@ Default is a simple RC parallel circuit.
 @member SHIELD Connected to the shield of a connector, etc.
 @member GND Ground plane connection for the termination.
 
-@param R-query Resistor query parameters - default is `ResistorQuery()`.
-@param C-query Capacitor query parameters. Default sets a min rated
-voltage of 50.0V.
+@param R-query Resistor query parameters - default is `get-default-resistor-query()`.
+@param C-query Capacitor query parameters - defualt is `get-default-capacitor-query()`. 
+By default, this function will set min rated voltage to 50.0V if no voltage rating
+is present in the `C-query`.
 <DOC>
 public defn shield-termination (
-  R-query:ResistorQuery = ResistorQuery(),
-  C-query:CapacitorQuery = CapacitorQuery(rated-voltage = AtLeast(50.0))
+  R-query:ResistorQuery = get-default-resistor-query(),
+  C-query:CapacitorQuery = get-default-capacitor-query(),
   ) -> Instantiable:
+  val has-V-rating = key?(C-query, RatedVoltage)
+  val C-query* = if not has-V-rating:
+    set(
+      C-query, 
+      rated-voltage = AtLeast(50.0)
+      sort! = SortKey(rated-voltage = Increasing)
+      )
+  else: C-query
 
   pcb-module shield-term-t :
     port SHIELD
     port GND
     insert-resistor(SHIELD, GND, R-query, resistance = 0.0, inst-name = "R")
-    insert-capacitor(SHIELD, GND, C-query, capacitance = 4.7e-9, inst-name = "C")
+    insert-capacitor(SHIELD, GND, C-query*, capacitance = 4.7e-9, inst-name = "C")
 
   shield-term-t


### PR DESCRIPTION
This adds better default query configuration control by the user at the top-level.

This relies on:
https://github.com/JITx-Inc/jitx-client/pull/5253