### PR TITLE
Update to `dp-coupler` for non-JSL 2-pin landpatterns

### DIFF
--- a/src/landpatterns/courtyard.stanza
+++ b/src/landpatterns/courtyard.stanza
@@ -162,6 +162,24 @@ public defn get-courtyard-boundary (
   else:
     bounds $ Union(content)
 
+doc: \<DOC>
+Extract the courtyard shape for the landpattern of a component.
+
+This function introspects the given component and finds the courtyard
+layer of its landpattern. It then returns a Union of the landpatterns
+courtyard layer.
+
+@param comp Instantiable component (pcb-component) with assigned landpattern.
+
+<DOC>
+public defn get-courtyard-shape (comp:Instantiable) -> Shape:
+  val lp = landpattern(comp)
+  val topC = Courtyard(Top)
+  Union $ for lspec in layers(lp) seq?:
+    switch(specifier(lspec)):
+      Courtyard(Top):
+        One $ shape(lspec)
+      else: None()
 
 doc: \<DOC>
 Extract the courtyard dimensions for the landpattern of a component.
@@ -174,10 +192,4 @@ courtyard layer.
 @return X and Y dimensions of the courtyard boundary in mm
 <DOC>
 public defn get-courtyard-dims (comp:Instantiable) -> Dims:
-  val lp = landpattern(comp)
-  val topC = Courtyard(Top)
-  dims $ Union $ for lspec in layers(lp) seq?:
-    switch(specifier(lspec)):
-      Courtyard(Top):
-        One $ shape(lspec)
-      else: None()
+  dims $ get-courtyard-shape(comp)

--- a/src/si/couplers.stanza
+++ b/src/si/couplers.stanza
@@ -27,8 +27,18 @@ Example: Block Capacitors for SI transmitter
 adjacent to one another. The components will still be placed at the same X location,
 but the right component will be slid up (positive Y) by (y-skew/2). The left component
 will be slid down (negative Y) by (y-skew/2).
+@param pre-pose To support components that are not defined in JSL's standard 2-pin land pattern
+framework, the `pre-pose` argument can be used to modify the component placement
+before constructing the coupler structure. This pose modification is applied to both
+components equally. By default, this value is `loc(0.0, 0.0)`
 <DOC>
-public pcb-module dp-coupler (comp:Instantiable -- margin:Double = 0.0, y-skew:Double = 0.0) :
+public pcb-module dp-coupler (
+  comp:Instantiable 
+  -- 
+  margin:Double = 0.0, 
+  y-skew:Double = 0.0,
+  pre-pose:Pose = loc(0.0, 0.0)
+  ) :
   port A : diff-pair
   port B : diff-pair
 
@@ -49,12 +59,15 @@ public pcb-module dp-coupler (comp:Instantiable -- margin:Double = 0.0, y-skew:D
   ; This places these components such that they are directly adjacent
   ;  to each other. This assumes that the pads for the 2-pin component
   ;  are aligned vertically on the Y axis.
-  val cyard = get-courtyard-dims(comp)
+  val cyard-sh = pre-pose * get-courtyard-shape(comp)
+  val cyard = dims(cyard-sh)
+
   val x-off = (x(cyard) + margin) / 2.0
 
   val y2 = y-skew / 2.0
-  place(c[0]) at loc(x-off, y2) on Top
-  place(c[1]) at loc((- x-off), (- y2)) on Top
+
+  place(c[0]) at loc(x-off, y2) * pre-pose on Top
+  place(c[1]) at loc((- x-off), (- y2)) * pre-pose on Top
 
 doc: \<DOC>
 Construct Aligned Symmetric Shunt Components


### PR DESCRIPTION

In the previous implementation 

```
  inst tx-coupler : dp-coupler(
    create-part(
      mpn = "ESD132-B1-W0201 E6327", 
      manufacturer = "Infineon"
    )
  )
```

Results in something like this:

<img width="316" alt="Screenshot 2025-01-23 at 3 16 32 PM" src="https://github.com/user-attachments/assets/a1f5a542-c6a0-49ab-bc97-49007f1aef25" />

because the parts-DB landpattern for this part is rotated 90 degrees from the JSL 2-pin standard landpattern.

This PR adds a new `pre-pose` argument that allows for the components in the `dp-coupler` to be oriented before being constructed in the coupler form. 

```
  inst tx-coupler : dp-coupler(
    create-part(
      mpn = "ESD132-B1-W0201 E6327", 
      manufacturer = "Infineon"
    ),
    pre-pose = loc(0.0, 0.0, 90.0)
  )
```

<img width="227" alt="Screenshot 2025-01-23 at 3 18 47 PM" src="https://github.com/user-attachments/assets/1903ed4e-7112-482c-a698-038181a65072" />


@Johnsel - FYI
