### PR TITLE
Updated app-specific keepout

### DIFF
--- a/examples/landpatterns/app-specific-keepout.stanza
+++ b/examples/landpatterns/app-specific-keepout.stanza
@@ -42,11 +42,16 @@ track the instance as it moves in the layout.
 <DOC>
 pcb-module test-design:
   inst non-keepout : test-SOIC
+  net GND (non-keepout.VSS)
 
   inst app-keepout : test-SOIC
+  net (GND, app-keepout.VSS)
+
   val KO = KeepoutOverlay(Rectangle(4.0, 6.0))
   make-keepout-overlay(KO, app-keepout, name = "D-Overlay")
 
+  geom(GND):
+    copper-pour(LayerIndex(0), isolate = 0.25, rank = 1) = board-shape
 
 ; Set the top level module (the module to be compile into a schematic and PCB)
 set-current-design("APP-Specific-Keepout-TEST")

--- a/examples/landpatterns/board.stanza
+++ b/examples/landpatterns/board.stanza
@@ -44,11 +44,18 @@ public pcb-stackup jlcpcb-jlc2313 :
   stack(0.035, copper)
   stack(0.019, soldermask) ; 0.5mil over conductor
 
+public pcb-via default-th:
+  start = Top
+  stop = Bottom
+  type = MechanicalDrill
+  diameter = 0.6
+  hole-diameter = 0.3
 
 public pcb-board default-board (outline:Shape) :
   stackup = jlcpcb-jlc2313
   boundary = outline
   signal-boundary = outline
+  vias = [default-th]
 
 public pcb-rules default-rules :
   min-copper-width = 0.13 ; 5mil


### PR DESCRIPTION
Example of how it now shows the keepout region's effect: 

<img width="346" alt="Screenshot 2025-03-20 at 3 22 42 PM" src="https://github.com/user-attachments/assets/4ada104f-0939-45f3-aa6b-cfd4ad21cde7" />
