### PR TITLE
Jitx 9353/expand or shrink

### DIFF
--- a/slm.toml
+++ b/slm.toml
@@ -1,4 +1,4 @@
 name = "jsl"
-version = "0.9.7"
+version = "0.9.9"
 [dependencies]
 maybe-utils = { git = "StanzaOrg/maybe-utils", version = "0.1.6"}

--- a/src/design/Substrate.stanza
+++ b/src/design/Substrate.stanza
@@ -275,12 +275,12 @@ public defn make-board-def (f:Substrate, outline:Shape -- signal-shrink:Maybe<Do
     stackup = create-pcb-stackup $ stackup(f)
     boundary = outline
     match(signal-shrink):
-      (_:None): 
+      (_:None):
         signal-boundary = outline
       (given:One<Double>):
         val shrink = value(given)
         ensure-positive!("signal-shrink", shrink)
-        signal-boundary = expand(outline, (- shrink))
+        signal-boundary = expand-or-shrink(outline, (- shrink))
       (given:One<Shape>):
         signal-boundary = value(given)
     vias = vias(f)

--- a/src/geometry/basics.stanza
+++ b/src/geometry/basics.stanza
@@ -59,7 +59,8 @@ public defn expand-union (x:Shape|Union, amount:Double) -> Shape:
     (U:Union):
       Union $ for obj in shapes(U) seq:
         expand-union(obj, amount)
-    (y:Shape): expand(y, amount)
+    (y:Shape):
+      expand-or-shrink(y, amount)
 
 doc: \<DOC>
 Increase the size of a `Dims` by `amount` on all sides

--- a/src/landpatterns/BGA/pads.stanza
+++ b/src/landpatterns/BGA/pads.stanza
@@ -272,11 +272,11 @@ public defn build-bga-pad (
     type = SMD
 
     val c-adj = compute-adj(copper-adj(config), ball)
-    val copper = expand(ball, c-adj)
+    val copper = expand-or-shrink(ball, c-adj)
     shape = copper
 
     val s-adj = compute-adj(mask-adj(config), ball)
-    val smask = expand(ball, s-adj)
+    val smask = expand-or-shrink(ball, s-adj)
     make-soldermask(smask)
 
     match(paste-adj(config)):
@@ -298,7 +298,7 @@ public defn build-bga-pad (
         make-pastemask(paste-sh)
       (paste:Double|Percentage):
         val p-adj = compute-adj(paste, ball)
-        val paste-sh = expand(ball, p-adj)
+        val paste-sh = expand-or-shrink(ball, p-adj)
         make-pastemask(paste-sh)
 
   bga-pad

--- a/src/landpatterns/leads/lead-profile.stanza
+++ b/src/landpatterns/leads/lead-profile.stanza
@@ -61,7 +61,7 @@ public defn compute-params (
 
   val delta = Gmin(ipc) + x(pad-size)
   val pitch = pitch(pf)
-  #Lead-Profile-Params(pad-size, delta, pitch)
+  Lead-Profile-Params(pad-size, delta, pitch)
 
 
 doc: \<DOC>

--- a/src/landpatterns/pads.stanza
+++ b/src/landpatterns/pads.stanza
@@ -136,7 +136,7 @@ different shapes - specifically rectangle and non-convex pad shapes
 <DOC>
 public defn make-soldermask (amount:Double = get-default-soldermask-amount()) :
   inside pcb-pad:
-    val mask-shape = expand(pad-shape(self), amount)
+    val mask-shape = expand-or-shrink(pad-shape(self), amount)
     make-soldermask(mask-shape)
 
 
@@ -175,7 +175,7 @@ default this is the top-side (convention when constructing pads).
 <DOC>
 public defn make-pastemask (amount:Double, side:Side = Top) :
   inside pcb-pad:
-    val mask-shape = expand(pad-shape(self), amount)
+    val mask-shape = expand-or-shrink(pad-shape(self), amount)
     make-pastemask(mask-shape, side)
 
 doc: \<DOC>
@@ -196,7 +196,7 @@ TODO - Create a diagram here for the pad definition
 <DOC>
 public pcb-pad smd-pad (
   copper:Shape,
-  mask:Shape|False = expand(copper, get-default-soldermask-amount()),
+  mask:Shape|False = expand-or-shrink(copper, get-default-soldermask-amount()),
   paste:Shape|False = copper
   ) :
   name  = "SMD Pad"
@@ -266,7 +266,7 @@ The default value is `false` meaning **no** pastemask opening is applied.
 public pcb-pad pth-pad (
   hole:Shape,
   copper:Shape,
-  mask:Shape|False = expand(copper, get-default-soldermask-amount()),
+  mask:Shape|False = expand-or-shrink(copper, get-default-soldermask-amount()),
   paste:Shape|False = false
   ) :
   name = "PTH-Pad"
@@ -345,7 +345,7 @@ public pcb-pad npth-pad (
     (m:False) :
       ; @NOTE - this was broken in OCDB
       val amount = get-default-soldermask-amount()
-      expand(hole, amount)
+      expand-or-shrink(hole, amount)
     (m:Shape) : m
   layer(SolderMask(Top)) = sm
   layer(SolderMask(Bottom)) = sm

--- a/src/landpatterns/thermal-pads.stanza
+++ b/src/landpatterns/thermal-pads.stanza
@@ -170,7 +170,7 @@ public defn smd-thermal-pad (tp:ThermalPad) -> Pad:
     (_:None): sh ; Replicate the copper shape
     (given:One<PasteSubdivision>):
       create-paste-subdivision $ value(given)
-  smd-pad(sh, expand(sh, sm), paste)
+  smd-pad(sh, expand-or-shrink(sh, sm), paste)
 
 
 doc: \<DOC>

--- a/src/landpatterns/two-pin/radial.stanza
+++ b/src/landpatterns/two-pin/radial.stanza
@@ -219,7 +219,7 @@ public defn build-polarity-cylinder-marker (
   ; val [pad-1, pad-2] = get-two-pin-pads(vp)
   ; val neg-fill = PolygonWithArcs([Point(R, 0.0), Point((- R), 0.0), Arc(Point(0.0, 0.0), R, 180.0, 180.0)])
   ; val neg-smask = get-layer(pad-2, SolderMask(side))
-  ; val neg-smask* = expand(pose(pad-2) * neg-smask[0], mask-clearance)
+  ; val neg-smask* = expand-or-shrink(pose(pad-2) * neg-smask[0], mask-clearance)
   ; val neg-fill* = Difference(neg-fill, neg-smask*)
   ; add(markers, neg-fill*)
 


### PR DESCRIPTION
Switches calls to the `expand(shape, amount)` function with calls to `expand-or-shrink(shape, amount)` instead. Note: this PR requires the PR in `jitx-client` of the same ticket to work.